### PR TITLE
added TkinterScheduler.schedule_periodic() so scheduled actions run in t...

### DIFF
--- a/rx/concurrency/mainloopscheduler/tkinterscheduler.py
+++ b/rx/concurrency/mainloopscheduler/tkinterscheduler.py
@@ -73,3 +73,31 @@ class TkinterScheduler(Scheduler):
 
         duetime = self.to_datetime(duetime)
         return self.schedule_relative(duetime - self.now(), action, state)
+
+    def schedule_periodic(self, period, action, state=None):
+        """Schedules a periodic piece of work to be executed in the tkinter
+        mainloop.
+
+        Keyword arguments:
+        period -- Period in milliseconds for running the work periodically.
+        action -- Action to be executed.
+        state -- [Optional] Initial state passed to the action upon the first
+            iteration.
+
+        Returns the disposable object used to cancel the scheduled recurring
+        action (best effort)."""
+
+        state = [state]
+
+        def interval():
+            state[0] = action(state[0])
+            alarm[0] = self.master.after(period, interval)
+
+        log.debug("timeout: %s", period)
+        alarm = [self.master.after(period, interval)]
+
+        def dispose():
+            # nonlocal alarm
+            self.master.after_cancel(alarm[0])
+
+        return Disposable(dispose)

--- a/tests/test_concurrency/test_mainloopscheduler/test_tkinterscheduler.py
+++ b/tests/test_concurrency/test_mainloopscheduler/test_tkinterscheduler.py
@@ -13,7 +13,7 @@ except Exception:
     raise SkipTest("No display, skipping")
 
 from rx.concurrency import TkinterScheduler
-        
+
 class TestTkinterScheduler(unittest.TestCase):
 
     def test_tkinter_schedule_now(self):
@@ -32,7 +32,7 @@ class TestTkinterScheduler(unittest.TestCase):
         def done():
             assert(ran[0] == True)
             root.quit()
-        
+
         root.after_idle(done)
         root.mainloop()
 
@@ -66,6 +66,25 @@ class TestTkinterScheduler(unittest.TestCase):
         def done():
             root.quit()
             assert(not ran[0])
-            
+
+        root.after(300, done)
+        root.mainloop()
+
+    def test_tkinter_schedule_action_periodic(self):
+        scheduler = TkinterScheduler(root)
+        period = 50
+        counter = [3]
+
+        def action(scheduler, state):
+            if state:
+                counter[0] -= 1
+                return state - 1
+
+        scheduler.schedule_periodic(period, action, counter[0])
+
+        def done():
+            root.quit()
+            assert counter[0] == 0
+
         root.after(300, done)
         root.mainloop()


### PR DESCRIPTION
...he tkinter mainloop instead of a Timer thread.

My tkinter program wouldn't quit properly because of a sleeping Timer thread
from an Observable.interval(TICK, scheduler=TkinterScheduler(window)) stream.
My research showed that TkinterScheduler doesn't overwrite the default implementation of
schedule_periodic() defined in the Scheduler base class, which uses a
threading.Timer. I overwrote this method in TkinterScheduler to run periodic
actions in the tkinter mainloop. Now my program quits properly.