### PR TITLE
Various scheduler combis in the marbles tests

### DIFF
--- a/rx/linq/observable/timeinterval.py
+++ b/rx/linq/observable/timeinterval.py
@@ -5,7 +5,7 @@ from rx.internal import extensionmethod
 
 
 @extensionmethod(Observable)
-def time_interval(self, scheduler):
+def time_interval(self, scheduler=None):
     """Records the time interval between consecutive values in an
     observable sequence.
 

--- a/tests/test_testing/test_marbles.py
+++ b/tests/test_testing/test_marbles.py
@@ -9,6 +9,7 @@ tested_marbles = '0-1-(10)|', '0|', '(10)-(20)|', '(abc)-|'
 def test_alias():
     assert rx.Observable.from_string == rx.Observable.from_marbles
 
+
 class TestFromToMarbles(unittest.TestCase):
     def _run_test(self,
                   expected_results,

--- a/tests/test_testing/test_marbles.py
+++ b/tests/test_testing/test_marbles.py
@@ -1,14 +1,52 @@
 import rx
-from rx.testing import marbles
+import unittest
+from rx.testing import marbles, TestScheduler
+from rx.concurrency import timeout_scheduler, new_thread_scheduler
 
+# marble sequences to test:
+tested_marbles = '0-1-(10)|', '0|', '(10)-(20)|', '(abc)-|'
 
 def test_alias():
     assert rx.Observable.from_string == rx.Observable.from_marbles
 
+class TestFromToMarbles(unittest.TestCase):
+    def _run_test(self,
+                  expected_results,
+                  src_scheduler,
+                  dest_scheduler=None,
+                  tested_marbles=tested_marbles):
+        '''helper method, running the actual tests with given schedulers'''
+        dest_scheduler = dest_scheduler or src_scheduler
+        for marbles, expected in zip(tested_marbles, expected_results):
+            stream = rx.Observable.from_string(marbles, src_scheduler)
+            result = stream.to_blocking().to_marbles(dest_scheduler)
+            self.assertEqual(result, expected)
 
-def test_from_to_marbles():
-    for marbles in '0-1-(10)-|', '0|', '(10)-(20)|', '(abc)|':
-        #from nose.tools import set_trace; set_trace()
-        stream = rx.Observable.from_string(marbles)
-        result = stream.to_blocking().to_marbles()
-        assert result == marbles
+    def test_new_thread_scheduler(self):
+        'this is the default scheduler'
+        self._run_test(tested_marbles, new_thread_scheduler)
+
+    def test_timeout_scheduler(self):
+        self._run_test(tested_marbles, timeout_scheduler)
+
+    def test_timeout_new_thread_scheduler(self):
+        self._run_test(tested_marbles, timeout_scheduler, new_thread_scheduler)
+
+    def test_new_thread_scheduler_timeout(self):
+        self._run_test(tested_marbles, new_thread_scheduler, timeout_scheduler)
+
+    def test_timeout_testscheduler(self):
+        '''the test scheduler uses virtual time => `to_marbles` does not
+           see the original delays.
+        '''
+        expected = [t.replace('-', '') for t in tested_marbles]
+        self._run_test(expected, timeout_scheduler, TestScheduler())
+
+    def test_newthread_testscheduler(self):
+        '''the test scheduler uses virtual time => `to_marbles` does not
+           see the original delays.
+        '''
+        expected = [t.replace('-', '') for t in tested_marbles]
+        self._run_test(expected, new_thread_scheduler, TestScheduler())
+
+


### PR DESCRIPTION
Hi Dag, I saw you fixed those intermittent from/to marbles errors.

I had those probs locally as well and created a bunch of tests for various scheduler combis. 

Not sure though if you should pull that, since it adds a lot of test time (3 seconds in total) -> you decide.

Maybe one marbles string per combination is enough or you ignore the PR completely.

I think though those marbles are really useful for testing and we should fix the behaviour for various schedulers. 