### PR TITLE
Better error handling for on_callable

### DIFF
--- a/rx/concurrency/eventloopscheduler.py
+++ b/rx/concurrency/eventloopscheduler.py
@@ -79,7 +79,6 @@ class EventLoopScheduler(SchedulerBase, Disposable):
     def schedule_periodic(self, period, action, state=None):
         """Schedule a periodic piece of work."""
 
-        dt = self.to_timedelta(period)
         disposed = []
 
         s = [state]
@@ -88,12 +87,12 @@ class EventLoopScheduler(SchedulerBase, Disposable):
             if disposed:
                 return
 
-            self.schedule_relative(dt, tick)
+            self.schedule_relative(period, tick)
             new_state = action(s[0])
             if new_state is not None:
                 s[0] = new_state
 
-        self.schedule_relative(dt, tick)
+        self.schedule_relative(period, tick)
 
         def dispose():
             disposed.append(True)

--- a/rx/linq/observable/returnvalue.py
+++ b/rx/linq/observable/returnvalue.py
@@ -58,8 +58,8 @@ def from_callable(cls, supplier, scheduler=None):
             try:
                 observer.on_next(supplier())
                 observer.on_completed()
-            except Exception:
-                observer.on_error(Exception)
+            except Exception as e:
+                observer.on_error(e)
         return scheduler.schedule(action)
 
     return AnonymousObservable(subscribe)


### PR DESCRIPTION
We're currently passing the type of `Exception` to `on_error`, instead of the instance of the exception that was caught.