### PR TITLE
Make pluck docstring more accurate and add pluck_attr

### DIFF
--- a/rx/linq/observable/pluck.py
+++ b/rx/linq/observable/pluck.py
@@ -3,14 +3,35 @@ from rx.internal import extensionmethod
 
 
 @extensionmethod(Observable)
-def pluck(self, property):
-    """Retrieves the value of a specified property from all elements in the
-    Observable sequence.
+def pluck(self, key):
+    """Retrieves the value of a specified key using dict-like access (as in
+    element[key]) from all elements in the Observable sequence.
+
+    Keyword arguments:
+    key {String} The key to pluck.
+
+    Returns a new Observable {Observable} sequence of key values.
+
+    To pluck an attribute of each element, use pluck_attr.
+
+    """
+
+    return self.map(lambda x: x[key])
+
+
+@extensionmethod(Observable)
+def pluck_attr(self, property):
+    """Retrieves the value of a specified property (using getattr) from all
+    elements in the Observable sequence.
 
     Keyword arguments:
     property {String} The property to pluck.
 
     Returns a new Observable {Observable} sequence of property values.
+
+    To pluck values using dict-like access (as in element[key]) on each
+    element, use pluck.
+
     """
 
-    return self.map(lambda x: x[property])
+    return self.map(lambda x: getattr(x, property))

--- a/tests/test_observable/test_pluck.py
+++ b/tests/test_observable/test_pluck.py
@@ -1,8 +1,6 @@
 import unittest
 
-from rx.observable import Observable
 from rx.testing import TestScheduler, ReactiveTest
-from rx.disposables import Disposable, SerialDisposable
 
 on_next = ReactiveTest.on_next
 on_completed = ReactiveTest.on_completed
@@ -11,6 +9,7 @@ subscribe = ReactiveTest.subscribe
 subscribed = ReactiveTest.subscribed
 disposed = ReactiveTest.disposed
 created = ReactiveTest.created
+
 
 class TestPluck(unittest.TestCase):
 
@@ -29,6 +28,39 @@ class TestPluck(unittest.TestCase):
             on_error(430, Exception('ex'))
         )
         results = scheduler.start(create=lambda: xs.pluck('prop'))
+
+        results.messages.assert_equal(
+            on_next(210, 2),
+            on_next(240, 3),
+            on_next(290, 4),
+            on_next(350, 5),
+            on_completed(400)
+        )
+        xs.subscriptions.assert_equal(subscribe(200, 400))
+
+
+class TestPluckAttr(unittest.TestCase):
+
+    def test_pluck_attr_completed(self):
+        scheduler = TestScheduler()
+
+        class DummyClass:
+
+            def __init__(self, prop):
+                self.prop = prop
+
+        xs = scheduler.create_hot_observable(
+            on_next(180, DummyClass(1)),
+            on_next(210, DummyClass(2)),
+            on_next(240, DummyClass(3)),
+            on_next(290, DummyClass(4)),
+            on_next(350, DummyClass(5)),
+            on_completed(400),
+            on_next(410, DummyClass(-1)),
+            on_completed(420),
+            on_error(430, Exception('ex'))
+        )
+        results = scheduler.start(create=lambda: xs.pluck_attr('prop'))
 
         results.messages.assert_equal(
             on_next(210, 2),


### PR DESCRIPTION
The docstring of `pluck` says that it grabs the "value of the specified **property**" from each element, but in reality it is using `__getitem__` on each element. Therefore, I changed the docstring of `pluck` to be more specific, and I added a new `pluck_attr` method that actually grabs properties using `getattr`.

I was going to say that `pluck` uses `__getitem__` to get values, but I think that to a beginner the phrase "dict-like" is easier to understand. I also mention specifically that `pluck` calls `element[key]` in the docstring, in case a user calls `help(Observable.pluck)` and can't see the simple implementation.