### PR TITLE
fix `many_select`

### DIFF
--- a/rx/linq/observable/manyselect.py
+++ b/rx/linq/observable/manyselect.py
@@ -59,7 +59,7 @@ def many_select(self, selector, scheduler=None):
         def mapper(x):
             curr = ChainObservable(x)
 
-            chain[0] and chain[0].on_next(x)
+            chain[0] and chain[0].on_next(curr)
             chain[0] = curr
 
             return curr

--- a/tests/test_observable/test_manyselect.py
+++ b/tests/test_observable/test_manyselect.py
@@ -43,6 +43,15 @@ class TestManySelect(unittest.TestCase):
 
         self._obs_equal(left, right)
 
+    def test_many_select_subsequent_elements(self):
+        count = 3
+        xs = Observable.range(1, count)
+
+        left = xs.many_select(lambda x: x.to_list())
+        right = Observable.from_iterable([[e for e in range(i, count + 1)] for i in range(1, count + 1)])
+
+        self._obs_equal(left, right)
+
     def test_many_select_basic(self):
         scheduler = TestScheduler()
 

--- a/tests/test_observable/test_manyselect.py
+++ b/tests/test_observable/test_manyselect.py
@@ -15,7 +15,7 @@ created = ReactiveTest.created
 class TestManySelect(unittest.TestCase):
 
     def test_many_select_law_1(self):
-        xs = Observable.range(1, 0)
+        xs = Observable.range(1, 3)
 
         left = xs.many_select(lambda x: x.first())
         right = xs

--- a/tests/test_observable/test_manyselect.py
+++ b/tests/test_observable/test_manyselect.py
@@ -3,6 +3,7 @@ import unittest
 from rx.core import Observable
 from rx.testing import TestScheduler, ReactiveTest
 
+
 on_next = ReactiveTest.on_next
 on_completed = ReactiveTest.on_completed
 on_error = ReactiveTest.on_error
@@ -12,15 +13,35 @@ disposed = ReactiveTest.disposed
 created = ReactiveTest.created
 
 
+def _extract(x):
+    return x.first()
+
+
+def _duplicate(x):
+    """This is ``pure`` or ``return``. We need it in order to compare equality
+    of inputs and outputs of ``many_select``, since we don't have a true
+    ``extract`` function.
+    """
+    return Observable.from_iterable([x]).first()
+
+
+def _comparer(x, y):
+    """Compares two items of type ``Observable[a]``."""
+    return x.sequence_equal(y).first()
+
+
 class TestManySelect(unittest.TestCase):
+
+    def _obs_equal(self, left, right):
+        return left.sequence_equal(right, _comparer).first().subscribe(self.assertTrue)
 
     def test_many_select_law_1(self):
         xs = Observable.range(1, 3)
 
-        left = xs.many_select(lambda x: x.first())
-        right = xs
+        left = xs.many_select(_extract)
+        right = xs.map(_duplicate)  # since .first() returns ``Observable[a]`` and not ``a``.
 
-        left.sequence_equal(right).first().subscribe(self.assertTrue)
+        self._obs_equal(left, right)
 
     def test_many_select_basic(self):
         scheduler = TestScheduler()


### PR DESCRIPTION
It seems `many_select` is broken as far as satisfying the co-monad laws for co-bind / extend. I'm under the impression that `many_select` was intended to be co-bind/extend because it says so in the docstring and Bart de Smet [mentions as much here](https://social.msdn.microsoft.com/Forums/en-US/e70fe8b6-6d9d-486a-a8d0-c1bc66551ded/what-does-the-new-manyselect-operator-do?forum=rx).

**The main issue is that `first` is not `extract`**, as implemented. It should have type `Observable[a] -> a` but instead has type `Observable[a] -> Observable[a]`. Thus, this test fails because of `extract`. Note that `first` could be a lawful `extract, based on [these laws](https://hackage.haskell.org/package/comonad-5.0.2/docs/Control-Comonad.html#v:duplicate) (I briefly worked them out on paper).

Actually, the types are just all weird, because you can't go from `Observable[a] -> a`, because `first` isn't `extract`:

`Observable[a] ->`
 (private: after calling `map(ChainedObservable)`) `Observable[Observable[a]] ->`
(after applying `selector: Observable[a] -> Observable[b]`, which should have been `Observable[a] -> b`)
`Observable[Observable[b]]` (should have been `Observable[b]`)

In fact, I don't think there's any method in rx with type `Observable[a] -> b`, since the only thing that looks like that is `subscribe: Observer[a, b] -> Observable[a] -> "b"` where `b` is the type of the side-effect and `subscribe` actually returns unit/void.

That said, a possible candidate for `extract` could be something like `o.first().to_future()`, which does have type `Observable[a] -> b` (or really `Observable[Future[a]] -> Future[b]`, but whatever).

**The second issue is that this implementation doesn't do anything interesting with `extend` / `many_select`**. As far as I can tell (because the code is magic), 

**The third issue is that I think it's broken.** The implementation, both here and in RxJS, is some serious magic. The tests in RxJS are the same (and thus also trivial), so I'm not convinced that this has ever worked. I gather that we're supposed to get something like:

```python
>>> rx.Observable.from_iterable([1, 2, 3]).many_select(lambda x: x.first()). ...
... Observable([1, 2, 3], [2, 3], [3])
```

but instead we get `Observable([1], [2], [3]). [I think RxJS is similarly broken.](https://github.com/Reactive-Extensions/RxJS/issues/1358)

Given these issues, I think some action items are

1. stop trying to have co-monadic bind (also deprecate `many_select` as implemented, since it doesn't do anything), or fix `many_select` so it works like .NET.
2. implement a functioning `extract`, probably as `o.first().to_future()`

I'm going to try to fix `many_select`, and just make the tests accommodate the fact that we don't have an `extract`.