### PR TITLE
fix interval: missing default value (None) for the default scheduler

### DIFF
--- a/rx/__init__.py
+++ b/rx/__init__.py
@@ -253,7 +253,7 @@ def generate(initial_state, condition, iterate, result_mapper) -> Observable:
     return _generate(initial_state, condition, iterate, result_mapper)
 
 
-def interval(period, scheduler: typing.Scheduler) -> Observable:
+def interval(period, scheduler: typing.Scheduler = None) -> Observable:
     """Returns an observable sequence that produces a value after each
     period.
 


### PR DESCRIPTION
To use the default scheduler (timeout scheduler), None should be the default value for the _scheduler_ argument.
