### PR TITLE
still better error handling for `adapt_call`

### DIFF
--- a/rx/internal/utils.py
+++ b/rx/internal/utils.py
@@ -43,7 +43,7 @@ def adapt_call(func):
         # Type Errors together to generate a meaningful
         # error message.
         raise TypeError(*exceptions)
-        
+
     return func_wrapped
 
 

--- a/rx/internal/utils.py
+++ b/rx/internal/utils.py
@@ -19,7 +19,7 @@ def adapt_call(func):
     Adapt call from taking n params to only taking 1 or 2 params
     """
 
-    def _should_reraise_TypeError(tb):
+    def _should_reraise_TypeError():
         """Determine whether or not we should re-raise a given TypeError. Since
         we rely on excepting TypeError in order to determine whether or not we
         can adapt a function, we can't immediately determine whether a given
@@ -36,6 +36,8 @@ def adapt_call(func):
         and hence we can check for the presence of the third frame, which indicates
         whether an error occurred in the body.
         """
+        _, __, tb = sys.exc_info()
+
         return tb.tb_next.tb_next is not None
 
     cached = [None]
@@ -56,7 +58,7 @@ def adapt_call(func):
             except TypeError:
                 # Preserve the original traceback if there was a TypeError raised
                 # in the body of the adapted function.
-                if _should_reraise_TypeError(sys.exc_traceback):
+                if _should_reraise_TypeError():
                     raise
                 else:
                     continue

--- a/rx/internal/utils.py
+++ b/rx/internal/utils.py
@@ -40,10 +40,10 @@ def adapt_call(func):
 
     cached = [None]
 
-    def func1(arg1, *_):
+    def func1(arg1, *_, **__):
         return func(arg1)
 
-    def func2(arg1, arg2=None, *_):
+    def func2(arg1, arg2=None, *_, **__):
         return func(arg1, arg2)
 
     def func_wrapped(*args, **kw):

--- a/tests/test_core/test_util.py
+++ b/tests/test_core/test_util.py
@@ -58,7 +58,7 @@ class TestUtil(unittest.TestCase):
         with self.assertRaises(TypeError) as e:
             adapt_call(throws)(None)
 
-        self.assertEqual(err_msg, e.exception.message)
+        self.assertEqual(err_msg, str(e.exception))
 
     def test_adapt_call_adaptation_error(self):
 
@@ -74,4 +74,4 @@ class TestUtil(unittest.TestCase):
             adapt_call(not_adaptable)(None, None)
 
         for e in (e1, e2):
-            self.assertEqual(err_msg, e.exception.message)
+            self.assertEqual(err_msg, str(e.exception))

--- a/tests/test_core/test_util.py
+++ b/tests/test_core/test_util.py
@@ -48,3 +48,30 @@ class TestUtil(unittest.TestCase):
 
         value = func(42, 43, 44)
         assert value == 4200
+
+    def test_adapt_call_underlying_error(self):
+        err_msg = "We should see the original traceback."
+
+        def throws(a):
+            raise TypeError(err_msg)
+
+        with self.assertRaises(TypeError) as e:
+            adapt_call(throws)(None)
+
+        self.assertEqual(err_msg, e.exception.message)
+
+    def test_adapt_call_adaptation_error(self):
+
+        def not_adaptable(a, b, c):
+            pass
+
+        err_msg = "Couldn't adapt function {}".format(not_adaptable.__name__)
+
+        with self.assertRaises(TypeError) as e1:
+            adapt_call(not_adaptable)(None)
+
+        with self.assertRaises(TypeError) as e2:
+            adapt_call(not_adaptable)(None, None)
+
+        for e in (e1, e2):
+            self.assertEqual(err_msg, e.exception.message)

--- a/tests/test_core/test_util.py
+++ b/tests/test_core/test_util.py
@@ -8,16 +8,16 @@ class C(object):
 
     def __call__(self, x):
         return x + self._arg
-    
+
     def method1(self, x):
         return x + self._arg
-    
+
     def method2(self, x, y):
         return x + self._arg
-    
+
     def method3(self, x, y, z):
         return x + y + z + self._arg
-    
+
     @classmethod
     def clsmethod(cls, x):
         return x * 10


### PR DESCRIPTION
This is another go at the problem solved by #205. 

I think this approach does a better job than the previous one because it will preserve the traceback around `TypeError`s raised within the body of an adapted function.

I also added some coverage for error handling. The code is pretty thoroughly documented with explanations since error handling (properly) in python is tricky!

Without better error handling, I'm uncomfortable using this for production code, as some errors would be swallowed (pre-205), or lack the context necessary for debugging and escalation (pre-this PR). Since `adapt_call` is used frequently, this could have posed a significant problem.