### PR TITLE
Add pypi version badge for RxPy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-[![Travis Build Status](https://img.shields.io/travis/ReactiveX/RxPY.svg)](https://travis-ci.org/ReactiveX/RxPY)[![Coveralls Coverage Status](https://img.shields.io/coveralls/dbrattli/RxPY.svg)](https://coveralls.io/r/dbrattli/RxPY)
-
+[![Travis Build Status](https://img.shields.io/travis/ReactiveX/RxPY.svg)](https://travis-ci.org/ReactiveX/RxPY)[![Coveralls Coverage Status](https://img.shields.io/coveralls/dbrattli/RxPY.svg)](https://coveralls.io/r/dbrattli/RxPY)[![pypi version](https://img.shields.io/pypi/v/rx.svg)](https://pypi.python.org/pypi/Rx/)
 The Reactive Extensions for Python (RxPY)
 =========================================
 


### PR DESCRIPTION
I found the release version on GitHub doesn't match on PyPi.
In order to mark the newest version of the library, I think it needs a badge on `README.md`.