### PR TITLE
Fix parallel example for Python 3

### DIFF
--- a/examples/parallel/timer.py
+++ b/examples/parallel/timer.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 import rx
 import concurrent.futures
 import time
@@ -11,7 +13,7 @@ def sleep(t):
 
 
 def output(result):
-    print '%d seconds' % result
+    print('%d seconds' % result)
 
 with concurrent.futures.ProcessPoolExecutor(5) as executor:
     rx.Observable.from_(seconds).flat_map(


### PR DESCRIPTION
This is just a very simple fix in `timer.py` for Python 3.