### PR TITLE
Adds conditional branch for 'on_next' in 'do_action'.

### DIFF
--- a/rx/linq/observable/doaction.py
+++ b/rx/linq/observable/doaction.py
@@ -40,12 +40,15 @@ def do_action(self, on_next=None, on_error=None, on_completed=None,
 
     def subscribe(observer):
         def _on_next(x):
-            try:
-                on_next(x)
-            except Exception as e:
-                observer.on_error(e)
+            if not on_next:
+                observer.on_next(x)
+            else:
+                try:
+                    on_next(x)
+                except Exception as e:
+                    observer.on_error(e)
 
-            observer.on_next(x)
+                observer.on_next(x)
 
         def _on_error(exception):
             if not on_error:

--- a/tests/test_observable/test_doaction.py
+++ b/tests/test_observable/test_doaction.py
@@ -82,6 +82,19 @@ class TestDo(unittest.TestCase):
         self.assertEqual(0, i[0])
         assert(not completed[0])
 
+    def test_do_action_without_next(self):
+        scheduler = TestScheduler()
+        xs = scheduler.create_hot_observable(on_next(150, 1), on_next(210, 2),  on_completed(250))
+        completed = [False]
+        def create():
+            def on_completed():
+                completed[0] = True
+            return xs.do_action(on_completed=on_completed)
+
+        scheduler.start(create)
+
+        assert(completed[0])
+
 # def test_do_next_error(self):
 #     ex = 'ex'
 #     scheduler = TestScheduler()


### PR DESCRIPTION
Adds conditional branch for 'on_next' in 'do_action' to allow to call 'do_action' without 'on_next'.

By [the comments in do_action](https://github.com/kstreee/RxPY/blob/26394fd3476090e68951f551f86b7cea13568eca/rx/linq/observable/doaction.py#L19-L25), `on_next` is optional parameter, but it isn't in implementation. But, without [the conditional branch](https://github.com/kstreee/RxPY/blob/42ccaddf082f370d48ecb8344bc8ab92934e2db5/rx/linq/observable/doaction.py#L43-L45) what I added in this pull request, calling `do_action` without `on_next` doesn't work normally.

For example, [the test case](https://github.com/kstreee/RxPY/blob/42ccaddf082f370d48ecb8344bc8ab92934e2db5/tests/test_observable/test_doaction.py#L85-L96) what I added in this pull request fails without the conditional branch for `on_next`.