### PR TITLE
remove result_mapper for zip_with_iterable operator

### DIFF
--- a/rx/__init__.py
+++ b/rx/__init__.py
@@ -595,7 +595,7 @@ def with_latest_from(*args: Union[Observable, Iterable[Observable]], mapper: Cal
 
 def zip(*args: Observable) -> Observable:
     """Merges the specified observable sequences into one observable
-    sequence by using a tuple aggregation whenever all of the
+    sequence by creating a tuple whenever all of the
     observable sequences have produced an element at a corresponding
     index.
 
@@ -607,7 +607,7 @@ def zip(*args: Observable) -> Observable:
 
     Returns:
         An observable sequence containing the result of combining
-        elements of the sources as tuple.
+        elements of the sources as a tuple.
     """
     from .core.observable.zip import _zip
     return _zip(*args)

--- a/rx/core/observable/zip.py
+++ b/rx/core/observable/zip.py
@@ -7,7 +7,7 @@ from rx.internal.utils import is_future
 
 def _zip(*args: Observable) -> Observable:
     """Merges the specified observable sequences into one observable
-    sequence by using a tuple aggregation whenever all of the
+    sequence by creating a tuple whenever all of the
     observable sequences have produced an element at a corresponding
     index.
 

--- a/rx/core/operators/zip.py
+++ b/rx/core/operators/zip.py
@@ -26,26 +26,22 @@ def _zip(*args: Observable) -> Callable[[Observable], Observable]:
         return rx.zip(*sources)
     return zip
 
-def _zip_with_iterable(second, result_mapper):
+def _zip_with_iterable(second):
     def zip_with_iterable(source: Observable) -> Observable:
         """Merges the specified observable sequence and list into one
-        observable sequence by using the mapper function whenever all of
+        observable sequence by using a tuple aggregation whenever all of
         the observable sequences have produced an element at a
         corresponding index.
 
-        The result mapper must be a function to invoke for each series of
-        elements at corresponding indexes in the sources.
-
         Example
-            >>> res = zip(xs, [1,2,3], result_mapper=fn)
+            >>> res = zip(xs, [1,2,3])
 
         Args:
             source -- Source observable to zip.
 
         Returns:
             An observable sequence containing the result of
-            combining elements of the sources using the specified result
-        mapper function.
+            combining elements of the sources as tuple.
         """
 
         first = source
@@ -61,7 +57,8 @@ def _zip_with_iterable(second, result_mapper):
                     right = second[index]
                     index += 1
                     try:
-                        result = result_mapper(left, right)
+                        result = (left, right)
+
                     except Exception as ex:
                         observer.on_error(ex)
                         return

--- a/rx/core/operators/zip.py
+++ b/rx/core/operators/zip.py
@@ -56,12 +56,7 @@ def _zip_with_iterable(second):
                 if index < length:
                     right = second[index]
                     index += 1
-                    try:
-                        result = (left, right)
-
-                    except Exception as ex:
-                        observer.on_error(ex)
-                        return
+                    result = (left, right)
                     observer.on_next(result)
                 else:
                     observer.on_completed()

--- a/rx/core/operators/zip.py
+++ b/rx/core/operators/zip.py
@@ -8,7 +8,7 @@ from rx.core.typing import Mapper
 def _zip(*args: Observable) -> Callable[[Observable], Observable]:
     def zip(source: Observable) -> Observable:
         """Merges the specified observable sequences into one observable
-        sequence by using tuple aggregation whenever all of the
+        sequence by creating a tuple whenever all of the
         observable sequences have produced an element at a corresponding
         index.
 
@@ -20,7 +20,7 @@ def _zip(*args: Observable) -> Callable[[Observable], Observable]:
 
         Returns:
             An observable sequence containing the result of combining
-            elements of the sources as tuple.
+            elements of the sources as a tuple.
         """
         sources = [source] + list(args)
         return rx.zip(*sources)
@@ -29,7 +29,7 @@ def _zip(*args: Observable) -> Callable[[Observable], Observable]:
 def _zip_with_iterable(second):
     def zip_with_iterable(source: Observable) -> Observable:
         """Merges the specified observable sequence and list into one
-        observable sequence by using a tuple aggregation whenever all of
+        observable sequence by creating a tuple whenever all of
         the observable sequences have produced an element at a
         corresponding index.
 
@@ -41,7 +41,7 @@ def _zip_with_iterable(second):
 
         Returns:
             An observable sequence containing the result of
-            combining elements of the sources as tuple.
+            combining elements of the sources as a tuple.
         """
 
         first = source

--- a/rx/operators/__init__.py
+++ b/rx/operators/__init__.py
@@ -2563,32 +2563,25 @@ def zip(*args: Observable) -> Callable[[Observable], Observable]:
     return _zip(*args)
 
 
-def zip_with_iterable(second, result_mapper):
+def zip_with_iterable(second):
     """Merges the specified observable sequence and list into one
-    observable sequence by using the mapper function whenever all of
+    observable sequence by using a tupple aggregation whenever all of
     the observable sequences have produced an element at a
     corresponding index.
 
-    The result mapper must be a function to invoke for each series of
-    elements at corresponding indexes in the sources.
-
     Example
-        >>> res = zip(xs, [1,2,3], result_mapper=fn)
+        >>> res = zip(xs, [1,2,3])
 
     Args:
         second: Iterable to zip.
-        result_mapper: Mapper function that produces an element
-            whenever all of the observable sequences have produced an
-            element at a corresponding index
 
     Returns:
         An operator function that takes and observable source and
         returns an observable sequence containing the result of
-        combining elements of the sources using the specified result
-        mapper function.
+        combining elements of the sources as tuple.
     """
     from rx.core.operators.zip import _zip_with_iterable
-    return _zip_with_iterable(second, result_mapper)
+    return _zip_with_iterable(second)
 
 
 zip_with_list = zip_with_iterable

--- a/rx/operators/__init__.py
+++ b/rx/operators/__init__.py
@@ -2544,7 +2544,7 @@ def with_latest_from(*args: Union[Observable, Iterable[Observable]], mapper: Cal
 
 def zip(*args: Observable) -> Callable[[Observable], Observable]:
     """Merges the specified observable sequences into one observable
-    sequence by using a tuple aggregation whenever all of the
+    sequence by creating a tuple whenever all of the
     observable sequences have produced an element at a corresponding
     index.
 
@@ -2557,7 +2557,7 @@ def zip(*args: Observable) -> Callable[[Observable], Observable]:
     Returns:
         An operator function that takes an observable source and
         returns an observable sequence containing the result of
-        combining elements of the sources as tuple.
+        combining elements of the sources as a tuple.
     """
     from rx.core.operators.zip import _zip
     return _zip(*args)
@@ -2565,7 +2565,7 @@ def zip(*args: Observable) -> Callable[[Observable], Observable]:
 
 def zip_with_iterable(second):
     """Merges the specified observable sequence and list into one
-    observable sequence by using a tupple aggregation whenever all of
+    observable sequence by creating a tuple whenever all of
     the observable sequences have produced an element at a
     corresponding index.
 
@@ -2578,7 +2578,7 @@ def zip_with_iterable(second):
     Returns:
         An operator function that takes and observable source and
         returns an observable sequence containing the result of
-        combining elements of the sources as tuple.
+        combining elements of the sources as a tuple.
     """
     from rx.core.operators.zip import _zip_with_iterable
     return _zip_with_iterable(second)

--- a/tests/test_observable/test_zip.py
+++ b/tests/test_observable/test_zip.py
@@ -365,9 +365,10 @@ class TestZip(unittest.TestCase):
         n2 = []
 
         def create():
-            def mapper(x, y):
-                return x + y
-            return n1.pipe(ops.zip_with_iterable(n2, result_mapper=mapper))
+            return n1.pipe(
+                    ops.zip_with_iterable(n2),
+                    ops.map(sum),
+                    )
 
         results = scheduler.start(create)
 
@@ -380,9 +381,10 @@ class TestZip(unittest.TestCase):
         n2 = []
 
         def create():
-            def mapper(x, y):
-                return x + y
-            return n1.pipe(ops.zip_with_iterable(n2, result_mapper=mapper))
+            return n1.pipe(
+                    ops.zip_with_iterable(n2),
+                    ops.map(sum),
+                    )
 
         results = scheduler.start(create)
 
@@ -395,9 +397,10 @@ class TestZip(unittest.TestCase):
         n2 = [2]
 
         def create():
-            def mapper(x, y):
-                return x + y
-            return n1.pipe(ops.zip_with_iterable(n2, result_mapper=mapper))
+            return n1.pipe(
+                    ops.zip_with_iterable(n2),
+                    ops.map(sum),
+                    )
 
         results = scheduler.start(create)
 
@@ -411,9 +414,11 @@ class TestZip(unittest.TestCase):
         n2 = []
 
         def create():
-            def mapper(x, y):
-                return x + y
-            return n1.pipe(ops.zip_with_iterable(n2, result_mapper=mapper))
+            return n1.pipe(
+                    ops.zip_with_iterable(n2),
+                    ops.map(sum),
+                    )
+
         results = scheduler.start(create)
 
         assert results.messages == [on_completed(215)]
@@ -425,9 +430,10 @@ class TestZip(unittest.TestCase):
         n2 = [2]
 
         def create():
-            def mapper(x, y):
-                return x + y
-            return n1.pipe(ops.zip_with_iterable(n2, result_mapper=mapper))
+            return n1.pipe(
+                    ops.zip_with_iterable(n2),
+                    ops.map(sum),
+                    )
 
         results = scheduler.start(create)
 
@@ -441,9 +447,11 @@ class TestZip(unittest.TestCase):
         n2 = [3]
 
         def create():
-            def mapper(x, y):
-                return x + y
-            return n1.pipe(ops.zip_with_iterable(n2, result_mapper=mapper))
+            return n1.pipe(
+                    ops.zip_with_iterable(n2),
+                    ops.map(sum),
+                    )
+
         results = scheduler.start(create)
 
         assert results.messages == [on_next(215, 2 + 3), on_completed(230)]
@@ -456,9 +464,11 @@ class TestZip(unittest.TestCase):
         n2 = []
 
         def create():
-            def mapper(x, y):
-                return x + y
-            return n1.pipe(ops.zip_with_iterable(n2, result_mapper=mapper))
+            return n1.pipe(
+                    ops.zip_with_iterable(n2),
+                    ops.map(sum),
+                    )
+
         results = scheduler.start(create)
 
         assert results.messages == [on_error(220, ex)]
@@ -471,9 +481,11 @@ class TestZip(unittest.TestCase):
         n2 = [2]
 
         def create():
-            def mapper(x, y):
-                return x + y
-            return n1.pipe(ops.zip_with_iterable(n2, result_mapper=mapper))
+            return n1.pipe(
+                    ops.zip_with_iterable(n2),
+                    ops.map(sum),
+                    )
+
         results = scheduler.start(create)
 
         assert results.messages == [on_error(220, ex)]
@@ -487,30 +499,13 @@ class TestZip(unittest.TestCase):
         n2 = [5, 4, 3, 2]
 
         def create():
-            def mapper(x, y):
-                return x + y
-            return n1.pipe(ops.zip_with_iterable(n2, result_mapper=mapper))
+            return n1.pipe(
+                    ops.zip_with_iterable(n2),
+                    ops.map(sum),
+                    )
+
         results = scheduler.start(create)
 
         assert results.messages == [on_next(210, 7), on_next(220, 7),
                                     on_next(230, 7), on_next(240, 7)]
         assert n1.subscriptions == [subscribe(200, 1000)]
-
-    def test_zip_with_iterable_mapperthrows(self):
-        ex = 'ex'
-        scheduler = TestScheduler()
-        n1 = scheduler.create_hot_observable(
-                on_next(150, 1), on_next(215, 2), on_next(225, 4),
-                on_completed(240))
-        n2 = [3, 5]
-
-        def create():
-            def mapper(x, y):
-                if y == 5:
-                    raise Exception(ex)
-                return x + y
-            return n1.pipe(ops.zip_with_iterable(n2, result_mapper=mapper))
-        results = scheduler.start(create)
-
-        assert results.messages == [on_next(215, 2 + 3), on_error(225, ex)]
-        assert n1.subscriptions == [subscribe(200, 225)]

--- a/tests/test_observable/test_zip.py
+++ b/tests/test_observable/test_zip.py
@@ -48,9 +48,9 @@ class TestZip(unittest.TestCase):
 
         def create():
             return e1.pipe(
-                    ops.zip(e2),
-                    ops.map(sum),
-                    )
+                ops.zip(e2),
+                ops.map(sum),
+                )
 
         results = scheduler.start(create)
         assert results.messages == [on_completed(210)]
@@ -64,9 +64,9 @@ class TestZip(unittest.TestCase):
 
         def create():
             return e1.pipe(
-                    ops.zip(e2),
-                    ops.map(sum),
-                    )
+                ops.zip(e2),
+                ops.map(sum),
+                )
 
         results = scheduler.start(create)
         assert results.messages == [on_completed(215)]
@@ -80,9 +80,9 @@ class TestZip(unittest.TestCase):
 
         def create():
             return e2.pipe(
-                    ops.zip(e1),
-                    ops.map(sum),
-                    )
+                ops.zip(e1),
+                ops.map(sum),
+                )
 
         results = scheduler.start(create)
         assert results.messages == [on_completed(215)]
@@ -95,9 +95,9 @@ class TestZip(unittest.TestCase):
 
         def create():
             return e2.pipe(
-                    ops.zip(e1),
-                    ops.map(sum),
-                    )
+                ops.zip(e1),
+                ops.map(sum),
+                )
 
         results = scheduler.start(create)
         assert results.messages == []
@@ -110,9 +110,9 @@ class TestZip(unittest.TestCase):
 
         def create():
             return e1.pipe(
-                    ops.zip(e2),
-                    ops.map(sum),
-                    )
+                ops.zip(e2),
+                ops.map(sum),
+                )
 
         results = scheduler.start(create)
         assert results.messages == []
@@ -126,9 +126,9 @@ class TestZip(unittest.TestCase):
 
         def create():
             return e1.pipe(
-                    ops.zip(e2),
-                    ops.map(sum),
-                    )
+                ops.zip(e2),
+                ops.map(sum),
+                )
 
         results = scheduler.start(create)
         assert results.messages == [on_next(220, 2 + 3), on_completed(240)]
@@ -143,9 +143,9 @@ class TestZip(unittest.TestCase):
 
         def create():
             return e1.pipe(
-                    ops.zip(e2),
-                    ops.map(sum),
-                    )
+                ops.zip(e2),
+                ops.map(sum),
+                )
 
         results = scheduler.start(create)
         assert results.messages == [on_error(220, ex)]
@@ -160,9 +160,9 @@ class TestZip(unittest.TestCase):
 
         def create():
             return e2.pipe(
-                    ops.zip(e1),
-                    ops.map(sum),
-                    )
+                ops.zip(e1),
+                ops.map(sum),
+                )
 
         results = scheduler.start(create)
         assert results.messages == [on_error(220, ex)]
@@ -176,9 +176,9 @@ class TestZip(unittest.TestCase):
 
         def create():
             return e1.pipe(
-                    ops.zip(e2),
-                    ops.map(sum),
-                    )
+                ops.zip(e2),
+                ops.map(sum),
+                )
 
         results = scheduler.start(create)
         assert results.messages == [on_error(220, ex)]
@@ -192,9 +192,9 @@ class TestZip(unittest.TestCase):
 
         def create():
             return e2.pipe(
-                    ops.zip(e1),
-                    ops.map(sum),
-                    )
+                ops.zip(e1),
+                ops.map(sum),
+                )
 
         results = scheduler.start(create)
         assert results.messages == [on_error(220, ex)]
@@ -210,9 +210,9 @@ class TestZip(unittest.TestCase):
 
         def create():
             return e2.pipe(
-                    ops.zip(e1),
-                    ops.map(sum),
-                    )
+                ops.zip(e1),
+                ops.map(sum),
+                )
 
         results = scheduler.start(create)
         assert results.messages == [on_error(220, ex2)]
@@ -226,9 +226,10 @@ class TestZip(unittest.TestCase):
         e2 = scheduler.create_hot_observable(msgs2)
 
         def create():
-            return e1.pipe(ops.zip(e2),
-                           ops.map(sum),
-                           )
+            return e1.pipe(
+                ops.zip(e2),
+                ops.map(sum),
+                )
 
         results = scheduler.start(create)
         assert results.messages == [on_error(220, ex)]
@@ -243,9 +244,9 @@ class TestZip(unittest.TestCase):
 
         def create():
             return e2.pipe(
-                    ops.zip(e1),
-                    ops.map(sum),
-                    )
+                ops.zip(e1),
+                ops.map(sum),
+                )
 
         results = scheduler.start(create)
         assert results.messages == [on_error(220, ex)]
@@ -273,9 +274,9 @@ class TestZip(unittest.TestCase):
 
         def create():
             return e1.pipe(
-                    ops.zip(e2),
-                    ops.map(sum),
-                    )
+                ops.zip(e2),
+                ops.map(sum),
+                )
 
         results = scheduler.start(create).messages
         assert(length == len(results))
@@ -310,9 +311,9 @@ class TestZip(unittest.TestCase):
 
         def create():
             return e1.pipe(
-                    ops.zip(e2),
-                    ops.map(sum),
-                    )
+                ops.zip(e2),
+                ops.map(sum),
+                )
 
         results = scheduler.start(create).messages
         assert(length == len(results))
@@ -346,9 +347,9 @@ class TestZip(unittest.TestCase):
 
         def create():
             return e1.pipe(
-                    ops.zip(e2),
-                    ops.map(sum),
-                    )
+                ops.zip(e2),
+                ops.map(sum),
+                )
 
         results = scheduler.start(create).messages
         assert(length == len(results))
@@ -366,9 +367,9 @@ class TestZip(unittest.TestCase):
 
         def create():
             return n1.pipe(
-                    ops.zip_with_iterable(n2),
-                    ops.map(sum),
-                    )
+                ops.zip_with_iterable(n2),
+                ops.map(sum),
+                )
 
         results = scheduler.start(create)
 
@@ -382,9 +383,9 @@ class TestZip(unittest.TestCase):
 
         def create():
             return n1.pipe(
-                    ops.zip_with_iterable(n2),
-                    ops.map(sum),
-                    )
+                ops.zip_with_iterable(n2),
+                ops.map(sum),
+                )
 
         results = scheduler.start(create)
 
@@ -398,9 +399,9 @@ class TestZip(unittest.TestCase):
 
         def create():
             return n1.pipe(
-                    ops.zip_with_iterable(n2),
-                    ops.map(sum),
-                    )
+                ops.zip_with_iterable(n2),
+                ops.map(sum),
+                )
 
         results = scheduler.start(create)
 
@@ -415,9 +416,9 @@ class TestZip(unittest.TestCase):
 
         def create():
             return n1.pipe(
-                    ops.zip_with_iterable(n2),
-                    ops.map(sum),
-                    )
+                ops.zip_with_iterable(n2),
+                ops.map(sum),
+                )
 
         results = scheduler.start(create)
 
@@ -431,9 +432,9 @@ class TestZip(unittest.TestCase):
 
         def create():
             return n1.pipe(
-                    ops.zip_with_iterable(n2),
-                    ops.map(sum),
-                    )
+                ops.zip_with_iterable(n2),
+                ops.map(sum),
+                )
 
         results = scheduler.start(create)
 
@@ -448,9 +449,9 @@ class TestZip(unittest.TestCase):
 
         def create():
             return n1.pipe(
-                    ops.zip_with_iterable(n2),
-                    ops.map(sum),
-                    )
+                ops.zip_with_iterable(n2),
+                ops.map(sum),
+                )
 
         results = scheduler.start(create)
 
@@ -465,9 +466,9 @@ class TestZip(unittest.TestCase):
 
         def create():
             return n1.pipe(
-                    ops.zip_with_iterable(n2),
-                    ops.map(sum),
-                    )
+                ops.zip_with_iterable(n2),
+                ops.map(sum),
+                )
 
         results = scheduler.start(create)
 
@@ -482,9 +483,9 @@ class TestZip(unittest.TestCase):
 
         def create():
             return n1.pipe(
-                    ops.zip_with_iterable(n2),
-                    ops.map(sum),
-                    )
+                ops.zip_with_iterable(n2),
+                ops.map(sum),
+                )
 
         results = scheduler.start(create)
 
@@ -500,9 +501,9 @@ class TestZip(unittest.TestCase):
 
         def create():
             return n1.pipe(
-                    ops.zip_with_iterable(n2),
-                    ops.map(sum),
-                    )
+                ops.zip_with_iterable(n2),
+                ops.map(sum),
+                )
 
         results = scheduler.start(create)
 


### PR DESCRIPTION
Remove result_mapper argument for zip operator. 

The resulting elements are now zipped in tuple.