### PR TITLE
Align buffer_with_time_or_count signature with doc

### DIFF
--- a/rx/linq/observable/bufferwithtimeorcount.py
+++ b/rx/linq/observable/bufferwithtimeorcount.py
@@ -4,7 +4,7 @@ from rx.internal import extensionmethod
 
 
 @extensionmethod(Observable)
-def buffer_with_time_or_count(self, timespan, count, scheduler):
+def buffer_with_time_or_count(self, timespan, count, scheduler=None):
     """Projects each element of an observable sequence into a buffer that
     is completed when either it's full or a given amount of time has
     elapsed.


### PR DESCRIPTION
According to docs, `buffer_with_time_or_count` has an optional scheduler
parameter but in reality it's mandatory. Let's make it optional for real
as passing `None` as third argument all the time is a bit inconvenient.