### PR TITLE
fixed issue-157: `generate()` fails to re-subscribe

### DIFF
--- a/rx/linq/observable/generate.py
+++ b/rx/linq/observable/generate.py
@@ -33,11 +33,11 @@ def generate(cls, initial_state, condition, iterate, result_selector, scheduler=
     """
 
     scheduler = scheduler or current_thread_scheduler
-    mad = MultipleAssignmentDisposable()
 
     def subscribe(observer):
         first = [True]
         state = [initial_state]
+        mad = MultipleAssignmentDisposable()
 
         def action(scheduler, state1=None):
             has_result = False

--- a/tests/test_observable/test_generate.py
+++ b/tests/test_observable/test_generate.py
@@ -102,3 +102,28 @@ class TestGenerate(unittest.TestCase):
         results.messages.assert_equal(
                             on_next(201, 0),
                             on_next(202, 1))
+
+    def test_generate_repeat(self):
+        scheduler = TestScheduler()
+
+        def create():
+            return Observable.generate(0,
+                    lambda x: x <= 3,
+                    lambda x: x + 1,
+                    lambda x: x,
+                    scheduler) \
+                .repeat(2)
+
+        results = scheduler.start(create)
+
+        results.messages.assert_equal(
+                on_next(201, 0),
+                on_next(202, 1),
+                on_next(203, 2),
+                on_next(204, 3),
+                on_next(206, 0),
+                on_next(207, 1),
+                on_next(208, 2),
+                on_next(209, 3),
+                on_completed(210)
+        )

--- a/tests/test_observable/test_todict.py
+++ b/tests/test_observable/test_todict.py
@@ -31,7 +31,7 @@ class TestToDict(unittest.TestCase):
         res = scheduler.start(create)
         print(res.messages)
         res.messages.assert_equal(
-            on_next(660, {8: 16, 10: 20, 4: 8, 6: 12}),
+            on_next(660, {4: 8, 6: 12, 8: 16, 10: 20}),
             on_completed(660)
         )
 


### PR DESCRIPTION
1. Added test case that was failing
2. Fixed `generate()` method
3. Fixed test in `to_dict` that fails under Python 3.6 (due to dicts are now ordered)