### PR TITLE
partial tests update to pipe style

### DIFF
--- a/tests/test_observable/test_all.py
+++ b/tests/test_observable/test_all.py
@@ -1,5 +1,6 @@
 import unittest
 
+from rx import operators as _
 from rx.testing import TestScheduler, ReactiveTest
 
 on_next = ReactiveTest.on_next
@@ -19,7 +20,7 @@ class TestAll(unittest.TestCase):
         xs = scheduler.create_hot_observable(msgs)
 
         def create():
-            return xs.all(lambda x: x > 0)
+            return xs.pipe(_.all(lambda x: x > 0))
 
         res = scheduler.start(create=create).messages
         assert res == [on_next(250, True), on_completed(250)]
@@ -30,7 +31,7 @@ class TestAll(unittest.TestCase):
         xs = scheduler.create_hot_observable(msgs)
 
         def create():
-            return xs.all(lambda x: x > 0)
+            return xs.pipe(_.all(lambda x: x > 0))
 
         res = scheduler.start(create=create).messages
         assert res == [on_next(250, True), on_completed(250)]
@@ -41,7 +42,7 @@ class TestAll(unittest.TestCase):
         xs = scheduler.create_hot_observable(msgs)
 
         def create():
-            return xs.all(lambda x: x > 0)
+            return xs.pipe(_.all(lambda x: x > 0))
 
         res = scheduler.start(create=create).messages
         assert res == [on_next(210, False), on_completed(210)]
@@ -52,7 +53,7 @@ class TestAll(unittest.TestCase):
         xs = scheduler.create_hot_observable(msgs)
 
         def create():
-            return xs.all(lambda x: x > 0)
+            return xs.pipe(_.all(lambda x: x > 0))
 
         res = scheduler.start(create=create).messages
         assert res == [on_next(210, False), on_completed(210)]
@@ -63,7 +64,7 @@ class TestAll(unittest.TestCase):
         xs = scheduler.create_hot_observable(msgs)
 
         def create():
-            return xs.all(lambda x: x > 0)
+            return xs.pipe(_.all(lambda x: x > 0))
 
         res = scheduler.start(create=create).messages
         assert res == [on_next(210, False), on_completed(210)]
@@ -74,7 +75,7 @@ class TestAll(unittest.TestCase):
         xs = scheduler.create_hot_observable(msgs)
 
         def create():
-            return xs.all(lambda x: x > 0)
+            return xs.pipe(_.all(lambda x: x > 0))
 
         res = scheduler.start(create=create).messages
         assert res == [on_next(250, True), on_completed(250)]
@@ -86,7 +87,7 @@ class TestAll(unittest.TestCase):
         xs = scheduler.create_hot_observable(msgs)
 
         def create():
-            return xs.all(lambda x: x > 0)
+            return xs.pipe(_.all(lambda x: x > 0))
         res = scheduler.start(create=create).messages
         assert res == [on_error(210, ex)]
 
@@ -96,7 +97,7 @@ class TestAll(unittest.TestCase):
         xs = scheduler.create_hot_observable(msgs)
 
         def create():
-            return xs.all(lambda x: x > 0)
+            return xs.pipe(_.all(lambda x: x > 0))
 
         res = scheduler.start(create=create).messages
         assert res == []

--- a/tests/test_observable/test_average.py
+++ b/tests/test_observable/test_average.py
@@ -1,5 +1,6 @@
 import unittest
 
+from rx import operators as _
 from rx.testing import TestScheduler, ReactiveTest
 
 on_next = ReactiveTest.on_next
@@ -17,7 +18,7 @@ class TestAverage(unittest.TestCase):
         scheduler = TestScheduler()
         msgs = [on_next(150, 1), on_completed(250)]
         xs = scheduler.create_hot_observable(msgs)
-        res = scheduler.start(create=lambda: xs.average()).messages
+        res = scheduler.start(create=lambda: xs.pipe(_.average())).messages
 
         assert(len(res) == 1)
         assert(res[0].value.kind == 'E' and res[0].value.exception != None)
@@ -29,18 +30,19 @@ class TestAverage(unittest.TestCase):
         xs = scheduler.create_hot_observable(msgs)
 
         def create():
-            return xs.average()
+            return xs.pipe(_.average())
 
         res = scheduler.start(create=create).messages
         assert res == [on_next(250, 2.0), on_completed(250)]
 
     def test_average_int32_some(self):
         scheduler = TestScheduler()
-        msgs = [on_next(150, 1), on_next(210, 3), on_next(220, 4), on_next(230, 2), on_completed(250)]
+        msgs = [on_next(150, 1), on_next(210, 3), on_next(220, 4),
+                on_next(230, 2), on_completed(250)]
         xs = scheduler.create_hot_observable(msgs)
 
         def create():
-            return xs.average()
+            return xs.pipe(_.average())
 
         res = scheduler.start(create=create).messages
         assert res == [on_next(250, 3.0), on_completed(250)]
@@ -51,7 +53,7 @@ class TestAverage(unittest.TestCase):
         msgs = [on_next(150, 1), on_error(210, ex)]
         xs = scheduler.create_hot_observable(msgs)
         def create():
-            return xs.average()
+            return xs.pipe(_.average())
 
         res = scheduler.start(create=create).messages
         assert res == [on_error(210, ex)]
@@ -62,17 +64,20 @@ class TestAverage(unittest.TestCase):
         xs = scheduler.create_hot_observable(msgs)
 
         def create():
-            return xs.average()
+            return xs.pipe(_.average())
 
         res = scheduler.start(create=create).messages
         assert res == []
 
     def test_average_mapper_regular_int32(self):
         scheduler = TestScheduler()
-        xs = scheduler.create_hot_observable(on_next(210, "b"), on_next(220, "fo"), on_next(230, "qux"), on_completed(240))
+        xs = scheduler.create_hot_observable(
+                on_next(210, "b"), on_next(220, "fo"),
+                on_next(230, "qux"), on_completed(240),
+                )
 
         def create():
-            return xs.average(len)
+            return xs.pipe(_.average(len))
 
         res = scheduler.start(create=create)
 

--- a/tests/test_observable/test_distinctuntilchanged.py
+++ b/tests/test_observable/test_distinctuntilchanged.py
@@ -1,6 +1,7 @@
 import unittest
 
-from rx.chained import Observable
+import rx
+from rx import operators as _
 from rx.testing import TestScheduler, ReactiveTest
 
 on_next = ReactiveTest.on_next
@@ -26,7 +27,7 @@ class TestDistinctUntilChanged(unittest.TestCase):
         scheduler = TestScheduler()
 
         def create():
-            return Observable.never().distinct_until_changed()
+            return rx.never().pipe(_.distinct_until_changed())
         results = scheduler.start(create)
 
         assert results.messages == []
@@ -36,7 +37,7 @@ class TestDistinctUntilChanged(unittest.TestCase):
         xs = scheduler.create_hot_observable(on_next(150, 1), on_completed(250))
 
         def create():
-            return xs.distinct_until_changed()
+            return xs.pipe(_.distinct_until_changed())
 
         results = scheduler.start(create).messages
         self.assertEqual(1, len(results))
@@ -47,7 +48,7 @@ class TestDistinctUntilChanged(unittest.TestCase):
         xs = scheduler.create_hot_observable(on_next(150, 1), on_next(220, 2), on_completed(250))
 
         def create():
-            return xs.distinct_until_changed()
+            return xs.pipe(_.distinct_until_changed())
         results = scheduler.start(create).messages
         self.assertEqual(2, len(results))
         assert(results[0].value.kind == 'N' and results[0].time == 220 and results[0].value.value == 2)
@@ -59,7 +60,7 @@ class TestDistinctUntilChanged(unittest.TestCase):
         xs = scheduler.create_hot_observable(on_next(150, 1), on_error(250, ex))
 
         def create():
-            return xs.distinct_until_changed()
+            return xs.pipe(_.distinct_until_changed())
 
         results = scheduler.start(create).messages
         self.assertEqual(1, len(results))
@@ -76,7 +77,7 @@ class TestDistinctUntilChanged(unittest.TestCase):
             on_completed(250))
 
         def create():
-            return xs.distinct_until_changed()
+            return xs.pipe(_.distinct_until_changed())
 
         results = scheduler.start(create).messages
         self.assertEqual(5, len(results))
@@ -92,7 +93,7 @@ class TestDistinctUntilChanged(unittest.TestCase):
             220, 2), on_next(230, 2), on_next(240, 2), on_completed(250))
 
         def create():
-            return xs.distinct_until_changed()
+            return xs.pipe(_.distinct_until_changed())
 
         results = scheduler.start(create).messages
         self.assertEqual(2, len(results))
@@ -105,7 +106,7 @@ class TestDistinctUntilChanged(unittest.TestCase):
             220, 3), on_next(225, 2), on_next(230, 2), on_next(230, 1), on_next(240, 2), on_completed(250))
 
         def create():
-            return xs.distinct_until_changed()
+            return xs.pipe(_.distinct_until_changed())
 
         results = scheduler.start(create).messages
         self.assertEqual(6, len(results))
@@ -122,7 +123,9 @@ class TestDistinctUntilChanged(unittest.TestCase):
             220, 3), on_next(230, 4), on_next(240, 5), on_completed(250))
 
         def create():
-            return xs.distinct_until_changed(comparer=lambda x, y: True)
+            return xs.pipe(
+                    _.distinct_until_changed(comparer=lambda x, y: True),
+                    )
 
         results = scheduler.start(create).messages
         self.assertEqual(2, len(results))
@@ -135,7 +138,9 @@ class TestDistinctUntilChanged(unittest.TestCase):
             220, 2), on_next(230, 2), on_next(240, 2), on_completed(250))
 
         def create():
-            return xs.distinct_until_changed(comparer=lambda x, y: False)
+            return xs.pipe(
+                    _.distinct_until_changed(comparer=lambda x, y: False),
+                    )
 
         results = scheduler.start(create).messages
         self.assertEqual(5, len(results))
@@ -151,7 +156,7 @@ class TestDistinctUntilChanged(unittest.TestCase):
             220, 4), on_next(230, 3), on_next(240, 5), on_completed(250))
 
         def create():
-            return xs.distinct_until_changed(lambda x: x % 2)
+            return xs.pipe(_.distinct_until_changed(lambda x: x % 2))
 
         results = scheduler.start(create).messages
         self.assertEqual(3, len(results))
@@ -165,7 +170,7 @@ class TestDistinctUntilChanged(unittest.TestCase):
         xs = scheduler.create_hot_observable(on_next(150, 1), on_next(210, 2), on_completed(250))
 
         def create():
-            return xs.distinct_until_changed(lambda x: _raise(ex))
+            return xs.pipe(_.distinct_until_changed(lambda x: _raise(ex)))
         results = scheduler.start(create)
         assert results.messages == [on_error(210, ex)]
 
@@ -175,7 +180,9 @@ class TestDistinctUntilChanged(unittest.TestCase):
         xs = scheduler.create_hot_observable(on_next(150, 1), on_next(210, 2), on_next(220, 3), on_completed(250))
 
         def create():
-            return xs.distinct_until_changed(comparer=lambda x, y: _raise(ex))
+            return xs.pipe(
+                    _.distinct_until_changed(comparer=lambda x, y: _raise(ex)),
+                    )
 
         results = scheduler.start(create)
         assert results.messages == [on_next(210, 2), on_error(220, ex)]

--- a/tests/test_observable/test_doaction.py
+++ b/tests/test_observable/test_doaction.py
@@ -1,6 +1,7 @@
 import unittest
 
-from rx.chained import Observable
+import rx
+from rx import operators as _
 from rx.testing import TestScheduler, ReactiveTest
 
 on_next = ReactiveTest.on_next
@@ -25,7 +26,7 @@ class TestDo(unittest.TestCase):
                 i[0] += 1
                 sum[0] -= x
                 return sum[0]
-            return xs.do_action(action)
+            return xs.pipe(_.do_action(action))
 
         scheduler.start(create)
 
@@ -42,7 +43,7 @@ class TestDo(unittest.TestCase):
             def action(x):
                 i[0] += 1
                 return i[0]
-            return xs.do_action(action)
+            return xs.pipe(_.do_action(action))
         scheduler.start(create)
 
         self.assertEqual(4, i[0])
@@ -62,7 +63,7 @@ class TestDo(unittest.TestCase):
 
             def on_completed():
                 completed[0] = True
-            return xs.do_action(on_next=on_next, on_completed=on_completed)
+            return xs.pipe(_.do_action(on_next=on_next, on_completed=on_completed))
 
         scheduler.start(create)
 
@@ -84,7 +85,9 @@ class TestDo(unittest.TestCase):
             def on_completed():
                 nonlocal completed
                 completed = True
-            return Observable.never().do_action(on_next=on_next, on_completed=on_completed)
+            return rx.never().pipe(
+                _.do_action(on_next=on_next, on_completed=on_completed),
+                )
 
         scheduler.start(create)
 
@@ -99,7 +102,7 @@ class TestDo(unittest.TestCase):
         def create():
             def on_completed():
                 completed[0] = True
-            return xs.do_action(on_completed=on_completed)
+            return xs.pipe(_.do_action(on_completed=on_completed))
 
         scheduler.start(create)
 

--- a/tests/test_observable/test_flatmap.py
+++ b/tests/test_observable/test_flatmap.py
@@ -1,6 +1,7 @@
 import unittest
 
-from rx.chained import Observable
+import rx
+from rx import operators as _
 from rx.testing import TestScheduler, ReactiveTest, is_prime
 
 on_next = ReactiveTest.on_next
@@ -16,123 +17,196 @@ class TestFlatMap(unittest.TestCase):
 
     def test_flat_map_then_complete_complete(self):
         scheduler = TestScheduler()
-        xs = scheduler.create_cold_observable(on_next(100, 4), on_next(
-            200, 2), on_next(300, 3), on_next(400, 1), on_completed(500))
-        ys = scheduler.create_cold_observable(on_next(50, "foo"), on_next(
-            100, "bar"), on_next(150, "baz"), on_next(200, "qux"), on_completed(250))
+        xs = scheduler.create_cold_observable(
+                on_next(100, 4), on_next(200, 2), on_next(300, 3),
+                on_next(400, 1), on_completed(500))
+        ys = scheduler.create_cold_observable(
+                on_next(50, "foo"), on_next(100, "bar"), on_next(150, "baz"),
+                on_next(200, "qux"), on_completed(250))
 
         def factory():
-            return xs.flat_map(ys)
+            return xs.pipe(_.flat_map(ys))
 
         results = scheduler.start(factory)
 
-        assert results.messages == [on_next(350, "foo"), on_next(400, "bar"), on_next(450, "baz"), on_next(450, "foo"), on_next(500, "qux"), on_next(500, "bar"), on_next(550, "baz"), on_next(
-            550, "foo"), on_next(600, "qux"), on_next(600, "bar"), on_next(650, "baz"), on_next(650, "foo"), on_next(700, "qux"), on_next(700, "bar"), on_next(750, "baz"), on_next(800, "qux"), on_completed(850)]
+        assert results.messages == [
+                on_next(350, "foo"), on_next(400, "bar"), on_next(450, "baz"),
+                on_next(450, "foo"), on_next(500, "qux"), on_next(500, "bar"),
+                on_next(550, "baz"), on_next(550, "foo"), on_next(600, "qux"),
+                on_next(600, "bar"), on_next(650, "baz"), on_next(650, "foo"),
+                on_next(700, "qux"), on_next(700, "bar"), on_next(750, "baz"),
+                on_next(800, "qux"), on_completed(850)]
         assert xs.subscriptions == [subscribe(200, 700)]
-        assert ys.subscriptions == [subscribe(300, 550), subscribe(
-            400, 650), subscribe(500, 750), subscribe(600, 850)]
+        assert ys.subscriptions == [
+                subscribe(300, 550), subscribe(400, 650),
+                subscribe(500, 750), subscribe(600, 850)]
 
     def test_flat_map_then_complete_complete_2(self):
         scheduler = TestScheduler()
-        xs = scheduler.create_cold_observable(on_next(100, 4), on_next(
-            200, 2), on_next(300, 3), on_next(400, 1), on_completed(700))
-        ys = scheduler.create_cold_observable(on_next(50, "foo"), on_next(
-            100, "bar"), on_next(150, "baz"), on_next(200, "qux"), on_completed(250))
+        xs = scheduler.create_cold_observable(
+                on_next(100, 4), on_next(200, 2), on_next(300, 3),
+                on_next(400, 1), on_completed(700))
+        ys = scheduler.create_cold_observable(
+                on_next(50, "foo"), on_next(100, "bar"), on_next(150, "baz"),
+                on_next(200, "qux"), on_completed(250))
 
         def factory():
-            return xs.flat_map(ys)
+            return xs.pipe(_.flat_map(ys))
         results = scheduler.start(factory)
 
-        assert results.messages == [on_next(350, "foo"), on_next(400, "bar"), on_next(450, "baz"), on_next(450, "foo"), on_next(500, "qux"), on_next(500, "bar"), on_next(550, "baz"), on_next(
-            550, "foo"), on_next(600, "qux"), on_next(600, "bar"), on_next(650, "baz"), on_next(650, "foo"), on_next(700, "qux"), on_next(700, "bar"), on_next(750, "baz"), on_next(800, "qux"), on_completed(900)]
+        assert results.messages == [
+                on_next(350, "foo"), on_next(400, "bar"), on_next(450, "baz"),
+                on_next(450, "foo"), on_next(500, "qux"), on_next(500, "bar"),
+                on_next(550, "baz"), on_next(550, "foo"), on_next(600, "qux"),
+                on_next(600, "bar"), on_next(650, "baz"), on_next(650, "foo"),
+                on_next(700, "qux"), on_next(700, "bar"), on_next(750, "baz"),
+                on_next(800, "qux"), on_completed(900)]
         assert xs.subscriptions == [subscribe(200, 900)]
-        assert ys.subscriptions == [subscribe(300, 550), subscribe(
-            400, 650), subscribe(500, 750), subscribe(600, 850)]
+        assert ys.subscriptions == [
+                subscribe(300, 550), subscribe(400, 650),
+                subscribe(500, 750), subscribe(600, 850)]
 
     def test_flat_map_then_never_complete(self):
         scheduler = TestScheduler()
-        xs = scheduler.create_cold_observable(on_next(100, 4), on_next(
-            200, 2), on_next(300, 3), on_next(400, 1), on_next(500, 5), on_next(700, 0))
-        ys = scheduler.create_cold_observable(on_next(50, "foo"), on_next(
-            100, "bar"), on_next(150, "baz"), on_next(200, "qux"), on_completed(250))
-        results = scheduler.start(lambda: xs.flat_map(ys))
+        xs = scheduler.create_cold_observable(
+                on_next(100, 4), on_next(200, 2), on_next(300, 3),
+                on_next(400, 1), on_next(500, 5), on_next(700, 0))
+        ys = scheduler.create_cold_observable(
+                on_next(50, "foo"), on_next(100, "bar"), on_next(150, "baz"),
+                on_next(200, "qux"), on_completed(250))
+        results = scheduler.start(lambda: xs.pipe(_.flat_map(ys)))
 
-        assert results.messages == [on_next(350, "foo"), on_next(400, "bar"), on_next(450, "baz"), on_next(450, "foo"), on_next(500, "qux"), on_next(500, "bar"), on_next(550, "baz"), on_next(550, "foo"), on_next(600, "qux"), on_next(
-            600, "bar"), on_next(650, "baz"), on_next(650, "foo"), on_next(700, "qux"), on_next(700, "bar"), on_next(750, "baz"), on_next(750, "foo"), on_next(800, "qux"), on_next(800, "bar"), on_next(850, "baz"), on_next(900, "qux"), on_next(950, "foo")]
+        assert results.messages == [
+                on_next(350, "foo"), on_next(400, "bar"), on_next(450, "baz"),
+                on_next(450, "foo"), on_next(500, "qux"), on_next(500, "bar"),
+                on_next(550, "baz"), on_next(550, "foo"), on_next(600, "qux"),
+                on_next(600, "bar"), on_next(650, "baz"), on_next(650, "foo"),
+                on_next(700, "qux"), on_next(700, "bar"), on_next(750, "baz"),
+                on_next(750, "foo"), on_next(800, "qux"), on_next(800, "bar"),
+                on_next(850, "baz"), on_next(900, "qux"), on_next(950, "foo")]
         assert xs.subscriptions == [subscribe(200, 1000)]
-        assert ys.subscriptions == [subscribe(300, 550), subscribe(400, 650), subscribe(
-            500, 750), subscribe(600, 850), subscribe(700, 950), subscribe(900, 1000)]
+        assert ys.subscriptions == [
+                subscribe(300, 550), subscribe(400, 650), subscribe(500, 750),
+                subscribe(600, 850), subscribe(700, 950), subscribe(900, 1000)]
 
     def test_flat_map_then_complete_never(self):
         scheduler = TestScheduler()
-        xs = scheduler.create_cold_observable(on_next(100, 4), on_next(
-            200, 2), on_next(300, 3), on_next(400, 1), on_completed(500))
-        ys = scheduler.create_cold_observable(on_next(50, "foo"), on_next(
-            100, "bar"), on_next(150, "baz"), on_next(200, "qux"))
-        results = scheduler.start(lambda: xs.flat_map(ys))
+        xs = scheduler.create_cold_observable(
+                on_next(100, 4), on_next(200, 2), on_next(300, 3),
+                on_next(400, 1), on_completed(500))
+        ys = scheduler.create_cold_observable(
+                on_next(50, "foo"), on_next(100, "bar"), on_next(150, "baz"),
+                on_next(200, "qux"))
+        results = scheduler.start(lambda: xs.pipe(_.flat_map(ys)))
 
-        assert results.messages == [on_next(350, "foo"), on_next(400, "bar"), on_next(450, "baz"), on_next(450, "foo"), on_next(500, "qux"), on_next(500, "bar"), on_next(550, "baz"), on_next(
-            550, "foo"), on_next(600, "qux"), on_next(600, "bar"), on_next(650, "baz"), on_next(650, "foo"), on_next(700, "qux"), on_next(700, "bar"), on_next(750, "baz"), on_next(800, "qux")]
+        assert results.messages == [
+                on_next(350, "foo"), on_next(400, "bar"), on_next(450, "baz"),
+                on_next(450, "foo"), on_next(500, "qux"), on_next(500, "bar"),
+                on_next(550, "baz"), on_next(550, "foo"), on_next(600, "qux"),
+                on_next(600, "bar"), on_next(650, "baz"), on_next(650, "foo"),
+                on_next(700, "qux"), on_next(700, "bar"), on_next(750, "baz"),
+                on_next(800, "qux")]
         assert xs.subscriptions == [subscribe(200, 700)]
-        assert ys.subscriptions == [subscribe(300, 1000), subscribe(
-            400, 1000), subscribe(500, 1000), subscribe(600, 1000)]
+        assert ys.subscriptions == [
+                subscribe(300, 1000), subscribe(400, 1000),
+                subscribe(500, 1000), subscribe(600, 1000)]
 
     def test_flat_map_then_complete_error(self):
         ex = 'ex'
         scheduler = TestScheduler()
-        xs = scheduler.create_cold_observable(on_next(100, 4), on_next(
-            200, 2), on_next(300, 3), on_next(400, 1), on_completed(500))
-        ys = scheduler.create_cold_observable(on_next(50, "foo"), on_next(
-            100, "bar"), on_next(150, "baz"), on_next(200, "qux"), on_error(300, ex))
-        results = scheduler.start(lambda: xs.flat_map(ys))
+        xs = scheduler.create_cold_observable(
+                on_next(100, 4), on_next(200, 2), on_next(300, 3),
+                on_next(400, 1), on_completed(500))
+        ys = scheduler.create_cold_observable(
+                on_next(50, "foo"), on_next(100, "bar"), on_next(150, "baz"),
+                on_next(200, "qux"), on_error(300, ex))
+        results = scheduler.start(lambda: xs.pipe(_.flat_map(ys)))
 
-        assert results.messages == [on_next(350, "foo"), on_next(400, "bar"), on_next(450, "baz"), on_next(
-            450, "foo"), on_next(500, "qux"), on_next(500, "bar"), on_next(550, "baz"), on_next(550, "foo"), on_error(600, ex)]
+        assert results.messages == [
+                on_next(350, "foo"), on_next(400, "bar"), on_next(450, "baz"),
+                on_next(450, "foo"), on_next(500, "qux"), on_next(500, "bar"),
+                on_next(550, "baz"), on_next(550, "foo"), on_error(600, ex)]
         assert xs.subscriptions == [subscribe(200, 600)]
-        assert ys.subscriptions == [subscribe(300, 600), subscribe(
-            400, 600), subscribe(500, 600), subscribe(600, 600)]
+        assert ys.subscriptions == [
+                subscribe(300, 600), subscribe(400, 600),
+                subscribe(500, 600), subscribe(600, 600)]
 
     def test_flat_map_then_error_complete(self):
         ex = 'ex'
         scheduler = TestScheduler()
-        xs = scheduler.create_cold_observable(on_next(100, 4), on_next(
-            200, 2), on_next(300, 3), on_next(400, 1), on_error(500, ex))
-        ys = scheduler.create_cold_observable(on_next(50, "foo"), on_next(
-            100, "bar"), on_next(150, "baz"), on_next(200, "qux"), on_completed(250))
-        results = scheduler.start(lambda: xs.flat_map(ys))
+        xs = scheduler.create_cold_observable(
+                on_next(100, 4), on_next(200, 2), on_next(300, 3),
+                on_next(400, 1), on_error(500, ex))
+        ys = scheduler.create_cold_observable(
+                on_next(50, "foo"), on_next(100, "bar"), on_next(150, "baz"),
+                on_next(200, "qux"), on_completed(250))
+        results = scheduler.start(lambda: xs.pipe(_.flat_map(ys)))
 
-        assert results.messages == [on_next(350, "foo"), on_next(400, "bar"), on_next(450, "baz"), on_next(450, "foo"), on_next(500, "qux"), on_next(
-            500, "bar"), on_next(550, "baz"), on_next(550, "foo"), on_next(600, "qux"), on_next(600, "bar"), on_next(650, "baz"), on_next(650, "foo"), on_error(700, ex)]
+        assert results.messages == [
+                on_next(350, "foo"), on_next(400, "bar"), on_next(450, "baz"),
+                on_next(450, "foo"), on_next(500, "qux"), on_next(500, "bar"),
+                on_next(550, "baz"), on_next(550, "foo"), on_next(600, "qux"),
+                on_next(600, "bar"), on_next(650, "baz"), on_next(650, "foo"),
+                on_error(700, ex)]
         assert xs.subscriptions == [subscribe(200, 700)]
-        assert ys.subscriptions == [subscribe(300, 550), subscribe(
-            400, 650), subscribe(500, 700), subscribe(600, 700)]
+        assert ys.subscriptions == [
+                subscribe(300, 550), subscribe(400, 650),
+                subscribe(500, 700), subscribe(600, 700)]
 
     def test_flat_map_then_error_error(self):
         ex = 'ex'
         scheduler = TestScheduler()
-        xs = scheduler.create_cold_observable(on_next(100, 4), on_next(
-            200, 2), on_next(300, 3), on_next(400, 1), on_error(500, ex))
-        ys = scheduler.create_cold_observable(on_next(50, "foo"), on_next(
-            100, "bar"), on_next(150, "baz"), on_next(200, "qux"), on_error(250, ex))
-        results = scheduler.start(lambda: xs.flat_map(ys))
+        xs = scheduler.create_cold_observable(
+                on_next(100, 4), on_next(200, 2), on_next(300, 3),
+                on_next(400, 1), on_error(500, ex))
+        ys = scheduler.create_cold_observable(
+                on_next(50, "foo"), on_next(100, "bar"), on_next(150, "baz"),
+                on_next(200, "qux"), on_error(250, ex))
+        results = scheduler.start(lambda: xs.pipe(_.flat_map(ys)))
 
-        assert results.messages == [on_next(350, "foo"), on_next(400, "bar"), on_next(
-            450, "baz"), on_next(450, "foo"), on_next(500, "qux"), on_next(500, "bar"), on_error(550, ex)]
+        assert results.messages == [
+                on_next(350, "foo"), on_next(400, "bar"), on_next(450, "baz"),
+                on_next(450, "foo"), on_next(500, "qux"), on_next(500, "bar"),
+                on_error(550, ex)]
         assert xs.subscriptions == [subscribe(200, 550)]
         assert ys.subscriptions == [
             subscribe(300, 550), subscribe(400, 550), subscribe(500, 550)]
 
     def test_flat_map_complete(self):
         scheduler = TestScheduler()
-        xs = scheduler.create_hot_observable(on_next(5, scheduler.create_cold_observable(on_error(1, 'ex1'))), on_next(105, scheduler.create_cold_observable(on_error(1, 'ex2'))), on_next(300, scheduler.create_cold_observable(on_next(10, 102), on_next(90, 103), on_next(110, 104), on_next(190, 105), on_next(440, 106), on_completed(460))), on_next(400, scheduler.create_cold_observable(on_next(
-            180, 202), on_next(190, 203), on_completed(205))), on_next(550, scheduler.create_cold_observable(on_next(10, 301), on_next(50, 302), on_next(70, 303), on_next(260, 304), on_next(310, 305), on_completed(410))), on_next(750, scheduler.create_cold_observable(on_completed(40))), on_next(850, scheduler.create_cold_observable(on_next(80, 401), on_next(90, 402), on_completed(100))), on_completed(900))
+        xs = scheduler.create_hot_observable(
+                on_next(5, scheduler.create_cold_observable(
+                        on_error(1, 'ex1'))),
+                on_next(105, scheduler.create_cold_observable(
+                        on_error(1, 'ex2'))),
+                on_next(300, scheduler.create_cold_observable(
+                        on_next(10, 102), on_next(90, 103),
+                        on_next(110, 104), on_next(190, 105),
+                        on_next(440, 106), on_completed(460))),
+                on_next(400, scheduler.create_cold_observable(
+                        on_next(180, 202), on_next(190, 203),
+                        on_completed(205))),
+                on_next(550, scheduler.create_cold_observable(
+                        on_next(10, 301), on_next(50, 302),
+                        on_next(70, 303), on_next(260, 304),
+                        on_next(310, 305), on_completed(410))),
+                on_next(750, scheduler.create_cold_observable(
+                        on_completed(40))),
+                on_next(850, scheduler.create_cold_observable(
+                        on_next(80, 401), on_next(90, 402),
+                        on_completed(100))),
+                on_completed(900))
 
         def factory():
-            return xs.flat_map(lambda x: x)
+            return xs.pipe(_.flat_map(lambda x: x))
         results = scheduler.start(factory)
 
-        assert results.messages == [on_next(310, 102), on_next(390, 103), on_next(410, 104), on_next(490, 105), on_next(560, 301), on_next(580, 202), on_next(
-            590, 203), on_next(600, 302), on_next(620, 303), on_next(740, 106), on_next(810, 304), on_next(860, 305), on_next(930, 401), on_next(940, 402), on_completed(960)]
+        assert results.messages == [
+                on_next(310, 102), on_next(390, 103), on_next(410, 104),
+                on_next(490, 105), on_next(560, 301), on_next(580, 202),
+                on_next(590, 203), on_next(600, 302), on_next(620, 303),
+                on_next(740, 106), on_next(810, 304), on_next(860, 305),
+                on_next(930, 401), on_next(940, 402), on_completed(960)]
         assert xs.subscriptions == [subscribe(200, 900)]
         assert xs.messages[2].value.value.subscriptions == [
             subscribe(300, 760)]
@@ -147,15 +221,38 @@ class TestFlatMap(unittest.TestCase):
 
     def test_flat_map_complete_inner_not_complete(self):
         scheduler = TestScheduler()
-        xs = scheduler.create_hot_observable(on_next(5, scheduler.create_cold_observable(on_error(1, 'ex1'))), on_next(105, scheduler.create_cold_observable(on_error(1, 'ex2'))), on_next(300, scheduler.create_cold_observable(on_next(10, 102), on_next(90, 103), on_next(110, 104), on_next(190, 105), on_next(440, 106), on_completed(460))), on_next(400, scheduler.create_cold_observable(
-            on_next(180, 202), on_next(190, 203))), on_next(550, scheduler.create_cold_observable(on_next(10, 301), on_next(50, 302), on_next(70, 303), on_next(260, 304), on_next(310, 305), on_completed(410))), on_next(750, scheduler.create_cold_observable(on_completed(40))), on_next(850, scheduler.create_cold_observable(on_next(80, 401), on_next(90, 402), on_completed(100))), on_completed(900))
+        xs = scheduler.create_hot_observable(
+                on_next(5, scheduler.create_cold_observable(
+                        on_error(1, 'ex1'))),
+                on_next(105, scheduler.create_cold_observable(
+                        on_error(1, 'ex2'))),
+                on_next(300, scheduler.create_cold_observable(
+                        on_next(10, 102), on_next(90, 103),
+                        on_next(110, 104), on_next(190, 105),
+                        on_next(440, 106), on_completed(460))),
+                on_next(400, scheduler.create_cold_observable(
+                        on_next(180, 202), on_next(190, 203))),
+                on_next(550, scheduler.create_cold_observable(
+                        on_next(10, 301), on_next(50, 302),
+                        on_next(70, 303), on_next(260, 304),
+                        on_next(310, 305), on_completed(410))),
+                on_next(750, scheduler.create_cold_observable(
+                        on_completed(40))),
+                on_next(850, scheduler.create_cold_observable(
+                        on_next(80, 401), on_next(90, 402),
+                        on_completed(100))),
+                on_completed(900))
 
         def factory():
-            return xs.flat_map(lambda x: x)
+            return xs.pipe(_.flat_map(lambda x: x))
         results = scheduler.start(factory)
 
-        assert results.messages == [on_next(310, 102), on_next(390, 103), on_next(410, 104), on_next(490, 105), on_next(560, 301), on_next(580, 202), on_next(
-            590, 203), on_next(600, 302), on_next(620, 303), on_next(740, 106), on_next(810, 304), on_next(860, 305), on_next(930, 401), on_next(940, 402)]
+        assert results.messages == [
+                on_next(310, 102), on_next(390, 103), on_next(410, 104),
+                on_next(490, 105), on_next(560, 301), on_next(580, 202),
+                on_next(590, 203), on_next(600, 302), on_next(620, 303),
+                on_next(740, 106), on_next(810, 304), on_next(860, 305),
+                on_next(930, 401), on_next(940, 402)]
         assert xs.subscriptions == [subscribe(200, 900)]
         assert xs.messages[2].value.value.subscriptions == [
             subscribe(300, 760)]
@@ -170,15 +267,38 @@ class TestFlatMap(unittest.TestCase):
 
     def test_flat_map_complete_outer_not_complete(self):
         scheduler = TestScheduler()
-        xs = scheduler.create_hot_observable(on_next(5, scheduler.create_cold_observable(on_error(1, 'ex1'))), on_next(105, scheduler.create_cold_observable(on_error(1, 'ex2'))), on_next(300, scheduler.create_cold_observable(on_next(10, 102), on_next(90, 103), on_next(110, 104), on_next(190, 105), on_next(440, 106), on_completed(460))), on_next(400, scheduler.create_cold_observable(
-            on_next(180, 202), on_next(190, 203), on_completed(205))), on_next(550, scheduler.create_cold_observable(on_next(10, 301), on_next(50, 302), on_next(70, 303), on_next(260, 304), on_next(310, 305), on_completed(410))), on_next(750, scheduler.create_cold_observable(on_completed(40))), on_next(850, scheduler.create_cold_observable(on_next(80, 401), on_next(90, 402), on_completed(100))))
+        xs = scheduler.create_hot_observable(
+                on_next(5, scheduler.create_cold_observable(
+                        on_error(1, 'ex1'))),
+                on_next(105, scheduler.create_cold_observable(
+                        on_error(1, 'ex2'))),
+                on_next(300, scheduler.create_cold_observable(
+                        on_next(10, 102), on_next(90, 103),
+                        on_next(110, 104), on_next(190, 105),
+                        on_next(440, 106), on_completed(460))),
+                on_next(400, scheduler.create_cold_observable(
+                        on_next(180, 202), on_next(190, 203),
+                        on_completed(205))),
+                on_next(550, scheduler.create_cold_observable(
+                        on_next(10, 301), on_next(50, 302),
+                        on_next(70, 303), on_next(260, 304),
+                        on_next(310, 305), on_completed(410))),
+                on_next(750, scheduler.create_cold_observable(
+                        on_completed(40))),
+                on_next(850, scheduler.create_cold_observable(
+                        on_next(80, 401), on_next(90, 402),
+                        on_completed(100))))
 
         def factory():
-            return xs.flat_map(lambda x: x)
+            return xs.pipe(_.flat_map(lambda x: x))
         results = scheduler.start(factory)
 
-        assert results.messages == [on_next(310, 102), on_next(390, 103), on_next(410, 104), on_next(490, 105), on_next(560, 301), on_next(580, 202), on_next(
-            590, 203), on_next(600, 302), on_next(620, 303), on_next(740, 106), on_next(810, 304), on_next(860, 305), on_next(930, 401), on_next(940, 402)]
+        assert results.messages == [
+                on_next(310, 102), on_next(390, 103), on_next(410, 104),
+                on_next(490, 105), on_next(560, 301), on_next(580, 202),
+                on_next(590, 203), on_next(600, 302), on_next(620, 303),
+                on_next(740, 106), on_next(810, 304), on_next(860, 305),
+                on_next(930, 401), on_next(940, 402)]
         assert xs.subscriptions == [subscribe(200, 1000)]
         assert xs.messages[2].value.value.subscriptions == [
             subscribe(300, 760)]
@@ -194,15 +314,39 @@ class TestFlatMap(unittest.TestCase):
     def test_flat_map_error_outer(self):
         ex = 'ex'
         scheduler = TestScheduler()
-        xs = scheduler.create_hot_observable(on_next(5, scheduler.create_cold_observable(on_error(1, 'ex1'))), on_next(105, scheduler.create_cold_observable(on_error(1, 'ex2'))), on_next(300, scheduler.create_cold_observable(on_next(10, 102), on_next(90, 103), on_next(110, 104), on_next(190, 105), on_next(440, 106), on_completed(460))), on_next(400, scheduler.create_cold_observable(on_next(
-            180, 202), on_next(190, 203), on_completed(205))), on_next(550, scheduler.create_cold_observable(on_next(10, 301), on_next(50, 302), on_next(70, 303), on_next(260, 304), on_next(310, 305), on_completed(410))), on_next(750, scheduler.create_cold_observable(on_completed(40))), on_next(850, scheduler.create_cold_observable(on_next(80, 401), on_next(90, 402), on_completed(100))), on_error(900, ex))
+        xs = scheduler.create_hot_observable(
+                on_next(5, scheduler.create_cold_observable(
+                        on_error(1, 'ex1'))),
+                on_next(105, scheduler.create_cold_observable(
+                        on_error(1, 'ex2'))),
+                on_next(300, scheduler.create_cold_observable(
+                        on_next(10, 102), on_next(90, 103),
+                        on_next(110, 104), on_next(190, 105),
+                        on_next(440, 106), on_completed(460))),
+                on_next(400, scheduler.create_cold_observable(
+                        on_next(180, 202), on_next(190, 203),
+                        on_completed(205))),
+                on_next(550, scheduler.create_cold_observable(
+                        on_next(10, 301), on_next(50, 302),
+                        on_next(70, 303), on_next(260, 304),
+                        on_next(310, 305), on_completed(410))),
+                on_next(750, scheduler.create_cold_observable(
+                        on_completed(40))),
+                on_next(850, scheduler.create_cold_observable(
+                        on_next(80, 401), on_next(90, 402),
+                        on_completed(100))),
+                on_error(900, ex))
 
         def factory():
-            return xs.flat_map(lambda x: x)
+            return xs.pipe(_.flat_map(lambda x: x))
         results = scheduler.start(factory)
 
-        assert results.messages == [on_next(310, 102), on_next(390, 103), on_next(410, 104), on_next(490, 105), on_next(560, 301), on_next(
-            580, 202), on_next(590, 203), on_next(600, 302), on_next(620, 303), on_next(740, 106), on_next(810, 304), on_next(860, 305), on_error(900, ex)]
+        assert results.messages == [
+                on_next(310, 102), on_next(390, 103), on_next(410, 104),
+                on_next(490, 105), on_next(560, 301), on_next(580, 202),
+                on_next(590, 203), on_next(600, 302), on_next(620, 303),
+                on_next(740, 106), on_next(810, 304), on_next(860, 305),
+                on_error(900, ex)]
         assert xs.subscriptions == [subscribe(200, 900)]
         assert xs.messages[2].value.value.subscriptions == [
             subscribe(300, 760)]
@@ -218,15 +362,38 @@ class TestFlatMap(unittest.TestCase):
     def test_flat_map_error_inner(self):
         ex = 'ex'
         scheduler = TestScheduler()
-        xs = scheduler.create_hot_observable(on_next(5, scheduler.create_cold_observable(on_error(1, 'ex1'))), on_next(105, scheduler.create_cold_observable(on_error(1, 'ex2'))), on_next(300, scheduler.create_cold_observable(on_next(10, 102), on_next(90, 103), on_next(110, 104), on_next(190, 105), on_next(440, 106), on_error(460, ex))), on_next(400, scheduler.create_cold_observable(on_next(
-            180, 202), on_next(190, 203), on_completed(205))), on_next(550, scheduler.create_cold_observable(on_next(10, 301), on_next(50, 302), on_next(70, 303), on_next(260, 304), on_next(310, 305), on_completed(410))), on_next(750, scheduler.create_cold_observable(on_completed(40))), on_next(850, scheduler.create_cold_observable(on_next(80, 401), on_next(90, 402), on_completed(100))), on_completed(900))
+        xs = scheduler.create_hot_observable(
+                on_next(5, scheduler.create_cold_observable(
+                        on_error(1, 'ex1'))),
+                on_next(105, scheduler.create_cold_observable(
+                        on_error(1, 'ex2'))),
+                on_next(300, scheduler.create_cold_observable(
+                        on_next(10, 102), on_next(90, 103),
+                        on_next(110, 104), on_next(190, 105),
+                        on_next(440, 106), on_error(460, ex))),
+                on_next(400, scheduler.create_cold_observable(
+                        on_next(180, 202), on_next(190, 203),
+                        on_completed(205))),
+                on_next(550, scheduler.create_cold_observable(
+                        on_next(10, 301), on_next(50, 302),
+                        on_next(70, 303), on_next(260, 304),
+                        on_next(310, 305), on_completed(410))),
+                on_next(750, scheduler.create_cold_observable(
+                        on_completed(40))),
+                on_next(850, scheduler.create_cold_observable(
+                        on_next(80, 401), on_next(90, 402),
+                        on_completed(100))),
+                on_completed(900))
 
         def factory():
-            return xs.flat_map(lambda x: x)
+            return xs.pipe(_.flat_map(lambda x: x))
         results = scheduler.start(factory)
 
-        assert results.messages == [on_next(310, 102), on_next(390, 103), on_next(410, 104), on_next(490, 105), on_next(
-            560, 301), on_next(580, 202), on_next(590, 203), on_next(600, 302), on_next(620, 303), on_next(740, 106), on_error(760, ex)]
+        assert results.messages == [
+                on_next(310, 102), on_next(390, 103), on_next(410, 104),
+                on_next(490, 105), on_next(560, 301), on_next(580, 202),
+                on_next(590, 203), on_next(600, 302), on_next(620, 303),
+                on_next(740, 106), on_error(760, ex)]
         assert xs.subscriptions == [subscribe(200, 760)]
         assert xs.messages[2].value.value.subscriptions == [
             subscribe(300, 760)]
@@ -240,15 +407,37 @@ class TestFlatMap(unittest.TestCase):
 
     def test_flat_map_dispose(self):
         scheduler = TestScheduler()
-        xs = scheduler.create_hot_observable(on_next(5, scheduler.create_cold_observable(on_error(1, 'ex1'))), on_next(105, scheduler.create_cold_observable(on_error(1, 'ex2'))), on_next(300, scheduler.create_cold_observable(on_next(10, 102), on_next(90, 103), on_next(110, 104), on_next(190, 105), on_next(440, 106), on_completed(460))), on_next(400, scheduler.create_cold_observable(on_next(
-            180, 202), on_next(190, 203), on_completed(205))), on_next(550, scheduler.create_cold_observable(on_next(10, 301), on_next(50, 302), on_next(70, 303), on_next(260, 304), on_next(310, 305), on_completed(410))), on_next(750, scheduler.create_cold_observable(on_completed(40))), on_next(850, scheduler.create_cold_observable(on_next(80, 401), on_next(90, 402), on_completed(100))), on_completed(900))
+        xs = scheduler.create_hot_observable(
+                on_next(5, scheduler.create_cold_observable(
+                        on_error(1, 'ex1'))),
+                on_next(105, scheduler.create_cold_observable(
+                        on_error(1, 'ex2'))),
+                on_next(300, scheduler.create_cold_observable(
+                        on_next(10, 102), on_next(90, 103),
+                        on_next(110, 104), on_next(190, 105),
+                        on_next(440, 106), on_completed(460))),
+                on_next(400, scheduler.create_cold_observable(
+                        on_next(180, 202), on_next(190, 203),
+                        on_completed(205))),
+                on_next(550, scheduler.create_cold_observable(
+                        on_next(10, 301), on_next(50, 302),
+                        on_next(70, 303), on_next(260, 304),
+                        on_next(310, 305), on_completed(410))),
+                on_next(750, scheduler.create_cold_observable(
+                        on_completed(40))),
+                on_next(850, scheduler.create_cold_observable(
+                        on_next(80, 401), on_next(90, 402),
+                        on_completed(100))),
+                on_completed(900))
 
         def create():
-            return xs.flat_map(lambda x: x)
+            return xs.pipe(_.flat_map(lambda x: x))
         results = scheduler.start(create, disposed=700)
 
-        assert results.messages == [on_next(310, 102), on_next(390, 103), on_next(410, 104), on_next(
-            490, 105), on_next(560, 301), on_next(580, 202), on_next(590, 203), on_next(600, 302), on_next(620, 303)]
+        assert results.messages == [
+                on_next(310, 102), on_next(390, 103), on_next(410, 104),
+                on_next(490, 105), on_next(560, 301), on_next(580, 202),
+                on_next(590, 203), on_next(600, 302), on_next(620, 303)]
         assert xs.subscriptions == [subscribe(200, 700)]
         assert xs.messages[2].value.value.subscriptions == [
             subscribe(300, 700)]
@@ -263,8 +452,28 @@ class TestFlatMap(unittest.TestCase):
         invoked = [0]
         ex = 'ex'
         scheduler = TestScheduler()
-        xs = scheduler.create_hot_observable(on_next(5, scheduler.create_cold_observable(on_error(1, 'ex1'))), on_next(105, scheduler.create_cold_observable(on_error(1, 'ex2'))), on_next(300, scheduler.create_cold_observable(on_next(10, 102), on_next(90, 103), on_next(110, 104), on_next(190, 105), on_next(440, 106), on_completed(460))), on_next(400, scheduler.create_cold_observable(on_next(
-            180, 202), on_next(190, 203), on_completed(205))), on_next(550, scheduler.create_cold_observable(on_next(10, 301), on_next(50, 302), on_next(70, 303), on_next(260, 304), on_next(310, 305), on_completed(410))), on_next(750, scheduler.create_cold_observable(on_completed(40))), on_next(850, scheduler.create_cold_observable(on_next(80, 401), on_next(90, 402), on_completed(100))), on_completed(900))
+        xs = scheduler.create_hot_observable(
+                on_next(5, scheduler.create_cold_observable(
+                        on_error(1, 'ex1'))),
+                on_next(105, scheduler.create_cold_observable(
+                        on_error(1, 'ex2'))),
+                on_next(300, scheduler.create_cold_observable(
+                        on_next(10, 102), on_next(90, 103),
+                        on_next(110, 104), on_next(190, 105),
+                        on_next(440, 106), on_completed(460))),
+                on_next(400, scheduler.create_cold_observable(
+                        on_next(180, 202), on_next(190, 203),
+                        on_completed(205))),
+                on_next(550, scheduler.create_cold_observable(
+                        on_next(10, 301), on_next(50, 302),
+                        on_next(70, 303), on_next(260, 304),
+                        on_next(310, 305), on_completed(410))),
+                on_next(750, scheduler.create_cold_observable(
+                        on_completed(40))),
+                on_next(850, scheduler.create_cold_observable(
+                        on_next(80, 401), on_next(90, 402),
+                        on_completed(100))),
+                on_completed(900))
 
         def factory():
             def projection(x):
@@ -272,11 +481,12 @@ class TestFlatMap(unittest.TestCase):
                 if invoked[0] == 3:
                     raise Exception(ex)
                 return x
-            return xs.flat_map(projection)
+            return xs.pipe(_.flat_map(projection))
         results = scheduler.start(factory)
 
-        assert results.messages == [on_next(310, 102), on_next(
-            390, 103), on_next(410, 104), on_next(490, 105), on_error(550, ex)]
+        assert results.messages == [
+                on_next(310, 102), on_next(390, 103), on_next(410, 104),
+                on_next(490, 105), on_error(550, ex)]
         assert xs.subscriptions == [subscribe(200, 550)]
         assert xs.messages[2].value.value.subscriptions == [
             subscribe(300, 550)]
@@ -288,13 +498,14 @@ class TestFlatMap(unittest.TestCase):
 
     def test_flat_map_use_function(self):
         scheduler = TestScheduler()
-        xs = scheduler.create_hot_observable(on_next(210, 4), on_next(
-            220, 3), on_next(250, 5), on_next(270, 1), on_completed(290))
+        xs = scheduler.create_hot_observable(
+                on_next(210, 4), on_next(220, 3), on_next(250, 5),
+                on_next(270, 1), on_completed(290))
 
         def factory():
             def projection(x):
-                return Observable.interval(10).mapi(lambda a, b: x).take(x)
-            return xs.flat_map(projection)
+                return rx.interval(10).mapi(lambda a, b: x).take(x)
+            return xs.pipe(_.flat_map(projection))
         results = scheduler.start(factory)
 
         assert results.messages == [
@@ -331,7 +542,7 @@ class TestFlatMap(unittest.TestCase):
                 ys = [x] * x
                 inners.append(ys)
                 return ys
-            return xs.flat_map(mapper)
+            return xs.pipe(_.flat_map(mapper))
         res = scheduler.start(create)
 
         assert res.messages == [
@@ -364,8 +575,12 @@ class TestFlatMap(unittest.TestCase):
         )
 
         def create():
-            return xs.flat_mapi(mapper_indexed=lambda x, i: [x] * x, result_mapper_indexed=lambda x, y, i: x + y)
-
+            return xs.pipe(
+                _.flat_mapi(
+                        mapper_indexed=lambda x, i: [x] * x,
+                        result_mapper_indexed=lambda x, y, i: x + y,
+                        )
+                )
         res = scheduler.start(create)
 
         assert res.messages == [

--- a/tests/test_observable/test_last.py
+++ b/tests/test_observable/test_last.py
@@ -1,5 +1,6 @@
 import unittest
 
+from rx import operators as _
 from rx.testing import TestScheduler, ReactiveTest
 
 on_next = ReactiveTest.on_next
@@ -27,7 +28,7 @@ class TestLast(unittest.TestCase):
         xs = scheduler.create_hot_observable(on_next(150, 1), on_completed(250))
 
         def create():
-            return xs.last()
+            return xs.pipe(_.last())
 
         res = scheduler.start(create=create)
 
@@ -39,10 +40,11 @@ class TestLast(unittest.TestCase):
 
     def test_last_async_one(self):
         scheduler = TestScheduler()
-        xs = scheduler.create_hot_observable(on_next(150, 1), on_next(210, 2), on_completed(250))
+        xs = scheduler.create_hot_observable(
+                on_next(150, 1), on_next(210, 2), on_completed(250))
 
         def create():
-            return xs.last()
+            return xs.pipe(_.last())
 
         res = scheduler.start(create=create)
 
@@ -51,10 +53,12 @@ class TestLast(unittest.TestCase):
 
     def test_last_async_many(self):
         scheduler = TestScheduler()
-        xs = scheduler.create_hot_observable(on_next(150, 1), on_next(210, 2), on_next(220, 3), on_completed(250))
+        xs = scheduler.create_hot_observable(
+                on_next(150, 1), on_next(210, 2), on_next(220, 3),
+                on_completed(250))
 
         def create():
-            return xs.last()
+            return xs.pipe(_.last())
 
         res = scheduler.start(create=create)
 
@@ -67,7 +71,7 @@ class TestLast(unittest.TestCase):
         xs = scheduler.create_hot_observable(on_next(150, 1), on_error(210, ex))
 
         def create():
-            return xs.last()
+            return xs.pipe(_.last())
 
         res = scheduler.start(create=create)
 
@@ -76,12 +80,14 @@ class TestLast(unittest.TestCase):
 
     def test_last_async_predicate(self):
         scheduler = TestScheduler()
-        xs = scheduler.create_hot_observable(on_next(150, 1), on_next(210, 2), on_next(220, 3), on_next(230, 4), on_next(240, 5), on_completed(250))
+        xs = scheduler.create_hot_observable(
+                on_next(150, 1), on_next(210, 2), on_next(220, 3),
+                on_next(230, 4), on_next(240, 5), on_completed(250))
 
         def create():
             def predicate(x):
                 return x % 2 == 1
-            return xs.last(predicate)
+            return xs.pipe(_.last(predicate))
 
         res = scheduler.start(create=create)
 
@@ -90,17 +96,19 @@ class TestLast(unittest.TestCase):
 
     def test_last_async_predicate_none(self):
         scheduler = TestScheduler()
-        xs = scheduler.create_hot_observable(on_next(150, 1), on_next(210, 2), on_next(220, 3), on_next(230, 4), on_next(240, 5), on_completed(250))
+        xs = scheduler.create_hot_observable(
+                on_next(150, 1), on_next(210, 2), on_next(220, 3),
+                on_next(230, 4), on_next(240, 5), on_completed(250))
 
         def create():
             def predicate(x):
                 return x > 10
-            return xs.last(predicate)
+            return xs.pipe(_.last(predicate))
 
         res = scheduler.start(create=create)
 
         def predicate(e):
-            return not e is None
+            return e is not None
 
         assert [on_error(250, predicate)] == res.messages
         assert xs.subscriptions == [subscribe(200, 250)]
@@ -114,7 +122,7 @@ class TestLast(unittest.TestCase):
             def predicate(x):
                 return x % 2 == 1
 
-            return xs.last(predicate)
+            return xs.pipe(_.last(predicate))
         res = scheduler.start(create=create)
 
         assert res.messages == [on_error(210, ex)]
@@ -123,7 +131,9 @@ class TestLast(unittest.TestCase):
     def test_last_async_predicate_throws(self):
         ex = 'ex'
         scheduler = TestScheduler()
-        xs = scheduler.create_hot_observable(on_next(150, 1), on_next(210, 2), on_next(220, 3), on_next(230, 4), on_next(240, 5), on_completed(250))
+        xs = scheduler.create_hot_observable(
+                on_next(150, 1), on_next(210, 2), on_next(220, 3),
+                on_next(230, 4), on_next(240, 5), on_completed(250))
 
         def create():
             def predicate(x):
@@ -132,10 +142,9 @@ class TestLast(unittest.TestCase):
                 else:
                     raise Exception(ex)
 
-            return xs.last(predicate)
+            return xs.pipe(_.last(predicate))
 
         res = scheduler.start(create=create)
 
         assert res.messages == [on_error(230, ex)]
         assert xs.subscriptions == [subscribe(200, 230)]
-

--- a/tests/test_observable/test_lastordefault.py
+++ b/tests/test_observable/test_lastordefault.py
@@ -1,5 +1,6 @@
 import unittest
 
+from rx import operators as _
 from rx.testing import TestScheduler, ReactiveTest
 
 on_next = ReactiveTest.on_next
@@ -23,10 +24,11 @@ def _raise(ex):
 class TestLastOrDefault(unittest.TestCase):
     def test_last_or_default_async_empty(self):
         scheduler = TestScheduler()
-        xs = scheduler.create_hot_observable(on_next(150, 1), on_completed(250))
+        xs = scheduler.create_hot_observable(
+                on_next(150, 1), on_completed(250))
 
         def create():
-            return xs.last_or_default(None, 0)
+            return xs.pipe(_.last_or_default(None, 0))
 
         res = scheduler.start(create=create)
 
@@ -35,10 +37,11 @@ class TestLastOrDefault(unittest.TestCase):
 
     def test_last_or_default_async(self):
         scheduler = TestScheduler()
-        xs = scheduler.create_hot_observable(on_next(150, 1), on_next(210, 2), on_completed(250))
+        xs = scheduler.create_hot_observable(
+                on_next(150, 1), on_next(210, 2), on_completed(250))
 
         def create():
-            return xs.last_or_default(None, 0)
+            return xs.pipe(_.last_or_default(None, 0))
 
         res = scheduler.start(create=create)
 
@@ -47,10 +50,12 @@ class TestLastOrDefault(unittest.TestCase):
 
     def test_last_or_default_async_many(self):
         scheduler = TestScheduler()
-        xs = scheduler.create_hot_observable(on_next(150, 1), on_next(210, 2), on_next(220, 3), on_completed(250))
+        xs = scheduler.create_hot_observable(
+                on_next(150, 1), on_next(210, 2), on_next(220, 3),
+                on_completed(250))
 
         def create():
-            return xs.last_or_default(None, 0)
+            return xs.pipe(_.last_or_default(None, 0))
 
         res = scheduler.start(create=create)
 
@@ -63,7 +68,7 @@ class TestLastOrDefault(unittest.TestCase):
         xs = scheduler.create_hot_observable(on_next(150, 1), on_error(210, ex))
 
         def create():
-            return xs.last_or_default(None, 0)
+            return xs.pipe(_.last_or_default(None, 0))
 
         res = scheduler.start(create=create)
 
@@ -73,13 +78,15 @@ class TestLastOrDefault(unittest.TestCase):
 
     def test_last_or_default_async_predicate(self):
         scheduler = TestScheduler()
-        xs = scheduler.create_hot_observable(on_next(150, 1), on_next(210, 2), on_next(220, 3), on_next(230, 4), on_next(240, 5), on_completed(250))
+        xs = scheduler.create_hot_observable(
+                on_next(150, 1), on_next(210, 2), on_next(220, 3),
+                on_next(230, 4), on_next(240, 5), on_completed(250))
 
         def create():
             def predicate(x):
                 return x % 2 == 1
 
-            return xs.last_or_default(predicate, 0)
+            return xs.pipe(_.last_or_default(predicate, 0))
 
         res = scheduler.start(create=create)
 
@@ -88,13 +95,15 @@ class TestLastOrDefault(unittest.TestCase):
 
     def test_last_or_default_async_Predicate_none(self):
         scheduler = TestScheduler()
-        xs = scheduler.create_hot_observable(on_next(150, 1), on_next(210, 2), on_next(220, 3), on_next(230, 4), on_next(240, 5), on_completed(250))
+        xs = scheduler.create_hot_observable(
+                on_next(150, 1), on_next(210, 2), on_next(220, 3),
+                on_next(230, 4), on_next(240, 5), on_completed(250))
 
         def create():
             def predicate(x):
                 return x > 10
 
-            return xs.last_or_default(predicate, 0)
+            return xs.pipe(_.last_or_default(predicate, 0))
 
         res = scheduler.start(create=create)
 
@@ -109,7 +118,7 @@ class TestLastOrDefault(unittest.TestCase):
         def create():
             def predicate(x):
                 return x > 10
-            return xs.last_or_default(predicate, 0)
+            return xs.pipe(_.last_or_default(predicate, 0))
 
         res = scheduler.start(create=create)
 
@@ -119,7 +128,9 @@ class TestLastOrDefault(unittest.TestCase):
     def test_last_or_default_async_predicate_throws(self):
         ex = 'ex'
         scheduler = TestScheduler()
-        xs = scheduler.create_hot_observable(on_next(150, 1), on_next(210, 2), on_next(220, 3), on_next(230, 4), on_next(240, 5), on_completed(250))
+        xs = scheduler.create_hot_observable(
+                on_next(150, 1), on_next(210, 2), on_next(220, 3),
+                on_next(230, 4), on_next(240, 5), on_completed(250))
 
         def create():
             def predicate(x):
@@ -128,7 +139,7 @@ class TestLastOrDefault(unittest.TestCase):
                 else:
                     raise Exception(ex)
 
-            return xs.last_or_default(predicate, 0)
+            return xs.pipe(_.last_or_default(predicate, 0))
 
         res = scheduler.start(create=create)
 

--- a/tests/test_observable/test_materialize.py
+++ b/tests/test_observable/test_materialize.py
@@ -1,6 +1,7 @@
 import unittest
 
-from rx.chained import Observable
+import rx
+from rx import operators as _
 from rx.testing import TestScheduler, ReactiveTest
 
 on_next = ReactiveTest.on_next
@@ -18,7 +19,7 @@ class TestMaterialize(unittest.TestCase):
         scheduler = TestScheduler()
 
         def create():
-            return Observable.never().materialize()
+            return rx.never().pipe(_.materialize())
 
         results = scheduler.start(create)
         assert results.messages == []
@@ -28,7 +29,7 @@ class TestMaterialize(unittest.TestCase):
         xs = scheduler.create_hot_observable(on_next(150, 1), on_completed(250))
 
         def create():
-            return xs.materialize()
+            return xs.pipe(_.materialize())
 
         results = scheduler.start(create).messages
         assert(len(results) == 2)
@@ -37,10 +38,11 @@ class TestMaterialize(unittest.TestCase):
 
     def test_materialize_return(self):
         scheduler = TestScheduler()
-        xs = scheduler.create_hot_observable(on_next(150, 1), on_next(210, 2), on_completed(250))
+        xs = scheduler.create_hot_observable(
+                on_next(150, 1), on_next(210, 2), on_completed(250))
 
         def create():
-            return xs.materialize()
+            return xs.pipe(_.materialize())
 
         results = scheduler.start(create).messages
         assert(len(results) == 3)
@@ -55,7 +57,7 @@ class TestMaterialize(unittest.TestCase):
         xs = scheduler.create_hot_observable(on_next(150, 1), on_error(250, ex))
 
         def create():
-            return xs.materialize()
+            return xs.pipe(_.materialize())
 
         results = scheduler.start(create).messages
         assert(len(results) == 2)
@@ -67,7 +69,7 @@ class TestMaterialize(unittest.TestCase):
         scheduler = TestScheduler()
 
         def create():
-            return Observable.never().materialize().dematerialize()
+            return rx.never().pipe(_.materialize(), _.dematerialize())
 
         results = scheduler.start(create)
         assert results.messages == []
@@ -77,7 +79,7 @@ class TestMaterialize(unittest.TestCase):
         xs = scheduler.create_hot_observable(on_next(150, 1), on_completed(250))
 
         def create():
-            return xs.materialize().dematerialize()
+            return xs.pipe(_.materialize(), _.dematerialize())
 
         results = scheduler.start(create).messages
         assert(len(results) == 1)
@@ -85,10 +87,11 @@ class TestMaterialize(unittest.TestCase):
 
     def test_materialize_dematerialize_return(self):
         scheduler = TestScheduler()
-        xs = scheduler.create_hot_observable(on_next(150, 1), on_next(210, 2), on_completed(250))
+        xs = scheduler.create_hot_observable(
+                on_next(150, 1), on_next(210, 2), on_completed(250))
 
         def create():
-            return xs.materialize().dematerialize()
+            return xs.pipe(_.materialize(), _.dematerialize())
 
         results = scheduler.start(create).messages
         assert(len(results) == 2)
@@ -101,7 +104,7 @@ class TestMaterialize(unittest.TestCase):
         xs = scheduler.create_hot_observable(on_next(150, 1), on_error(250, ex))
 
         def create():
-            return xs.materialize().dematerialize()
+            return xs.pipe(_.materialize(), _.dematerialize())
 
         results = scheduler.start(create).messages
         assert(len(results) == 1)


### PR DESCRIPTION
Tests update for operators : 

- all
- average
- distinct_until_changed
- do_action
- flat_map
- last
- materialize

There are still some issues : 
- in all() tests: missing _some()_ operator (not in the test)
- in flat_map() tests: missing _interval()_, I have assumed it will be in the rx.init API instead of rx.operators
- in flat_mapi() tests: the old test provides a second kwarg  'result_mapper_indexed' in test_flat_map_iterable_complete_result_mapper
- in materialize() tests: missing _dematerialize()_ operator  

I have used '_' as an alias to rx.operators (saw this in the catch_exception test), but I've switched to 'ops' to avoid possible conflict. I don't know if a convention is needed ?   