### PR TITLE
Got the chess example working under Python 2.7

### DIFF
--- a/examples/chess/chess.py
+++ b/examples/chess/chess.py
@@ -66,7 +66,7 @@ def main():
     while True:
         for event in pygame.event.get():
             if event.type == pygame.MOUSEMOTION:
-                pos = event.__dict__["pos"]
+                pos = event.pos
                 mousemove.on_next(pos)
             elif event.type == pygame.QUIT: 
                 sys.exit()

--- a/rx/concurrency/mainloopscheduler/pygamescheduler.py
+++ b/rx/concurrency/mainloopscheduler/pygamescheduler.py
@@ -33,7 +33,7 @@ class PyGameScheduler(Scheduler):
         return self.schedule_relative(0, action, state)
 
     def run(self):
-        while self.queue.length:
+        while len(self.queue):
             item = self.queue.peek()
             diff = item.duetime - self.now()
             if diff > timedelta(0):


### PR DESCRIPTION
Fixed these two problems with the code:
=========== Problem 1 ==============================
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
/usr/lib/python2.7/dist-packages/IPython/utils/py3compat.pyc in execfile(fname, *where)
    202             else:
    203                 filename = fname
--> 204             __builtin__.execfile(filename, *where)

/home/eba/local/RxPY-master/examples/chess/chess.py in <module>()
     91 
     92 if __name__ == '__main__':
---> 93     main()

/home/eba/local/RxPY-master/examples/chess/chess.py in main()
     68             if event.type == pygame.MOUSEMOTION:
     69                 print event.type
---> 70                 pos = event.__dict__["pos"]
     71                 mousemove.on_next(pos)
     72             elif event.type == pygame.QUIT:

==================== Problem 2 ========================
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
/usr/lib/python2.7/dist-packages/IPython/utils/py3compat.pyc in execfile(fname, *where)
    202             else:
    203                 filename = fname
--> 204             __builtin__.execfile(filename, *where)

/home/eba/local/RxPY-master/examples/chess/chess.py in <module>()
     90 
     91 if __name__ == '__main__':
---> 92     main()

/home/eba/local/RxPY-master/examples/chess/chess.py in main()
     87             erase = []
     88 
---> 89         scheduler.run()
     90 
     91 if __name__ == '__main__':

/usr/local/lib/python2.7/dist-packages/rx/concurrency/mainloopscheduler/pygamescheduler.pyc in run(self)
     34 
     35     def run(self):
---> 36         while self.queue.length:
     37             item = self.queue.peek()
     38             diff = item.duetime - self.now()
