### PR TITLE
The only way that the GTK Demo would work for me.

### DIFF
--- a/rx/concurrency/mainloopscheduler/gtkscheduler.py
+++ b/rx/concurrency/mainloopscheduler/gtkscheduler.py
@@ -2,6 +2,12 @@ from rx.core import Disposable
 from rx.disposables import SingleAssignmentDisposable, CompositeDisposable
 from rx.concurrency.schedulerbase import SchedulerBase
 
+# Proposed change from UmlautBioEye: This was the only way the RxPY demo would work for me!
+# NOTE: It appears that BOTH my new import AND the existing import in __init__(self) are required
+#       in order for the GTK Demo to work.
+# -UmlautBioEye
+# -19 Jan 2017
+from gi.repository import GLib
 
 class GtkScheduler(SchedulerBase):
     """ A scheduler that schedules work via the GLib main loop


### PR DESCRIPTION
Added an additional import statement at the top of the file. This appears to be needed in addition to the import statement which appears __init__(self). It is the only way that the demo [time flies] program would run on my system.
-UmlautBioEye
-19 Jan 2017