### PR TITLE
Fix for #36: AsyncIOScheduler for Python 2

### DIFF
--- a/examples/asyncio/toasyncgenerator.py
+++ b/examples/asyncio/toasyncgenerator.py
@@ -1,6 +1,6 @@
-import asyncio
-
 import rx
+asyncio = rx.config['asyncio']
+
 from rx.concurrency import AsyncIOScheduler
 from rx.observable import Observable
 from rx.internal import extensionmethod

--- a/examples/autocomplete/autocomplete_asyncio.py
+++ b/examples/autocomplete/autocomplete_asyncio.py
@@ -7,7 +7,8 @@ Uses the RxPY AsyncIOScheduler (Python 3.4 is required)
 """
 
 import os
-import asyncio
+import rx
+asyncio = rx.config['asyncio']
 
 from tornado.websocket import WebSocketHandler
 from tornado.web import RequestHandler, StaticFileHandler, Application, url

--- a/rx/__init__.py
+++ b/rx/__init__.py
@@ -1,4 +1,12 @@
 try:
+    import asyncio
+except ImportError:
+    try:
+        import trollius as asyncio
+    except ImportError:
+        asyncio = None
+
+try:
     from threading import Lock
 except ImportError:
     from rx.internal.concurrency import NoLock as Lock
@@ -6,12 +14,17 @@ except ImportError:
 try:
     from asyncio import Future
 except ImportError:
-    Future = None
+    try:
+        from trollius import Future
+    except ImportError:
+        Future = None
+
 
 # Rx configuration dictionary
 config = {
     "Future": Future,
-    "Lock": Lock
+    "Lock": Lock,
+    "asyncio": asyncio
 }
 
 from .observable import Observable

--- a/rx/concurrency/mainloopscheduler/asyncioscheduler.py
+++ b/rx/concurrency/mainloopscheduler/asyncioscheduler.py
@@ -16,7 +16,9 @@ class AsyncIOScheduler(Scheduler):
 
     def __init__(self, loop=None):
         global asyncio
-        import asyncio
+        import rx
+        asyncio = rx.config['asyncio']
+
         self.loop = loop or asyncio.get_event_loop()
 
     def schedule(self, action, state=None):

--- a/tests/test_concurrency/test_mainloopscheduler/py2_asyncioscheduler.py
+++ b/tests/test_concurrency/test_mainloopscheduler/py2_asyncioscheduler.py
@@ -1,0 +1,86 @@
+from nose import SkipTest
+
+import rx
+asyncio = rx.config['asyncio']
+if asyncio is None:
+    raise SkipTest("asyncio not available")
+
+try:
+    from trollius import From
+except ImportError:
+    raise SkipTest("trollius.From not available")
+
+import unittest
+
+from datetime import datetime, timedelta
+from time import sleep
+from rx.concurrency import AsyncIOScheduler
+
+class TestAsyncIOScheduler(unittest.TestCase):
+
+    def test_asyncio_schedule_now(self):
+        loop = asyncio.get_event_loop()
+        scheduler = AsyncIOScheduler(loop)
+        res = scheduler.now() - datetime.now()
+        assert(res < timedelta(seconds=1))
+
+    def test_asyncio_schedule_action(self):
+        loop = asyncio.get_event_loop()
+
+        @asyncio.coroutine
+        def go():
+            scheduler = AsyncIOScheduler(loop)
+
+            class Nonlocal:
+                ran = False
+
+            def action(scheduler, state):
+                Nonlocal.ran = True
+
+            scheduler.schedule(action)
+
+            yield From(asyncio.sleep(0.1, loop=loop))
+            assert(Nonlocal.ran == True)
+
+        loop.run_until_complete(go())
+
+    def test_asyncio_schedule_action_due(self):
+        loop = asyncio.get_event_loop()
+
+        @asyncio.coroutine
+        def go():
+            scheduler = AsyncIOScheduler(loop)
+            starttime = loop.time()
+
+            class Nonlocal:
+               endtime = None
+
+            def action(scheduler, state):
+                Nonlocal.endtime = loop.time()
+
+            scheduler.schedule_relative(0.2, action)
+
+            yield From(asyncio.sleep(0.3, loop=loop))
+            diff = Nonlocal.endtime-starttime
+            assert(diff > 0.18)
+
+        loop.run_until_complete(go())
+
+    def test_asyncio_schedule_action_cancel(self):
+        loop = asyncio.get_event_loop()
+
+        @asyncio.coroutine
+        def go():
+            class Nonlocal:
+                ran = False
+            scheduler = AsyncIOScheduler(loop)
+
+            def action(scheduler, state):
+                Nonlocal.ran = True
+            d = scheduler.schedule_relative(0.01, action)
+            d.dispose()
+
+            yield From(asyncio.sleep(0.1, loop=loop))
+            assert(not Nonlocal.ran)
+
+        loop.run_until_complete(go())

--- a/tests/test_concurrency/test_mainloopscheduler/py3_asyncioscheduler.py
+++ b/tests/test_concurrency/test_mainloopscheduler/py3_asyncioscheduler.py
@@ -1,6 +1,8 @@
-try:
-    import asyncio
-except ImportError:
+from nose import SkipTest
+
+import rx
+asyncio = rx.config['asyncio']
+if asyncio is None:
     raise SkipTest("asyncio not available")
 
 import unittest

--- a/tests/test_concurrency/test_mainloopscheduler/test_asyncioscheduler.py
+++ b/tests/test_concurrency/test_mainloopscheduler/test_asyncioscheduler.py
@@ -1,7 +1,8 @@
 from nose import SkipTest
 
 import sys
-if sys.version_info.major < 3:
-    raise SkipTest("keyword `nonlocal` not available before Python 3")
 
-from .py3_asyncioscheduler import *
+if sys.version_info.major < 3:
+    from .py2_asyncioscheduler import *
+else:
+    from .py3_asyncioscheduler import *

--- a/tests/test_concurrency/test_mainloopscheduler/test_asyncioscheduler.py
+++ b/tests/test_concurrency/test_mainloopscheduler/test_asyncioscheduler.py
@@ -1,7 +1,7 @@
 from nose import SkipTest
-try:
-    import asyncio
-except ImportError:
-    raise SkipTest("asyncio not available")
+
+import sys
+if sys.version_info.major < 3:
+    raise SkipTest("keyword `nonlocal` not available before Python 3")
 
 from .py3_asyncioscheduler import *

--- a/tests/test_observable/py3_fromfuture.py
+++ b/tests/test_observable/py3_fromfuture.py
@@ -1,6 +1,11 @@
 import unittest
-import asyncio
-from asyncio import Future
+
+from nose import SkipTest
+import rx
+asyncio = rx.config['asyncio']
+if asyncio is None:
+    raise SkipTest("asyncio not available")
+Future = rx.config['Future']
 
 from rx import Observable
 

--- a/tests/test_observable/py3_start.py
+++ b/tests/test_observable/py3_start.py
@@ -1,6 +1,7 @@
 import unittest
-import asyncio
-from asyncio import Future
+import rx
+asyncio = rx.config['asyncio']
+Future = rx.config['Future']
 
 from rx import Observable
 from rx.testing import TestScheduler, ReactiveTest, is_prime, MockDisposable

--- a/tests/test_observable/py3_tofuture.py
+++ b/tests/test_observable/py3_tofuture.py
@@ -1,5 +1,10 @@
 import unittest
-import asyncio
+
+from nose import SkipTest
+import rx
+asyncio = rx.config['asyncio']
+if asyncio is None:
+    raise SkipTest("asyncio not available")
 
 from rx.observable import Observable
 from rx.testing import TestScheduler, ReactiveTest

--- a/tests/test_observable/test_fromfuture.py
+++ b/tests/test_observable/test_fromfuture.py
@@ -1,7 +1,7 @@
 from nose import SkipTest
-try:
-    import asyncio
-except ImportError:
-    raise SkipTest("asyncio not available")
+
+import rx
+asyncio = rx.config['asyncio']
+Future = rx.config['Future']
 
 from .py3_fromfuture import *

--- a/tests/test_observable/test_start.py
+++ b/tests/test_observable/test_start.py
@@ -1,7 +1,8 @@
 from nose import SkipTest
-try:
-    import asyncio
-except ImportError:
+
+import rx
+asyncio = rx.config['asyncio']
+if asyncio is None:
     raise SkipTest("asyncio not available")
 
 from .py3_start import *

--- a/tests/test_observable/test_tofuture.py
+++ b/tests/test_observable/test_tofuture.py
@@ -1,7 +1,8 @@
 from nose import SkipTest
-try:
-    import asyncio
-except ImportError:
+
+import rx
+asyncio = rx.config['asyncio']
+if asyncio is None:
     raise SkipTest("asyncio not available")
 
 from .py3_tofuture import *


### PR DESCRIPTION
Fix #36. Enable AsyncIOScheduler for Python 2 by using [trollius](http://trollius.readthedocs.org/) as `asyncio`. Also for a few test cases, use trollius's replacement for `yield from`, and [one of several possible replacements for `nonlocal`](http://stackoverflow.com/a/28433571/884640)