### PR TITLE
Don't override custom exceptions in throw.py

### DIFF
--- a/rx/linq/observable/throw.py
+++ b/rx/linq/observable/throw.py
@@ -24,7 +24,7 @@ def throw(cls, exception, scheduler=None):
 
     scheduler = scheduler or immediate_scheduler
 
-    exception = exception if type(exception) is Exception else Exception(exception)
+    exception = exception if isinstance(exception, Exception) else Exception(exception)
 
     def subscribe(observer):
         def action(scheduler, state):


### PR DESCRIPTION
Say I have a custom exception:

    class TimeoutException(Exception):
        pass

I throw this if some `observable` times out using

    observable.timeout(1000, Observable.throw(TimeoutError))

so that I can later switch on the type of the exception in a `.catch_exception` call.

The file change allows this behaviour. The old behaviour was to override the exception type to simply Exception (since `type(TimeoutException) != Exception`).