### PR TITLE
add LICENSE to distributions

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include LICENSE

--- a/setup.py
+++ b/setup.py
@@ -42,5 +42,6 @@ setup(
               'rx.concurrency', 'rx.concurrency.mainloopscheduler', 'rx.joins',
               'rx.linq.observable.blocking', 'rx.disposables', 'rx.subjects',
               'rx.backpressure', 'rx.testing'],
-    package_dir={'rx': 'rx'}
+    package_dir={'rx': 'rx'},
+    include_package_data=True,
 )


### PR DESCRIPTION
Thanks for the work!

This adds the `LICENSE` to distributions, as per the [Apache policy](http://www.apache.org/legal/src-headers.html).

Background: I am looking to package this for conda via the conda-forge process. In the meantime, I'll include a copy of the license there!

Thanks again!