### PR TITLE
fix issue with int + datetime.datetime

### DIFF
--- a/rx/linq/observable/timer.py
+++ b/rx/linq/observable/timer.py
@@ -46,7 +46,7 @@ def observable_timer_date_and_period(duetime, period, scheduler):
                 now = scheduler.now()
                 d[0] = d[0] + scheduler.to_timedelta(p)
                 if d[0] <= now:
-                    d[0] = now + p
+                    d[0] = now + scheduler.to_timedelta(p)
 
             observer.on_next(count[0])
             count[0] += 1


### PR DESCRIPTION
Little fix to timer.py.

This:
```python
Observable.timer(0, 1).map(next_message)
```

Caused such error:
```
Exception in thread Thread-7:
Traceback (most recent call last):
  File "/Users/alex/.pyenv/versions/2.7/lib/python2.7/threading.py", line 530, in __bootstrap_inner
    self.run()
  File "/Users/alex/.pyenv/versions/2.7/lib/python2.7/threading.py", line 734, in run
    self.function(*self.args, **self.kwargs)
  File "/Users/alex/.pyenv/versions/rxtest/lib/python2.7/site-packages/rx/concurrency/timeoutscheduler.py", line 43, in interval
    disposable.disposable = action(scheduler, state)
  File "/Users/alex/.pyenv/versions/rxtest/lib/python2.7/site-packages/rx/concurrency/scheduler.py", line 97, in schedule_work
    action(state3, inner_action)
  File "/Users/alex/.pyenv/versions/rxtest/lib/python2.7/site-packages/rx/concurrency/scheduler.py", line 193, in action1
    _action(func)
  File "/Users/alex/.pyenv/versions/rxtest/lib/python2.7/site-packages/rx/linq/observable/timer.py", line 49, in action
    d[0] = now + p
TypeError: unsupported operand type(s) for +: 'datetime.datetime' and 'int'
```
