### PR TITLE
Fix combine_latest:  mapper should be provide as a keyword argument

### DIFF
--- a/rx/core/operators/combinelatest.py
+++ b/rx/core/operators/combinelatest.py
@@ -26,5 +26,5 @@ def _combine_latest(other: Union[Observable, Iterable[Observable]],
         else:
             sources += other
 
-        return rx.combine_latest(sources, mapper)
+        return rx.combine_latest(sources, mapper=mapper)
     return combine_latest


### PR DESCRIPTION
When calling rx.combine_latest(*args, mapper), mapper must be a keyword argument because _mapper_ argument is defined after the positionnal arguments *args.