### PR TITLE
Fix recursive scheduling in concat.

### DIFF
--- a/rx/concurrency/currentthreadscheduler.py
+++ b/rx/concurrency/currentthreadscheduler.py
@@ -20,12 +20,12 @@ class Trampoline(object):
         while len(queue):
             item = queue.dequeue()
             if not item.is_cancelled():
-                diff = item.duetime - current_thread_scheduler.now
+                diff = item.duetime - item.scheduler.now
                 while diff > timedelta(0):
                     seconds = diff.seconds + diff.microseconds / 1E6 + diff.days * 86400
                     log.warning("Do not schedule blocking work!")
                     time.sleep(seconds)
-                    diff = item.duetime - current_thread_scheduler.now
+                    diff = item.duetime - item.scheduler.now
 
                 if not item.is_cancelled():
                     item.invoke()

--- a/rx/linq/observable/concat.py
+++ b/rx/linq/observable/concat.py
@@ -1,6 +1,6 @@
 from rx.core import Observable, AnonymousObservable, Disposable
 from rx.disposables import SingleAssignmentDisposable, CompositeDisposable, SerialDisposable
-from rx.concurrency import immediate_scheduler
+from rx.concurrency import CurrentThreadScheduler
 from rx.internal import extensionmethod, extensionclassmethod
 from rx.internal import Enumerable
 
@@ -59,7 +59,7 @@ def concat(cls, *args):
     sequence, in sequential order.
     """
 
-    scheduler = immediate_scheduler
+    scheduler = CurrentThreadScheduler()
 
     if isinstance(args[0], list) or isinstance(args[0], Enumerable):
         sources = args[0]


### PR DESCRIPTION
I encountered the maximum recursion exception while using following combinations.

```
def creator(observer):
    observer.on_next(1)
    observer.on_next(2)
    observer.on_completed()

Observable.while_do(lambda _: True, Observable.create(creator)).subscribe(print)
Observable.create(creator).repeat().subscribe(print)
```

The `repeat` and `while_do` with `create` leads maximum recursion exception because of `concat`.
So I searched about some issues which are related to this issue, and I found this #133 . To resolve this issue and the #133, I changed a scheduler that `concat` is using from `immediate_scheduler` into `CurrentThreadScheduler()`, and I tested that this change resolve both issues.  But, I'm not sure that using a new object by calling `CurrentThreadScheduler()` is okay to `concat`, so please check this out. (F.Y.I. former version of the issue #133, `concat` used `current_thread_scheduler` as a scheduler, and in that case, there wasn't maximum recursion exception.)