### PR TITLE
Fix the function __init__ of windowedobservable, fix typo in controlledobservable.

### DIFF
--- a/rx/backpressure/controlledsubject.py
+++ b/rx/backpressure/controlledsubject.py
@@ -7,7 +7,7 @@ from rx.core.notification import OnCompleted, OnError, OnNext
 
 class ControlledSubject(ObservableBase, Observer):
     def __init__(self, enable_queue=True, scheduler=None):
-        super(ControlledSubject, self).__init__(self._subscribe)
+        super(ControlledSubject, self).__init__()
 
         self.subject = Subject()
         self.enable_queue = enable_queue
@@ -19,7 +19,7 @@ class ControlledSubject(ObservableBase, Observer):
         self.has_completed = False
         self.scheduler = scheduler or current_thread_scheduler
 
-    def _subscribe(self, observer):
+    def _subscribe_core(self, observer):
         return self.subject.subscribe(observer)
 
     def on_completed(self):
@@ -29,7 +29,7 @@ class ControlledSubject(ObservableBase, Observer):
             self.subject.on_completed()
             self.dispose_current_request()
         else:
-            self.queue.push(OnCompleted())
+            self.queue.append(OnCompleted())
 
     def on_error(self, error):
         self.has_failed = True
@@ -39,7 +39,7 @@ class ControlledSubject(ObservableBase, Observer):
             self.subject.on_error(error)
             self.dispose_current_request()
         else:
-            self.queue.push(OnError(error))
+            self.queue.append(OnError(error))
 
     def on_next(self, value):
         if self.requested_count <= 0:

--- a/rx/backpressure/windowedobservable.py
+++ b/rx/backpressure/windowedobservable.py
@@ -15,7 +15,7 @@ class WindowedObserver(ObserverBase):
         self.received = 0
         self.schedule_disposable = None
 
-        super(WindowedObserver, self).__init__(self._next, self._error, self._completed)
+        super(WindowedObserver, self).__init__()
 
     def _on_completed_core(self):
         self.observer.on_completed()

--- a/tests/test_backpressure/test_controlledobservable.py
+++ b/tests/test_backpressure/test_controlledobservable.py
@@ -1,0 +1,61 @@
+import unittest
+
+from rx.testing import TestScheduler, ReactiveTest
+
+on_next = ReactiveTest.on_next
+on_completed = ReactiveTest.on_completed
+on_error = ReactiveTest.on_error
+subscribe = ReactiveTest.subscribe
+subscribed = ReactiveTest.subscribed
+disposed = ReactiveTest.disposed
+created = ReactiveTest.created
+
+
+class TestControlledObservable(unittest.TestCase):
+    def test_controlledobservable_simple(self):
+        scheduler = TestScheduler()
+        controlled = [None]
+        results1 = scheduler.create_observer()
+        results2 = scheduler.create_observer()
+
+        xs = scheduler.create_hot_observable(
+            on_next(150, 1),
+            on_next(210, 2),
+            on_next(230, 3),
+            on_next(301, 4),
+            on_next(350, 5),
+            on_next(399, 6),
+            on_completed(500)
+        )
+
+        def action1(scheduler, state=None):
+            controlled[0] = xs.controlled()
+        scheduler.schedule_absolute(200, action1)
+
+        def action2(scheduler, state=None):
+            controlled[0].subscribe(results1)
+        scheduler.schedule_absolute(300, action2)
+
+        def action3(scheduler, state=None):
+            controlled[0].request(4)
+        scheduler.schedule_absolute(380, action3)
+
+        def action4(scheduler, state=None):
+            controlled[0].subscribe(results2)
+        scheduler.schedule_absolute(400, action4)
+
+        def action3(scheduler, state=None):
+            controlled[0].request(2)
+        scheduler.schedule_absolute(410, action3)
+
+        scheduler.start()
+        results1.messages.assert_equal(
+            on_next(380, 4),
+            on_next(380, 5),
+            on_next(410, 6),
+            on_completed(500)
+        )
+        results2.messages.assert_equal(
+            on_next(410, 6),
+            on_completed(500)
+        )

--- a/tests/test_backpressure/test_windowedobservable.py
+++ b/tests/test_backpressure/test_windowedobservable.py
@@ -1,0 +1,62 @@
+import unittest
+
+from rx.testing import TestScheduler, ReactiveTest
+from rx.subjects import Subject
+from rx.backpressure.windowedobservable import WindowedObservable
+
+on_next = ReactiveTest.on_next
+on_completed = ReactiveTest.on_completed
+on_error = ReactiveTest.on_error
+subscribe = ReactiveTest.subscribe
+subscribed = ReactiveTest.subscribed
+disposed = ReactiveTest.disposed
+created = ReactiveTest.created
+
+
+class TestWindowedObservable(unittest.TestCase):
+    def test_windowedobservalbe_simple(self):
+        scheduler = TestScheduler()
+        windowed = [None]
+        subject = [None]
+        results1 = scheduler.create_observer()
+        results2 = scheduler.create_observer()
+
+        xs = scheduler.create_hot_observable(
+            on_next(150, 1),
+            on_next(210, 2),
+            on_next(230, 3),
+            on_next(301, 4),
+            on_next(350, 5),
+            on_next(399, 6),
+            on_completed(500)
+        )
+
+        def action1(scheduler, state=None):
+            subject[0] = Subject()
+            xs.subscribe(subject[0])
+        scheduler.schedule_absolute(100, action1)
+
+        def action2(scheduler, state=None):
+            windowed[0] = WindowedObservable(subject[0], 2)
+        scheduler.schedule_absolute(120, action2)
+
+        def action3(scheduler, state=None):
+            windowed[0].subscribe(results1)
+        scheduler.schedule_absolute(220, action3)
+
+        def action4(scheduler, state=None):
+            windowed[0].subscribe(results2)
+        scheduler.schedule_absolute(355, action4)
+
+        scheduler.start()
+        results1.messages.assert_equal(
+            on_next(230, 3),
+            on_next(301, 4),
+            on_next(350, 5),
+            on_next(399, 6),
+            on_completed(500)
+        )
+        results2.messages.assert_equal(
+            on_next(399, 6),
+            on_completed(500)
+        )


### PR DESCRIPTION
I fixed small bugs and made test cases for those.

1. WindowedObservable

Before I fix the file [`rx/backpressure/windowedobservable.py`](https://github.com/ReactiveX/RxPY/blob/2d8ad023d851775f50cc506709708b32aabf1150/rx/backpressure/windowedobservable.py#L18), it crashed while subscribing `WindowedObservable` with following exception messages for the following subscribing code.

Code
```
rx.backpressure.windowedobservable.WindowedObservable(
  rx.Observable.from_iterable([1,2,3,4,5]),
  4
).subscribe(p)
```

Exception
```
Traceback (most recent call last):
  File "rxpy.py", line 70, in <module>
    ).subscribe(p)
  File "/Users/kstreee/Documents/Programming/rxpy/rx/core/observablebase.py", line 83, in subscribe
    current_thread_scheduler.schedule(set_disposable)
  File "/Users/kstreee/Documents/Programming/rxpy/rx/concurrency/currentthreadscheduler.py", line 50,in schedule
    return self.schedule_relative(timedelta(0), action, state)
  File "/Users/kstreee/Documents/Programming/rxpy/rx/concurrency/currentthreadscheduler.py", line 67,in schedule_relative
    Trampoline.run(queue)
  File "/Users/kstreee/Documents/Programming/rxpy/rx/concurrency/currentthreadscheduler.py", line 31,in run
    item.invoke()
  File "/Users/kstreee/Documents/Programming/rxpy/rx/concurrency/scheduleditem.py", line 17, in invoke
    ret = self.scheduler.invoke_action(self.action, self.state)
  File "/Users/kstreee/Documents/Programming/rxpy/rx/concurrency/schedulerbase.py", line 14, in invoke_action
    ret = action(self, state)
  File "/Users/kstreee/Documents/Programming/rxpy/rx/core/observablebase.py", line 69, in set_disposable
    if not auto_detach_observer.fail(ex):
  File "/Users/kstreee/Documents/Programming/rxpy/rx/core/observerbase.py", line 60, in fail
    self._on_error_core(exn)
  File "/Users/kstreee/Documents/Programming/rxpy/rx/core/autodetachobserver.py", line 23, in _on_error_core
    self.observer.on_error(exn)
  File "/Users/kstreee/Documents/Programming/rxpy/rx/core/observerbase.py", line 33, in on_error
    self._on_error_core(error)
  File "/Users/kstreee/Documents/Programming/rxpy/rx/core/anonymousobserver.py", line 17, in _on_error_core
    self._error(error)
  File "/Users/kstreee/Documents/Programming/rxpy/rx/internal/basic.py", line 33, in default_error
    raise err
AttributeError: 'WindowedObserver' object has no attribute '_next'
```


2. ControlledObservable
ControlledObservable has a similar bug with the fist case that I fixed. I fixed the __init__ function and generated a test case for it.