### PR TITLE
Removed ref to abingham/python-transducers.

### DIFF
--- a/rx/linq/observable/transduce.py
+++ b/rx/linq/observable/transduce.py
@@ -9,7 +9,6 @@ implementation is currently targeted for:
 Other implementations of transducers in Python are:
 
 * https://github.com/cognitect-labs/transducers-python
-* https://github.com/abingham/python-transducers
 """
 
 from rx import Observable


### PR DESCRIPTION
That work is pretty much dead at this point, and it has been merged into the sixty-north work.