### PR TITLE
`catch_exception`: pass source observable to handler

### DIFF
--- a/rx/linq/observable/catch.py
+++ b/rx/linq/observable/catch.py
@@ -4,9 +4,13 @@ from rx.disposables import SingleAssignmentDisposable, \
 from rx.concurrency import current_thread_scheduler
 from rx.internal import Enumerable
 from rx.internal import extensionmethod, extensionclassmethod
+from rx.internal.utils import adapt_call
 
 
 def catch_handler(source, handler):
+    # For compatibility with legacy handlers that don't take ``source``.
+    adapted_handler = adapt_call(handler)
+
     def subscribe(observer):
         d1 = SingleAssignmentDisposable()
         subscription = SerialDisposable()
@@ -15,7 +19,7 @@ def catch_handler(source, handler):
 
         def on_error(exception):
             try:
-                result = handler(exception, source)
+                result = adapted_handler(exception, source)
             except Exception as ex:
                 observer.on_error(ex)
                 return

--- a/rx/linq/observable/catch.py
+++ b/rx/linq/observable/catch.py
@@ -15,7 +15,7 @@ def catch_handler(source, handler):
 
         def on_error(exception):
             try:
-                result = handler(exception)
+                result = handler(exception, source)
             except Exception as ex:
                 observer.on_error(ex)
                 return

--- a/rx/testing/recorded.py
+++ b/rx/testing/recorded.py
@@ -1,4 +1,5 @@
 from rx.internal.basic import default_comparer
+from rx.core.notification import OnNext, OnCompleted, OnError
 
 
 class Recorded(object):
@@ -20,3 +21,23 @@ class Recorded(object):
 
     def __str__(self):
         return "%s@%s" % (self.value, self.time)
+
+
+def _mk_is_action_check(action_type):
+    """Create a function that checks whether a Recorded instance has a
+    notification of type ``action_type``.
+
+    :type action_type: rx.core.notification.Notification
+    """
+    def is_action(recorded):
+        return isinstance(recorded.value, action_type)
+    return is_action
+
+
+is_next = _mk_is_action_check(OnNext)
+
+
+is_completed = _mk_is_action_check(OnCompleted)
+
+
+is_error = _mk_is_action_check(OnError)

--- a/tests/test_observable/test_catch.py
+++ b/tests/test_observable/test_catch.py
@@ -1,3 +1,4 @@
+from functools import reduce
 import unittest
 
 from rx import Observable

--- a/tests/test_observable/test_catch.py
+++ b/tests/test_observable/test_catch.py
@@ -77,127 +77,55 @@ class TestCatch(unittest.TestCase):
         results.messages.assert_equal(*expected_msgs)
 
     def test_catch_no_errors(self):
-        scheduler = TestScheduler()
         msgs1 = [on_next(150, 1), on_next(210, 2), on_next(220, 3), on_completed(230)]
         msgs2 = [on_next(240, 5), on_completed(250)]
-        o1 = scheduler.create_hot_observable(msgs1)
-        o2 = scheduler.create_hot_observable(msgs2)
-
-        def create():
-            return o1.catch_exception(o2)
-        results = scheduler.start(create)
-
-        results.messages.assert_equal(on_next(210, 2), on_next(220, 3), on_completed(230))
 
         self._base_catch_exception_test([msgs1, msgs2])
 
     def test_catch_never(self):
-        scheduler = TestScheduler()
         msgs2 = [on_next(240, 5), on_completed(250)]
-        o1 = Observable.never()
-        o2 = scheduler.create_hot_observable(msgs2)
-
-        def create():
-            return o1.catch_exception(o2)
-        results = scheduler.start(create)
-
-        results.messages.assert_equal()
 
         # We don't do well with Observable.never(), so we pass expected_msgs.
         self._base_catch_exception_test([[], msgs2], expected_msgs=[])
 
     def test_catch_empty(self):
-        scheduler = TestScheduler()
         msgs1 = [on_next(150, 1), on_completed(230)]
         msgs2 = [on_next(240, 5), on_completed(250)]
-        o1 = scheduler.create_hot_observable(msgs1)
-        o2 = scheduler.create_hot_observable(msgs2)
-
-        def create():
-            return o1.catch_exception(o2)
-
-        results = scheduler.start(create)
-        results.messages.assert_equal(on_completed(230))
 
         self._base_catch_exception_test([msgs1, msgs2])
 
     def test_catch_return(self):
-        scheduler = TestScheduler()
         msgs1 = [on_next(150, 1), on_next(210, 2), on_completed(230)]
         msgs2 = [on_next(240, 5), on_completed(250)]
-        o1 = scheduler.create_hot_observable(msgs1)
-        o2 = scheduler.create_hot_observable(msgs2)
-
-        def create():
-            return o1.catch_exception(o2)
-
-        results = scheduler.start(create)
-        results.messages.assert_equal(on_next(210, 2), on_completed(230))
 
         self._base_catch_exception_test([msgs1, msgs2])
 
     def test_catch_error(self):
         ex = 'ex'
-        scheduler = TestScheduler()
         msgs1 = [on_next(150, 1), on_next(210, 2), on_next(220, 3), on_error(230, ex)]
         msgs2 = [on_next(240, 5), on_completed(250)]
-        o1 = scheduler.create_hot_observable(msgs1)
-        o2 = scheduler.create_hot_observable(msgs2)
-
-        def create():
-            return o1.catch_exception(o2)
-
-        results = scheduler.start(create)
-        results.messages.assert_equal(on_next(210, 2), on_next(220, 3), on_next(240, 5), on_completed(250))
 
         self._base_catch_exception_test([msgs1, msgs2])
 
     def test_catch_error_never(self):
         ex = 'ex'
-        scheduler = TestScheduler()
         msgs1 = [on_next(150, 1), on_next(210, 2), on_next(220, 3), on_error(230, ex)]
-        o1 = scheduler.create_hot_observable(msgs1)
-        o2 = Observable.never()
-        def create():
-            return o1.catch_exception(o2)
-
-        results = scheduler.start(create)
-        results.messages.assert_equal(on_next(210, 2), on_next(220, 3))
 
         # We don't do well with Observable.never(), so we pass expected_msgs.
         self._base_catch_exception_test([msgs1, []], expected_msgs=[on_next(210, 2), on_next(220, 3)])
 
     def test_catch_error_error(self):
         ex = 'ex'
-        scheduler = TestScheduler()
         msgs1 = [on_next(150, 1), on_next(210, 2), on_next(220, 3), on_error(230, 'ex1')]
         msgs2 = [on_next(240, 4), on_error(250, ex)]
-        o1 = scheduler.create_hot_observable(msgs1)
-        o2 = scheduler.create_hot_observable(msgs2)
-
-        def create():
-            return o1.catch_exception(o2)
-
-        results = scheduler.start(create)
-        results.messages.assert_equal(on_next(210, 2), on_next(220, 3), on_next(240, 4), on_error(250, ex))
 
         self._base_catch_exception_test([msgs1, msgs2])
 
     def test_catch_multiple(self):
         ex = 'ex'
-        scheduler = TestScheduler()
         msgs1 = [on_next(150, 1), on_next(210, 2), on_error(215, ex)]
         msgs2 = [on_next(220, 3), on_error(225, ex)]
         msgs3 = [on_next(230, 4), on_completed(235)]
-        o1 = scheduler.create_hot_observable(msgs1)
-        o2 = scheduler.create_hot_observable(msgs2)
-        o3 = scheduler.create_hot_observable(msgs3)
-
-        def create():
-            return Observable.catch_exception(o1, o2, o3)
-
-        results = scheduler.start(create)
-        results.messages.assert_equal(on_next(210, 2), on_next(220, 3), on_next(230, 4), on_completed(235))
 
         self._base_catch_exception_test([msgs1, msgs2, msgs3], use_chaining_api=False)
 
@@ -221,8 +149,6 @@ class TestCatch(unittest.TestCase):
 
         results.messages.assert_equal(on_next(210, 2), on_next(220, 3), on_next(240, 4), on_completed(250))
         assert(handler_called[0])
-
-        self._base_catch_exception_test([msgs1, msgs2])
 
     def test_catch_error_specific_caught_immediate(self):
         ex = 'ex'

--- a/tests/test_observable/test_catch.py
+++ b/tests/test_observable/test_catch.py
@@ -2,6 +2,7 @@ import unittest
 
 from rx import Observable
 from rx.testing import TestScheduler, ReactiveTest
+from rx.testing.recorded import is_next, is_completed, is_error
 
 on_next = ReactiveTest.on_next
 on_completed = ReactiveTest.on_completed
@@ -13,6 +14,67 @@ created = ReactiveTest.created
 
 
 class TestCatch(unittest.TestCase):
+
+    def _base_catch_exception_test(self, msgs, expected_msgs=None, use_chaining_api=True):
+        """Given lists of messages for successive observables, creates the
+        appropriate observables and chains them together using catch_exception.
+        Tests that the actions seen by a subscriber match the expected
+        messages.
+
+        Params:
+
+        :param msgs:
+            List of lists of expected messages.
+        :param expected_msgs:
+            List of expected messages received by subscribers. If not provided,
+            a "best guess" is used. Note that this "best guess" currently
+            doesn't perform well with non-terminating Observables (i.e.
+            Observable.never()).
+        :param use_chaining_api:
+            Whether to construct the catch_exception call by repeated chaining
+            off of instance methods, or by calling Observable.catch_exception
+            at the class level.
+        """
+        scheduler = TestScheduler()
+
+        def _ms_dispatch(ms):
+            if ms == []:
+                return Observable.never()
+            else:
+                return scheduler.create_hot_observable(ms)
+
+        os = [_ms_dispatch(ms) for ms in msgs]
+
+        def create():
+            if use_chaining_api:
+                return reduce(lambda o, catcher: o.catch_exception(catcher), os)
+            else:
+                return Observable.catch_exception(os)
+
+        if expected_msgs is None:
+            all_msgs = reduce(lambda acc, ms: acc + ms, msgs)
+
+            # This is an "imperative specification" of the expected behavior
+            # of catch_exception.
+            expected_msgs = []
+            for msg in all_msgs:
+                if is_completed(msg):
+                    expected_msgs.append(msg)
+                    break
+                elif is_error(msg):
+                    continue
+                elif is_next(msg):
+                    expected_msgs.append(msg)
+
+            expected_msgs = expected_msgs[1:]
+
+            # If the final handler throws, catch_exception throws.
+            if is_error(all_msgs[-1]):
+                expected_msgs.append(all_msgs[-1])
+
+        results = scheduler.start(create)
+
+        results.messages.assert_equal(*expected_msgs)
 
     def test_catch_no_errors(self):
         scheduler = TestScheduler()
@@ -27,6 +89,8 @@ class TestCatch(unittest.TestCase):
 
         results.messages.assert_equal(on_next(210, 2), on_next(220, 3), on_completed(230))
 
+        self._base_catch_exception_test([msgs1, msgs2])
+
     def test_catch_never(self):
         scheduler = TestScheduler()
         msgs2 = [on_next(240, 5), on_completed(250)]
@@ -38,6 +102,9 @@ class TestCatch(unittest.TestCase):
         results = scheduler.start(create)
 
         results.messages.assert_equal()
+
+        # We don't do well with Observable.never(), so we pass expected_msgs.
+        self._base_catch_exception_test([[], msgs2], expected_msgs=[])
 
     def test_catch_empty(self):
         scheduler = TestScheduler()
@@ -52,6 +119,8 @@ class TestCatch(unittest.TestCase):
         results = scheduler.start(create)
         results.messages.assert_equal(on_completed(230))
 
+        self._base_catch_exception_test([msgs1, msgs2])
+
     def test_catch_return(self):
         scheduler = TestScheduler()
         msgs1 = [on_next(150, 1), on_next(210, 2), on_completed(230)]
@@ -64,6 +133,8 @@ class TestCatch(unittest.TestCase):
 
         results = scheduler.start(create)
         results.messages.assert_equal(on_next(210, 2), on_completed(230))
+
+        self._base_catch_exception_test([msgs1, msgs2])
 
     def test_catch_error(self):
         ex = 'ex'
@@ -79,6 +150,8 @@ class TestCatch(unittest.TestCase):
         results = scheduler.start(create)
         results.messages.assert_equal(on_next(210, 2), on_next(220, 3), on_next(240, 5), on_completed(250))
 
+        self._base_catch_exception_test([msgs1, msgs2])
+
     def test_catch_error_never(self):
         ex = 'ex'
         scheduler = TestScheduler()
@@ -90,6 +163,9 @@ class TestCatch(unittest.TestCase):
 
         results = scheduler.start(create)
         results.messages.assert_equal(on_next(210, 2), on_next(220, 3))
+
+        # We don't do well with Observable.never(), so we pass expected_msgs.
+        self._base_catch_exception_test([msgs1, []], expected_msgs=[on_next(210, 2), on_next(220, 3)])
 
     def test_catch_error_error(self):
         ex = 'ex'
@@ -104,6 +180,8 @@ class TestCatch(unittest.TestCase):
 
         results = scheduler.start(create)
         results.messages.assert_equal(on_next(210, 2), on_next(220, 3), on_next(240, 4), on_error(250, ex))
+
+        self._base_catch_exception_test([msgs1, msgs2])
 
     def test_catch_multiple(self):
         ex = 'ex'
@@ -120,6 +198,8 @@ class TestCatch(unittest.TestCase):
 
         results = scheduler.start(create)
         results.messages.assert_equal(on_next(210, 2), on_next(220, 3), on_next(230, 4), on_completed(235))
+
+        self._base_catch_exception_test([msgs1, msgs2, msgs3], use_chaining_api=False)
 
     def test_catch_error_specific_caught(self):
         ex = 'ex'
@@ -141,6 +221,8 @@ class TestCatch(unittest.TestCase):
 
         results.messages.assert_equal(on_next(210, 2), on_next(220, 3), on_next(240, 4), on_completed(250))
         assert(handler_called[0])
+
+        self._base_catch_exception_test([msgs1, msgs2])
 
     def test_catch_error_specific_caught_immediate(self):
         ex = 'ex'

--- a/tests/test_observable/test_catch.py
+++ b/tests/test_observable/test_catch.py
@@ -243,3 +243,24 @@ class TestCatch(unittest.TestCase):
         msgs3 = [on_next(230, 4), on_completed(235)]
 
         self._base_call_tracked_handler_test([msgs1, msgs2, msgs3])
+
+    def test_legacy_handler_call_adapted(self):
+        handler_calls = [0]
+
+        def mk_handler(o2):
+            # This is the legacy type for handlers; note that we don't take
+            # the source observable as a parameter.
+            def handler(e):
+                handler_calls[0] += 1
+                return o2
+            return handler
+
+        ex = 'ex'
+        ex2 = 'ex'
+
+        msgs1 = [on_next(150, 1), on_next(210, 2), on_error(215, ex)]
+        msgs2 = [on_next(220, 3), on_error(225, ex2)]
+        msgs3 = [on_next(230, 4), on_completed(235)]
+
+        self._base_catch_exception_test([msgs1, msgs2, msgs3], mk_handler=mk_handler)
+        self.assertEqual(handler_calls[0], 2)

--- a/tests/test_observable/test_catch.py
+++ b/tests/test_observable/test_catch.py
@@ -131,7 +131,7 @@ class TestCatch(unittest.TestCase):
         o2 = scheduler.create_hot_observable(msgs2)
 
         def create():
-            def handler(e):
+            def handler(e, o):
                 handler_called[0] = True
                 return o2
 
@@ -150,7 +150,7 @@ class TestCatch(unittest.TestCase):
         o2 = scheduler.create_hot_observable(msgs2)
 
         def create():
-            def handler(e):
+            def handler(e, o):
                 handler_called[0] = True
                 return o2
 
@@ -170,7 +170,7 @@ class TestCatch(unittest.TestCase):
         o1 = scheduler.create_hot_observable(msgs1)
 
         def create():
-            def handler(e):
+            def handler(e, o):
                 handler_called[0] = True
                 raise Exception(ex2)
             return o1.catch_exception(handler)
@@ -193,10 +193,10 @@ class TestCatch(unittest.TestCase):
         o3 = scheduler.create_hot_observable(msgs3)
 
         def create():
-            def handler1(e):
+            def handler1(e, o):
                 first_handler_called[0] = True
                 return o2
-            def handler2(e):
+            def handler2(e, o):
                 second_handler_called[0] = True
                 return o3
             return o1.catch_exception(handler1).catch_exception(handler2)
@@ -221,11 +221,11 @@ class TestCatch(unittest.TestCase):
         o3 = scheduler.create_hot_observable(msgs3)
 
         def create():
-            def handler1(e):
+            def handler1(e, o):
                 first_handler_called[0] = True
                 assert(e == ex)
                 return o2
-            def handler2(e):
+            def handler2(e, o):
                 second_handler_called[0] = True
                 assert(e == ex2)
                 return o3


### PR DESCRIPTION
Fixes #125, and also some bonus test refactoring! (you can cherry-pick the first commit if you don't want the refactoring.)

re: changes to rx.testing.recorded: I don't really know where to put these functions.
re: docstrings: happy to change formats or whatever.

tests pass locally (py2.7) and I left in a commit with both the "old" tests and the "new" tests to show that I'm not breaking / reducing coverage.