### PR TITLE
Make `let` pass through `kwargs`.

### DIFF
--- a/rx/linq/observable/let.py
+++ b/rx/linq/observable/let.py
@@ -3,7 +3,7 @@ from rx.internal import extensionmethod
 
 
 @extensionmethod(Observable, alias="let")
-def let_bind(self, func):
+def let_bind(self, func, **kwargs):
     """Returns an observable sequence that is the result of invoking the
     selector on the source sequence, without sharing subscriptions. This
     operator allows for a fluent style of writing queries that use the same
@@ -16,6 +16,9 @@ def let_bind(self, func):
     Returns an observable {Observable} sequence that contains the elements
     of a sequence produced by multicasting the source sequence within a
     selector function.
+    
+    Any kwargs given will be passed through to the selector. This allows
+    for a clean syntax when composing with parameterized selectors.
     """
 
-    return func(self)
+    return func(self, **kwargs)


### PR DESCRIPTION
I'm using ``let_bind`` to do all my composition of re-usable components. Most of these components are parametrizable, so I need to pass parameters through to them. Since python doesn't have first-class composition or currying (which is the same reason I would rather do this parametrization via kwargs rather than higher-order-functions), this requires defining a helper function to pass the parameters through in a closure, like so:

```python
def persist_models_to_db(models_stream, chunk_size=None):
    ...

def main(chunk_size=None):
    return (
        get_source()
        .map(to_model)
        .let_bind(lambda o: persist_models_to_db(o, chunk_size)
    )
```

I would love to be able to do

```python
def main(chunk_size=None):
    return (
        get_source()
        .map(to_model)
        .let_bind(persist_models_to_db, chunk_size=chunk_size)
    )
```

instead.