### PR TITLE
More informative error message

### DIFF
--- a/rx/autodetachobserver.py
+++ b/rx/autodetachobserver.py
@@ -14,9 +14,9 @@ class AutoDetachObserver(AbstractObserver):
     def _next(self, value):
         try:
             self.observer.on_next(value)
-        except Exception as ex:
+        except Exception:
             self.dispose()
-            raise ex
+            raise
 
     def _error(self, exn):
         try:


### PR DESCRIPTION
Use `raise` instead of `raise <exception>` so that the original exception comes through (more informative -- shows client where their code is causing the problem)