### PR TITLE
Make stop_and_wait work

### DIFF
--- a/rx/backpressure/stopandwaitobservable.py
+++ b/rx/backpressure/stopandwaitobservable.py
@@ -51,6 +51,7 @@ class StopAndWaitObservable(ObservableBase):
         super(StopAndWaitObservable, self).__init__()
         self.scheduler = scheduler or timeout_scheduler
         self.source = source
+        self.subscription = None
 
     def _subscribe_core(self, observer):
         observer = StopAndWaitObserver(observer, self, self.subscription, self.scheduler)

--- a/tests/test_observable/test_stopandwait.py
+++ b/tests/test_observable/test_stopandwait.py
@@ -1,0 +1,44 @@
+import unittest
+
+from rx.testing import TestScheduler, ReactiveTest
+
+on_next = ReactiveTest.on_next
+on_completed = ReactiveTest.on_completed
+on_error = ReactiveTest.on_error
+subscribe = ReactiveTest.subscribe
+subscribed = ReactiveTest.subscribed
+disposed = ReactiveTest.disposed
+created = ReactiveTest.created
+
+
+class TestStopAndWait(unittest.TestCase):
+
+    def test_never(self):
+        scheduler = TestScheduler()
+
+        xs = scheduler.create_hot_observable(
+            on_next(150, 1)
+        )
+
+        def create():
+            return xs.controlled(True, scheduler).stop_and_wait()
+
+        results = scheduler.start(create)
+        results.messages.assert_equal()
+        xs.subscriptions.assert_equal(subscribe(200, 1000))
+
+    def test_empty(self):
+        scheduler = TestScheduler()
+
+        xs = scheduler.create_hot_observable(
+            on_next(150, 1),
+            on_completed(250)
+        )
+
+        def create():
+            return xs.controlled(True, scheduler).stop_and_wait()
+
+        results = scheduler.start(create)
+
+        results.messages.assert_equal(on_completed(250))
+        xs.subscriptions.assert_equal(subscribe(200, 250))


### PR DESCRIPTION
I defined the `subscription` attribute in the `SoptAndWaitObservable.__init__` body following the [question on stack overflow](http://stackoverflow.com/questions/41913806/rxpy-how-to-use-stop-and-wait).