### PR TITLE
Fix subscribe on GroupedObservable with callbacks

### DIFF
--- a/rx/linq/groupedobservable.py
+++ b/rx/linq/groupedobservable.py
@@ -10,8 +10,6 @@ class GroupedObservable(Observable):
             return CompositeDisposable(merged_disposable.disposable, underlying_observable.subscribe(observer))
 
         self.underlying_observable = underlying_observable if not merged_disposable else AnonymousObservable(subscribe)
-    
-    def subscribe(self, observer):
-        return self.underlying_observable.subscribe(observer)
 
-    
+    def subscribe(self, on_next=None, on_error=None, on_completed=None):
+        return self.underlying_observable.subscribe(on_next, on_error, on_completed)


### PR DESCRIPTION
When subscribing to a GroupedObservable with callbacks instead of an observer, this would lead to a crash (see partial stack trace below). I found this when using `.pairwise()` on the inner observable, which uses `subscribe()` this way.

Let me know if you want these kind of regression tests to be committed somewhere, I'll be happy to!

Testcase:

``` python
    def test_groupedobservable_subscribe_with_callbacks(self):
        scheduler = VirtualTimeScheduler(0, lambda a, b: a - b)
        xs = HotObservable(scheduler, [on_next(1, "foo")])

        def action(scheduler, state):
            xs.group_by(lambda x: x).subscribe(lambda grp: grp.subscribe(lambda x: None, lambda e: None, lambda: None))

        scheduler.schedule(action)
        scheduler.start()
```

Stack trace:

```
...
  File ".../RxPy/rx/observable.py", line 36, in subscribe
    return self._subscribe(observer)
  File ".../RxPy/rx/anonymousobservable.py", line 43, in _subscribe
    set_disposable()
  File ".../RxPy/rx/anonymousobservable.py", line 35, in set_disposable
    if not auto_detach_observer.fail(ex):
  File ".../RxPy/rx/abstractobserver.py", line 52, in fail
    self.error(exn)
  File ".../RxPy/rx/autodetachobserver.py", line 24, in error
    self.observer.on_error(exn)
  File ".../RxPy/rx/abstractobserver.py", line 34, in on_error
    self.error(error)
  File ".../RxPy/rx/internal/basic.py", line 26, in default_error
    raise err
TypeError: subscribe() takes exactly 2 arguments (4 given)
```
