### PR TITLE
Remove result_mapper for join and group_join operators

### DIFF
--- a/rx/core/operators/groupjoin.py
+++ b/rx/core/operators/groupjoin.py
@@ -11,7 +11,7 @@ from rx.subjects import Subject
 log = logging.getLogger("Rx")
 
 
-def _group_join(right, left_duration_mapper, right_duration_mapper, result_mapper
+def _group_join(right, left_duration_mapper, right_duration_mapper
                ) -> Callable[[Observable], Observable]:
     """Correlates the elements of two sequences based on overlapping
     durations, and groups the results.
@@ -24,15 +24,9 @@ def _group_join(right, left_duration_mapper, right_duration_mapper, result_mappe
         right_duration_mapper: A function to select the duration (expressed
             as an observable sequence) of each element of the right observable
             sequence, used to determine overlap.
-        result_mapper: A function invoked to compute a result element for
-            any element of the left sequence with overlapping elements from the
-            right observable sequence. The first parameter passed to the
-            function is an element of the left sequence. The second parameter
-            passed to the function is an observable sequence with elements from
-            the right sequence that overlap with the left sequence's element.
 
     Returns:
-        An observable sequence that contains result elements computed
+        An observable sequence that contains elements combined into a tuple
     from source elements that have an overlapping duration.
     """
 
@@ -57,7 +51,7 @@ def _group_join(right, left_duration_mapper, right_duration_mapper, result_mappe
                     left_map[_id] = subject
 
                 try:
-                    result = result_mapper(value, add_ref(subject, rcd))
+                    result = (value, add_ref(subject, rcd))
                 except Exception as e:
                     log.error("*** Exception: %s" % e)
                     for left_value in left_map.values():

--- a/rx/core/operators/join.py
+++ b/rx/core/operators/join.py
@@ -7,7 +7,7 @@ from rx.internal import noop
 from rx.disposables import SingleAssignmentDisposable, CompositeDisposable
 
 
-def _join(right, left_duration_mapper, right_duration_mapper, result_mapper) -> Callable[[Observable], Observable]:
+def _join(right, left_duration_mapper, right_duration_mapper) -> Callable[[Observable], Observable]:
     def join(source: Observable) -> Observable:
         """Correlates the elements of two sequences based on
         overlapping durations.
@@ -16,8 +16,8 @@ def _join(right, left_duration_mapper, right_duration_mapper, result_mapper) -> 
             source: Source observable.
 
         Return:
-            An observable sequence that contains result elements
-            computed from source elements that have an overlapping
+            An observable sequence that contains elements
+            combined into a tuple from source elements that have an overlapping
             duration.
         """
 
@@ -58,12 +58,7 @@ def _join(right, left_duration_mapper, right_duration_mapper, result_mapper) -> 
                 md.disposable = duration.pipe(take(1)).subscribe_(noop, observer.on_error, lambda: expire(), scheduler)
 
                 for val in right_map.values():
-                    try:
-                        result = result_mapper(value, val)
-                    except Exception as exception:
-                        observer.on_error(exception)
-                        return
-
+                    result = (value, val)
                     observer.on_next(result)
 
             def on_completed_left():
@@ -98,12 +93,7 @@ def _join(right, left_duration_mapper, right_duration_mapper, result_mapper) -> 
                 md.disposable = duration.pipe(take(1)).subscribe_(noop, observer.on_error, lambda: expire(), scheduler)
 
                 for val in left_map.values():
-                    try:
-                        result = result_mapper(val, value)
-                    except Exception as exception:
-                        observer.on_error(exception)
-                        return
-
+                    result = (val, value)
                     observer.on_next(result)
 
             def on_completed_right():
@@ -115,4 +105,3 @@ def _join(right, left_duration_mapper, right_duration_mapper, result_mapper) -> 
             return group
         return AnonymousObservable(subscribe)
     return join
- 

--- a/rx/core/operators/window.py
+++ b/rx/core/operators/window.py
@@ -40,12 +40,19 @@ def _window(window_openings=None, window_closing_mapper=None) -> Callable[[Obser
 
 
 def observable_window_with_openings(self, window_openings, window_closing_mapper):
+
+    def mapper(args):
+        _, window = args
+        return window
+
     return window_openings.pipe(
         ops.group_join(
             self,
             window_closing_mapper,
-            lambda _: empty(), lambda _, window: window))
-
+            lambda _: empty(),
+            ),
+        ops.map(mapper),
+        )
 
 def observable_window_with_boundaries(self, window_boundaries):
     source = self

--- a/rx/operators/__init__.py
+++ b/rx/operators/__init__.py
@@ -894,7 +894,7 @@ def group_by_until(key_mapper, element_mapper, duration_mapper) -> Callable[[Obs
     return _group_by_until(key_mapper, element_mapper, duration_mapper)
 
 
-def group_join(right, left_duration_mapper, right_duration_mapper, result_mapper
+def group_join(right, left_duration_mapper, right_duration_mapper,
                ) -> Callable[[Observable], Observable]:
     """Correlates the elements of two sequences based on overlapping
     durations, and groups the results.
@@ -907,22 +907,16 @@ def group_join(right, left_duration_mapper, right_duration_mapper, result_mapper
         right_duration_mapper: A function to select the duration
             (expressed as an observable sequence) of each element of
             the right observable sequence, used to determine overlap.
-        result_mapper: A function invoked to compute a result element
-            for any element of the left sequence with overlapping
-            elements from the right observable sequence. The first
-            parameter passed to the function is an element of the left
-            sequence. The second parameter passed to the function is an
-            observable sequence with elements from the right sequence
-            that overlap with the left sequence's element.
+
 
     Returns:
         An operator function that takes an observable source and
-        returns an observable sequence that contains result elements
-        computed from source elements that have an overlapping
+        returns an observable sequence that contains elements combined into
+        a tuple from source elements that have an overlapping
         duration.
     """
     from rx.core.operators.groupjoin import _group_join
-    return _group_join(right, left_duration_mapper, right_duration_mapper, result_mapper)
+    return _group_join(right, left_duration_mapper, right_duration_mapper)
 
 
 def ignore_elements() -> Observable:

--- a/rx/operators/__init__.py
+++ b/rx/operators/__init__.py
@@ -950,7 +950,7 @@ def is_empty() -> Callable[[Observable], Observable]:
     return _is_empty()
 
 
-def join(right, left_duration_mapper, right_duration_mapper, result_mapper) -> Callable[[Observable], Observable]:
+def join(right, left_duration_mapper, right_duration_mapper) -> Callable[[Observable], Observable]:
     """Correlates the elements of two sequences based on overlapping
     durations.
 
@@ -962,20 +962,15 @@ def join(right, left_duration_mapper, right_duration_mapper, result_mapper) -> C
         right_duration_mapper: A function to select the duration
             (expressed as an observable sequence) of each element of
             the right observable sequence, used to determine overlap.
-        result_mapper: A function invoked to compute a result element
-            for any two overlapping elements of the left and right
-            observable sequences. The parameters passed to the function
-            correspond with the elements from the left and right source
-            sequences for which overlap occurs.
 
     Return:
         An operator function that takes an observable source and
-        returns an observable sequence that contains result elements
-        computed from source elements that have an overlapping
+        returns an observable sequence that contains elements combined into a
+        tuple from source elements that have an overlapping
         duration.
     """
     from rx.core.operators.join import _join
-    return _join(right, left_duration_mapper, right_duration_mapper, result_mapper)
+    return _join(right, left_duration_mapper, right_duration_mapper)
 
 
 def last(predicate: Predicate = None) -> Callable[[Observable], Observable]:

--- a/tests/test_observable/test_groupjoin.py
+++ b/tests/test_observable/test_groupjoin.py
@@ -81,15 +81,18 @@ class TestGroup_join(unittest.TestCase):
         ysd = []
 
         def create():
+            def mapper(x_yy):
+                x, yy = x_yy
+                return yy.pipe(ops.map(lambda y: '{}{}'.format(x.value, y.value)))
+
             return xs.pipe(
                 ops.group_join(
                     ys,
                     lambda x: new_timer(xsd, x.interval, scheduler),
                     lambda y: new_timer(ysd, y.interval, scheduler),
-                    lambda x, yy: yy.pipe(ops.map(lambda y: str(x.value) + y.value))
-                ), ops.merge_all()
-            )
-
+                    ),
+                ops.flat_map(mapper),
+                )
 
         res = scheduler.start(create=create)
 
@@ -157,13 +160,18 @@ class TestGroup_join(unittest.TestCase):
         ysd = []
 
         def create():
-            return xs.pipe(ops.group_join(
+            def mapper(x_yy):
+                x, yy = x_yy
+                return yy.pipe(ops.map(lambda y: '{}{}'.format(x.value, y.value)))
+
+            return xs.pipe(
+                ops.group_join(
                     ys,
                     lambda x: new_timer(xsd, x.interval, scheduler),
                     lambda y: new_timer(ysd, y.interval, scheduler),
-                    lambda x, yy: yy.pipe(ops.map(lambda y: str(x.value) + y.value))
-                ), ops.merge_all()
-            )
+                    ),
+                ops.flat_map(mapper),
+                )
 
         res = scheduler.start(create=create)
 
@@ -224,14 +232,18 @@ class TestGroup_join(unittest.TestCase):
             on_completed(800))
 
         def create():
+            def mapper(x_yy):
+                x, yy = x_yy
+                return yy.pipe(ops.map(lambda y: '{}{}'.format(x.value, y.value)))
+
             return xs.pipe(
                 ops.group_join(
                     ys,
                     lambda x: rx.timer(x.interval).pipe(ops.filter(lambda _: False)),
                     lambda y: rx.timer(y.interval).pipe(ops.filter(lambda _: False)),
-                    lambda x, yy: yy.pipe(ops.map(lambda y: str(x.value) + y.value))
-                ), ops.merge_all()
-            )
+                    ),
+                ops.flat_map(mapper),
+                )
 
         results = scheduler.start(create=create)
 
@@ -286,15 +298,18 @@ class TestGroup_join(unittest.TestCase):
             on_completed(980))
 
         def create():
+            def mapper(x_yy):
+                x, yy = x_yy
+                return yy.pipe(ops.map(lambda y: '{}{}'.format(x.value, y.value)))
+
             return xs.pipe(
                 ops.group_join(
                     ys,
                     lambda x: rx.timer(x.interval),
                     lambda y: rx.timer(y.interval),
-                    lambda x, yy: yy.pipe(ops.map(lambda y: str(x.value) + y.value))
                     ),
-                ops.merge_all()
-            )
+                ops.flat_map(mapper),
+                )
 
         results = scheduler.start(create=create)
 
@@ -348,15 +363,18 @@ class TestGroup_join(unittest.TestCase):
             on_completed(900))
 
         def create():
+            def mapper(x_yy):
+                x, yy = x_yy
+                return yy.pipe(ops.map(lambda y: '{}{}'.format(x.value, y.value)))
+
             return xs.pipe(
                 ops.group_join(
                     ys,
                     lambda x: rx.timer(x.interval),
                     lambda y: rx.timer(y.interval),
-                    lambda x, yy: yy.pipe(ops.map(lambda y: str(x.value) + y.value))
-                ),
-                ops.merge_all()
-            )
+                    ),
+                ops.flat_map(mapper),
+                )
 
         results = scheduler.start(create=create)
 
@@ -411,15 +429,18 @@ class TestGroup_join(unittest.TestCase):
             on_completed(900))
 
         def create():
+            def mapper(x_yy):
+                x, yy = x_yy
+                return yy.pipe(ops.map(lambda y: '{}{}'.format(x.value, y.value)))
+
             return xs.pipe(
                 ops.group_join(
                     ys,
                     lambda x: rx.timer(x.interval),
                     lambda y: rx.timer(y.interval),
-                    lambda x, yy: yy.pipe(ops.map(lambda y: str(x.value) + y.value))
-                ),
-                ops.merge_all()
-            )
+                    ),
+                ops.flat_map(mapper),
+                )
 
         results = scheduler.start(create=create)
         assert results.messages == [
@@ -462,15 +483,18 @@ class TestGroup_join(unittest.TestCase):
             on_completed(900))
 
         def create():
+            def mapper(x_yy):
+                x, yy = x_yy
+                return yy.pipe(ops.map(lambda y: '{}{}'.format(x.value, y.value)))
+
             return xs.pipe(
                 ops.group_join(
                     ys,
                     lambda x: rx.timer(x.interval).pipe(ops.filter(lambda _: False)),
                     lambda y: rx.timer(y.interval).pipe(ops.filter(lambda _: False)),
-                    lambda x, yy: yy.pipe(ops.map(lambda y: str(x.value) + y.value))
-                ),
-                ops.merge_all()
-            )
+                    ),
+                ops.flat_map(mapper),
+                )
 
         results = scheduler.start(create=create)
         assert results.messages == [on_completed(210)]
@@ -483,15 +507,19 @@ class TestGroup_join(unittest.TestCase):
             on_completed(230))
 
         def create():
+            def mapper(x_yy):
+                x, yy = x_yy
+                return yy.pipe(ops.map(lambda y: '{}{}'.format(x.value, y.value)))
+
             return xs.pipe(
                 ops.group_join(
                     ys,
                     lambda x: rx.timer(x.interval),
                     lambda y: rx.timer(y.interval),
-                    lambda x, yy: yy.pipe(ops.map(lambda y: str(x.value) + y.value))
-                ),
-                ops.merge_all()
-            )
+                    ),
+                ops.flat_map(mapper),
+                )
+
         results = scheduler.start(create=create)
         assert results.messages == [on_next(220, "0hat")]
 
@@ -523,15 +551,18 @@ class TestGroup_join(unittest.TestCase):
             on_completed(800))
 
         def create():
+            def mapper(x_yy):
+                x, yy = x_yy
+                return yy.pipe(ops.map(lambda y: '{}{}'.format(x.value, y.value)))
+
             return xs.pipe(
                 ops.group_join(
                     ys,
                     lambda x: rx.timer(x.interval),
                     lambda y: rx.timer(y.interval),
-                    lambda x, yy: yy.pipe(ops.map(lambda y: str(x.value) + y.value))
-                ),
-                ops.merge_all()
-            )
+                    ),
+                ops.flat_map(mapper),
+                )
 
         results = scheduler.start(create=create, disposed=713)
         assert results.messages == [
@@ -572,15 +603,19 @@ class TestGroup_join(unittest.TestCase):
             on_completed(800))
 
         def create():
+            def mapper(x_yy):
+                x, yy = x_yy
+                return yy.pipe(ops.map(lambda y: '{}{}'.format(x.value, y.value)))
+
             return xs.pipe(
                 ops.group_join(
                     ys,
                     lambda x: rx.timer(x.interval),
                     lambda y: rx.timer(y.interval),
-                    lambda x, yy: yy.pipe(ops.map(lambda y: str(x.value) + y.value))
-                ),
-                ops.merge_all()
-            )
+                    ),
+                ops.flat_map(mapper),
+                )
+
         results = scheduler.start(create=create)
         assert results.messages == [
             on_next(215, "0hat"),
@@ -618,15 +653,19 @@ class TestGroup_join(unittest.TestCase):
             on_error(722, ex))
 
         def create():
+            def mapper(x_yy):
+                x, yy = x_yy
+                return yy.pipe(ops.map(lambda y: '{}{}'.format(x.value, y.value)))
+
             return xs.pipe(
                 ops.group_join(
                     ys,
                     lambda x: rx.timer(x.interval),
                     lambda y: rx.timer(y.interval),
-                    lambda x, yy: yy.pipe(ops.map(lambda y: str(x.value) + y.value))
-                ),
-                ops.merge_all()
-            )
+                    ),
+                ops.flat_map(mapper),
+                )
+
         results = scheduler.start(create=create)
         assert results.messages == [
             on_next(215, "0hat"),
@@ -675,16 +714,20 @@ class TestGroup_join(unittest.TestCase):
             on_completed(800))
 
         def create():
+            def mapper(x_yy):
+                x, yy = x_yy
+                return yy.pipe(ops.map(lambda y: '{}{}'.format(x.value, y.value)))
+
             return xs.pipe(
                 ops.group_join(
                     ys,
                     lambda x: rx.timer(x.interval).pipe(
                         ops.flat_map(rx.throw(ex) if x.value == 6 else rx.empty())),
                     lambda y: rx.timer(y.interval),
-                    lambda x, yy: yy.pipe(ops.map(lambda y: str(x.value) + y.value))
-                ),
-                ops.merge_all()
-            )
+                    ),
+                ops.flat_map(mapper),
+                )
+
         results = scheduler.start(create=create)
         assert results.messages == [
             on_next(215, "0hat"),
@@ -736,18 +779,20 @@ class TestGroup_join(unittest.TestCase):
             on_completed(800))
 
         def create():
+            def mapper(x_yy):
+                x, yy = x_yy
+                return yy.pipe(ops.map(lambda y: '{}{}'.format(x.value, y.value)))
+
             return xs.pipe(
                 ops.group_join(
                     ys,
                     lambda x: rx.timer(x.interval),
                     lambda y: rx.timer(y.interval).pipe(
-                        ops.flat_map(
-                            rx.throw(ex) if y.value == "tin" else rx.empty())
+                        ops.flat_map(rx.throw(ex) if y.value == "tin" else rx.empty())),
                     ),
-                    lambda x, yy: yy.pipe(ops.map(lambda y: str(x.value) + y.value))
-                ),
-                ops.merge_all()
-            )
+                ops.flat_map(mapper),
+                )
+
         results = scheduler.start(create=create)
 
         assert results.messages == [
@@ -803,14 +848,19 @@ class TestGroup_join(unittest.TestCase):
                 else:
                     return rx.empty()
 
+            def mapper(x_yy):
+                x, yy = x_yy
+                return yy.pipe(ops.map(lambda y: '{}{}'.format(x.value, y.value)))
+
             return xs.pipe(
                 ops.group_join(
                     ys,
                     left_duration_mapper,
                     lambda y: rx.timer(y.interval),
-                    lambda x, yy: yy.pipe(ops.map(lambda y: str(x.value) + y.value))
-                ), ops.merge_all()
-            )
+                    ),
+                ops.flat_map(mapper),
+                )
+
         results = scheduler.start(create=create)
         assert results.messages == [on_error(210, ex)]
 
@@ -851,123 +901,22 @@ class TestGroup_join(unittest.TestCase):
                 else:
                     return rx.empty()
 
-            def result_mapper(x, yy):
-                return yy.pipe(ops.map(lambda y: x.value + y.value))
+            def mapper(x_yy):
+                x, yy = x_yy
+                return yy.pipe(ops.map(lambda y: '{}{}'.format(x.value, y.value)))
 
             return xs.pipe(
                 ops.group_join(
                     ys,
                     lambda x: rx.timer(x.interval),
                     right_duration_mapper,
-                    result_mapper
-                ),
-                ops.merge_all()
-            )
+                    ),
+                ops.flat_map(mapper),
+                )
 
         results = scheduler.start(create=create)
 
         assert results.messages == [on_error(215, ex)]
-
-    def test_group_join_op_error_vii(self):
-        ex = 'ex'
-        scheduler = TestScheduler()
-        xs = scheduler.create_hot_observable(
-            on_next(215, TimeInterval(0, TimeSpan.from_ticks(10))),
-            on_next(219, TimeInterval(1, TimeSpan.from_ticks(5))),
-            on_next(240, TimeInterval(2, TimeSpan.from_ticks(10))),
-            on_next(300, TimeInterval(3, TimeSpan.from_ticks(100))),
-            on_next(310, TimeInterval(4, TimeSpan.from_ticks(80))),
-            on_next(500, TimeInterval(5, TimeSpan.from_ticks(90))),
-            on_next(700, TimeInterval(6, TimeSpan.from_ticks(25))),
-            on_next(710, TimeInterval(7, TimeSpan.from_ticks(300))),
-            on_next(720, TimeInterval(8, TimeSpan.from_ticks(100))),
-            on_next(830, TimeInterval(9, TimeSpan.from_ticks(10))),
-            on_completed(900))
-        ys = scheduler.create_hot_observable(
-            on_next(210, TimeInterval("hat", TimeSpan.from_ticks(20))),
-            on_next(217, TimeInterval("bat", TimeSpan.from_ticks(1))),
-            on_next(290, TimeInterval("wag", TimeSpan.from_ticks(200))),
-            on_next(300, TimeInterval("pig", TimeSpan.from_ticks(10))),
-            on_next(305, TimeInterval("cup", TimeSpan.from_ticks(50))),
-            on_next(600, TimeInterval("yak", TimeSpan.from_ticks(90))),
-            on_next(702, TimeInterval("tin", TimeSpan.from_ticks(20))),
-            on_next(712, TimeInterval("man", TimeSpan.from_ticks(10))),
-            on_next(722, TimeInterval("rat", TimeSpan.from_ticks(200))),
-            on_next(732, TimeInterval("wig", TimeSpan.from_ticks(5))),
-            on_completed(800)
-        )
-
-        def result_mapper(x, yy):
-            if x.value >= 0:
-                raise Exception(ex)
-            else:
-                return yy.pipe(ops.map(lambda y: x.value + y.value))
-
-        def create():
-            return xs.pipe(
-                ops.group_join(
-                    ys,
-                    lambda x: rx.timer(x.interval),
-                    lambda y: rx.timer(y.interval),
-                    result_mapper
-                ),
-                ops.merge_all()
-            )
-
-        results = scheduler.start(create=create)
-        assert results.messages == [on_error(215, ex)]
-
-    def test_group_join_op_error_viii(self):
-        ex = 'ex'
-        scheduler = TestScheduler()
-        xs = scheduler.create_hot_observable(
-            on_next(210, TimeInterval(0, TimeSpan.from_ticks(10))),
-            on_next(219, TimeInterval(1, TimeSpan.from_ticks(5))),
-            on_next(240, TimeInterval(2, TimeSpan.from_ticks(10))),
-            on_next(300, TimeInterval(3, TimeSpan.from_ticks(100))),
-            on_next(310, TimeInterval(4, TimeSpan.from_ticks(80))),
-            on_next(500, TimeInterval(5, TimeSpan.from_ticks(90))),
-            on_next(700, TimeInterval(6, TimeSpan.from_ticks(25))),
-            on_next(710, TimeInterval(7, TimeSpan.from_ticks(300))),
-            on_next(720, TimeInterval(8, TimeSpan.from_ticks(100))),
-            on_next(830, TimeInterval(9, TimeSpan.from_ticks(10))),
-            on_completed(900)
-        )
-        ys = scheduler.create_hot_observable(
-            on_next(215, TimeInterval("hat", TimeSpan.from_ticks(20))),
-            on_next(217, TimeInterval("bat", TimeSpan.from_ticks(1))),
-            on_next(290, TimeInterval("wag", TimeSpan.from_ticks(200))),
-            on_next(300, TimeInterval("pig", TimeSpan.from_ticks(10))),
-            on_next(305, TimeInterval("cup", TimeSpan.from_ticks(50))),
-            on_next(600, TimeInterval("yak", TimeSpan.from_ticks(90))),
-            on_next(702, TimeInterval("tin", TimeSpan.from_ticks(20))),
-            on_next(712, TimeInterval("man", TimeSpan.from_ticks(10))),
-            on_next(722, TimeInterval("rat", TimeSpan.from_ticks(200))),
-            on_next(732, TimeInterval("wig", TimeSpan.from_ticks(5))),
-            on_completed(800)
-        )
-
-        def create():
-            def result_mapper(x, yy):
-                if x.value >= 0:
-                    raise Exception(ex)
-                else:
-                    return yy.pipe(ops.map(lambda y: x.value + y.value))
-
-            return xs.pipe(
-                ops.group_join(
-                    ys,
-                    lambda x: rx.timer(x.interval),
-                    lambda y: rx.timer(y.interval),
-                    result_mapper
-                ),
-                ops.merge_all()
-            )
-
-        results = scheduler.start(create=create)
-
-        assert results.messages == [on_error(210, ex)]
-
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_observable/test_join.py
+++ b/tests/test_observable/test_join.py
@@ -68,11 +68,18 @@ class TestJoin(unittest.TestCase):
             on_completed(800))
 
         def create():
-            return xs.pipe(ops.join(ys,
-                        lambda x: rx.timer(x.interval),
-                        lambda y: rx.timer(y.interval),
-                        lambda x, y: "%s%s" % (x.value, y.value)
-            ))
+            def mapper(xy):
+                x, y = xy
+                return "{}{}".format(x.value, y.value)
+
+            return xs.pipe(
+                ops.join(
+                    ys,
+                    lambda x: rx.timer(x.interval),
+                    lambda y: rx.timer(y.interval),
+                    ),
+                ops.map(mapper),
+                )
 
         results = scheduler.start(create=create)
         assert results.messages == [
@@ -126,12 +133,20 @@ class TestJoin(unittest.TestCase):
             on_next(732, TimeInterval("wig", 5)),
             on_completed(990))
 
+
         def create():
-            return xs.pipe(ops.join(ys,
-                        lambda x: rx.timer(x.interval),
-                        lambda y: rx.timer(y.interval),
-                        lambda x, y: "%s%s" % (x.value, y.value)
-            ))
+            def mapper(xy):
+                x, y = xy
+                return "{}{}".format(x.value, y.value)
+
+            return xs.pipe(
+                ops.join(
+                    ys,
+                    lambda x: rx.timer(x.interval),
+                    lambda y: rx.timer(y.interval),
+                    ),
+                ops.map(mapper),
+                )
 
         results = scheduler.start(create=create)
         assert results.messages == [
@@ -158,8 +173,8 @@ class TestJoin(unittest.TestCase):
             on_completed(910)]
 
     def test_join_op_normal_iii(self):
-         scheduler = TestScheduler()
-         xs = scheduler.create_hot_observable(
+        scheduler = TestScheduler()
+        xs = scheduler.create_hot_observable(
              on_next(210, TimeInterval(0, 10)),
              on_next(219, TimeInterval(1, 5)),
              on_next(240, TimeInterval(2, 10)),
@@ -171,7 +186,7 @@ class TestJoin(unittest.TestCase):
              on_next(720, TimeInterval(8, 100)),
              on_next(830, TimeInterval(9, 10)),
              on_completed(900))
-         ys = scheduler.create_hot_observable(
+        ys = scheduler.create_hot_observable(
              on_next(215, TimeInterval("hat", 20)),
              on_next(217, TimeInterval("bat", 1)),
              on_next(290, TimeInterval("wag", 200)),
@@ -184,15 +199,22 @@ class TestJoin(unittest.TestCase):
              on_next(732, TimeInterval("wig", 5)),
              on_completed(800))
 
-         def create():
-             return xs.pipe(ops.join(ys,
-                            lambda x: rx.timer(x.interval).pipe(ops.filter(lambda _: False)),
-                            lambda y: rx.timer(y.interval).pipe(ops.filter(lambda _: False)),
-                            lambda x, y: "%s%s" % (x.value, y.value)
-             ))
+        def create():
+            def mapper(xy):
+                x, y = xy
+                return "{}{}".format(x.value, y.value)
 
-         results = scheduler.start(create=create)
-         assert results.messages == [
+            return xs.pipe(
+                ops.join(
+                    ys,
+                    lambda x: rx.timer(x.interval).pipe(ops.filter(lambda _: False)),
+                    lambda y: rx.timer(y.interval).pipe(ops.filter(lambda _: False)),
+                    ),
+                ops.map(mapper),
+                )
+
+        results = scheduler.start(create=create)
+        assert results.messages == [
              on_next(215, "0hat"),
              on_next(217, "0bat"),
              on_next(219, "1hat"),
@@ -243,11 +265,18 @@ class TestJoin(unittest.TestCase):
             on_completed(980))
 
         def create():
-            return xs.pipe(ops.join(ys,
-                lambda x: rx.timer(x.interval),
-                lambda y: rx.timer(y.interval),
-                lambda x, y: str(x.value) + y.value
-            ))
+            def mapper(xy):
+                x, y = xy
+                return "{}{}".format(x.value, y.value)
+
+            return xs.pipe(
+                ops.join(
+                    ys,
+                    lambda x: rx.timer(x.interval),
+                    lambda y: rx.timer(y.interval),
+                    ),
+                ops.map(mapper),
+                )
 
         results = scheduler.start(create=create)
 
@@ -301,11 +330,18 @@ class TestJoin(unittest.TestCase):
             on_completed(900))
 
         def create():
-            return xs.pipe(ops.join(ys,
-                lambda x: rx.timer(x.interval),
-                lambda y: rx.timer(y.interval),
-                lambda x, y: str(x.value) + y.value
-            ))
+            def mapper(xy):
+                x, y = xy
+                return "{}{}".format(x.value, y.value)
+
+            return xs.pipe(
+                ops.join(
+                    ys,
+                    lambda x: rx.timer(x.interval),
+                    lambda y: rx.timer(y.interval),
+                    ),
+                ops.map(mapper),
+                )
 
         results = scheduler.start(create=create)
 
@@ -334,35 +370,44 @@ class TestJoin(unittest.TestCase):
 
     def test_join_op_normal_vi(self):
         scheduler = TestScheduler()
-        xs = scheduler.create_hot_observable(on_next(210, TimeInterval(0, 10)),
-        on_next(219, TimeInterval(1, 5)),
-        on_next(240, TimeInterval(2, 10)),
-        on_next(300, TimeInterval(3, 100)),
-        on_next(310, TimeInterval(4, 80)),
-        on_next(500, TimeInterval(5, 90)),
-        on_next(700, TimeInterval(6, 25)),
-        on_next(710, TimeInterval(7, 30)),
-        on_next(720, TimeInterval(8, 200)),
-        on_next(830, TimeInterval(9, 10)),
-        on_completed(850))
-        ys = scheduler.create_hot_observable(on_next(215, TimeInterval("hat", 20)),
-        on_next(217, TimeInterval("bat", 1)),
-        on_next(290, TimeInterval("wag", 200)),
-        on_next(300, TimeInterval("pig", 10)),
-        on_next(305, TimeInterval("cup", 50)),
-        on_next(600, TimeInterval("yak", 90)),
-        on_next(702, TimeInterval("tin", 20)),
-        on_next(712, TimeInterval("man", 10)),
-        on_next(722, TimeInterval("rat", 20)),
-        on_next(732, TimeInterval("wig", 5)),
-        on_completed(900))
+        xs = scheduler.create_hot_observable(
+            on_next(210, TimeInterval(0, 10)),
+            on_next(219, TimeInterval(1, 5)),
+            on_next(240, TimeInterval(2, 10)),
+            on_next(300, TimeInterval(3, 100)),
+            on_next(310, TimeInterval(4, 80)),
+            on_next(500, TimeInterval(5, 90)),
+            on_next(700, TimeInterval(6, 25)),
+            on_next(710, TimeInterval(7, 30)),
+            on_next(720, TimeInterval(8, 200)),
+            on_next(830, TimeInterval(9, 10)),
+            on_completed(850))
+        ys = scheduler.create_hot_observable(
+            on_next(215, TimeInterval("hat", 20)),
+            on_next(217, TimeInterval("bat", 1)),
+            on_next(290, TimeInterval("wag", 200)),
+            on_next(300, TimeInterval("pig", 10)),
+            on_next(305, TimeInterval("cup", 50)),
+            on_next(600, TimeInterval("yak", 90)),
+            on_next(702, TimeInterval("tin", 20)),
+            on_next(712, TimeInterval("man", 10)),
+            on_next(722, TimeInterval("rat", 20)),
+            on_next(732, TimeInterval("wig", 5)),
+            on_completed(900))
 
         def create():
-            return xs.pipe(ops.join(ys,
-                lambda x: rx.timer(x.interval),
-                lambda y: rx.timer(y.interval),
-                lambda x, y: str(x.value) + y.value
-            ))
+            def mapper(xy):
+                x, y = xy
+                return "{}{}".format(x.value, y.value)
+
+            return xs.pipe(
+                ops.join(
+                    ys,
+                    lambda x: rx.timer(x.interval),
+                    lambda y: rx.timer(y.interval),
+                    ),
+                ops.map(mapper),
+                )
 
         results = scheduler.start(create=create)
 
@@ -403,7 +448,8 @@ class TestJoin(unittest.TestCase):
             on_next(720, TimeInterval(8, 100)),
             on_next(830, TimeInterval(9, 10)),
             on_completed(900))
-        ys = scheduler.create_hot_observable(on_next(215, TimeInterval("hat", 20)),
+        ys = scheduler.create_hot_observable(
+            on_next(215, TimeInterval("hat", 20)),
             on_next(217, TimeInterval("bat", 1)),
             on_next(290, TimeInterval("wag", 200)),
             on_next(300, TimeInterval("pig", 10)),
@@ -416,11 +462,18 @@ class TestJoin(unittest.TestCase):
             on_completed(800))
 
         def create():
-            return xs.pipe(ops.join(ys,
-                lambda x: rx.timer(x.interval),
-                lambda y: rx.timer(y.interval),
-                lambda x, y: str(x.value) + y.value
-            ))
+            def mapper(xy):
+                x, y = xy
+                return "{}{}".format(x.value, y.value)
+
+            return xs.pipe(
+                ops.join(
+                    ys,
+                    lambda x: rx.timer(x.interval),
+                    lambda y: rx.timer(y.interval),
+                    ),
+                ops.map(mapper),
+                )
 
         results = scheduler.start(create, disposed=713)
         assert results.messages == [
@@ -461,11 +514,18 @@ class TestJoin(unittest.TestCase):
             on_completed(800))
 
         def create():
-            return xs.pipe(ops.join(ys,
-                lambda x: rx.timer(x.interval),
-                lambda y: rx.timer(y.interval),
-                lambda x, y: str(x.value) + y.value
-            ))
+            def mapper(xy):
+                x, y = xy
+                return "{}{}".format(x.value, y.value)
+
+            return xs.pipe(
+                ops.join(
+                    ys,
+                    lambda x: rx.timer(x.interval),
+                    lambda y: rx.timer(y.interval),
+                    ),
+                ops.map(mapper),
+                    )
 
         results = scheduler.start(create=create, disposed=713)
         assert results.messages == [
@@ -504,11 +564,18 @@ class TestJoin(unittest.TestCase):
             on_error(722, ex))
 
         def create():
-            return xs.pipe(ops.join(ys,
-                lambda x: rx.timer(x.interval),
-                lambda y: rx.timer(y.interval),
-                lambda x, y: str(x.value) + y.value
-            ))
+            def mapper(xy):
+                x, y = xy
+                return "{}{}".format(x.value, y.value)
+
+            return xs.pipe(
+                ops.join(
+                    ys,
+                    lambda x: rx.timer(x.interval),
+                    lambda y: rx.timer(y.interval),
+                    ),
+                ops.map(mapper),
+                )
 
         results = scheduler.start(create=create)
 
@@ -545,7 +612,8 @@ class TestJoin(unittest.TestCase):
             on_next(720, TimeInterval(8, 100)),
             on_next(830, TimeInterval(9, 10)),
             on_completed(900))
-        ys = scheduler.create_hot_observable(on_next(215, TimeInterval("hat", 20)),
+        ys = scheduler.create_hot_observable(
+            on_next(215, TimeInterval("hat", 20)),
             on_next(217, TimeInterval("bat", 1)),
             on_next(290, TimeInterval("wag", 200)),
             on_next(300, TimeInterval("pig", 10)),
@@ -558,16 +626,23 @@ class TestJoin(unittest.TestCase):
             on_completed(800))
 
         def create():
-            return xs.pipe(ops.join(ys,
-                lambda x: rx.timer(x.interval).pipe(
-                        ops.flat_map(rx.throw(ex) if x.value == 6 else rx.empty())),
-                lambda y: rx.timer(y.interval),
-                lambda x, y: str(x.value) + y.value
-            ))
+            def mapper(xy):
+                x, y = xy
+                return "{}{}".format(x.value, y.value)
+
+            return xs.pipe(
+                ops.join(
+                    ys,
+                    lambda x: rx.timer(x.interval).pipe(ops.flat_map(rx.throw(ex) if x.value == 6 else rx.empty())),
+                    lambda y: rx.timer(y.interval),
+                    ),
+                ops.map(mapper),
+                )
 
         results = scheduler.start(create=create)
 
-        assert results.messages == [on_next(215, "0hat"),
+        assert results.messages == [
+            on_next(215, "0hat"),
             on_next(217, "0bat"),
             on_next(219, "1hat"),
             on_next(300, "3wag"),
@@ -616,12 +691,18 @@ class TestJoin(unittest.TestCase):
             on_completed(800))
 
         def create():
-            return xs.pipe(ops.join(ys,
-                lambda x: rx.timer(x.interval),
-                lambda y: rx.timer(y.interval).pipe(
-                    ops.flat_map(rx.throw(ex) if y.value == "tin" else rx.empty())),
-                lambda x, y: str(x.value) + y.value
-            ))
+            def mapper(xy):
+                x, y = xy
+                return "{}{}".format(x.value, y.value)
+
+            return xs.pipe(
+                ops.join(
+                    ys,
+                    lambda x: rx.timer(x.interval),
+                    lambda y: rx.timer(y.interval).pipe(ops.flat_map(rx.throw(ex) if y.value == "tin" else rx.empty())),
+                    ),
+                ops.map(mapper),
+                )
 
         results = scheduler.start(create=create)
 
@@ -678,11 +759,18 @@ class TestJoin(unittest.TestCase):
                 else:
                     return rx.empty()
 
-            return xs.pipe(ops.join(ys,
-                left_duration_mapper,
-                lambda y: rx.timer(y.interval),
-                lambda x, y: str(x.value) + y.value
-            ))
+            def mapper(xy):
+                x, y = xy
+                return "{}{}".format(x.value, y.value)
+
+            return xs.pipe(
+                ops.join(
+                    ys,
+                    left_duration_mapper,
+                    lambda y: rx.timer(y.interval),
+                    ),
+                ops.map(mapper),
+                )
 
         results = scheduler.start(create=create)
 
@@ -723,100 +811,18 @@ class TestJoin(unittest.TestCase):
                 else:
                     return rx.empty()
 
-            return xs.pipe(ops.join(ys,
-                lambda x: rx.timer(x.interval),
-                right_duration_mapper,
-                lambda x, y: str(x.value) + y.value
-            ))
+            def mapper(xy):
+                x, y = xy
+                return "{}{}".format(x.value, y.value)
 
-        results = scheduler.start(create=create)
-
-        assert results.messages == [on_error(215, ex)]
-
-    def test_join_op_error_vii(self):
-        ex = 'ex'
-        scheduler = TestScheduler()
-        xs = scheduler.create_hot_observable(
-            on_next(210, TimeInterval(0, 10)),
-            on_next(219, TimeInterval(1, 5)),
-            on_next(240, TimeInterval(2, 10)),
-            on_next(300, TimeInterval(3, 100)),
-            on_next(310, TimeInterval(4, 80)),
-            on_next(500, TimeInterval(5, 90)),
-            on_next(700, TimeInterval(6, 25)),
-            on_next(710, TimeInterval(7, 300)),
-            on_next(720, TimeInterval(8, 100)),
-            on_next(830, TimeInterval(9, 10)),
-            on_completed(900))
-        ys = scheduler.create_hot_observable(
-            on_next(215, TimeInterval("hat", 20)),
-            on_next(217, TimeInterval("bat", 1)),
-            on_next(290, TimeInterval("wag", 200)),
-            on_next(300, TimeInterval("pig", 10)),
-            on_next(305, TimeInterval("cup", 50)),
-            on_next(600, TimeInterval("yak", 90)),
-            on_next(702, TimeInterval("tin", 20)),
-            on_next(712, TimeInterval("man", 10)),
-            on_next(722, TimeInterval("rat", 200)),
-            on_next(732, TimeInterval("wig", 5)),
-            on_completed(800))
-
-        def create():
-            def result_mapper(x, y):
-                if x.value >= 0:
-                    raise Exception(ex)
-                else:
-                    return str(x.value) + y.value
-
-            return xs.pipe(ops.join(ys,
-                lambda x: rx.timer(x.interval),
-                lambda y: rx.timer(y.interval),
-                result_mapper,
-                ))
-
-        results = scheduler.start(create=create)
-        assert results.messages == [on_error(215, ex)]
-
-    def test_join_op_error_viii(self):
-        ex = 'ex'
-        scheduler = TestScheduler()
-        xs = scheduler.create_hot_observable(
-            on_next(210, TimeInterval(0, 10)),
-            on_next(219, TimeInterval(1, 5)),
-            on_next(240, TimeInterval(2, 10)),
-            on_next(300, TimeInterval(3, 100)),
-            on_next(310, TimeInterval(4, 80)),
-            on_next(500, TimeInterval(5, 90)),
-            on_next(700, TimeInterval(6, 25)),
-            on_next(710, TimeInterval(7, 300)),
-            on_next(720, TimeInterval(8, 100)),
-            on_next(830, TimeInterval(9, 10)),
-            on_completed(900))
-        ys = scheduler.create_hot_observable(
-            on_next(215, TimeInterval("hat", 20)),
-            on_next(217, TimeInterval("bat", 1)),
-            on_next(290, TimeInterval("wag", 200)),
-            on_next(300, TimeInterval("pig", 10)),
-            on_next(305, TimeInterval("cup", 50)),
-            on_next(600, TimeInterval("yak", 90)),
-            on_next(702, TimeInterval("tin", 20)),
-            on_next(712, TimeInterval("man", 10)),
-            on_next(722, TimeInterval("rat", 200)),
-            on_next(732, TimeInterval("wig", 5)),
-            on_completed(800))
-
-        def create():
-            def result_mapper(x, y):
-                if x.value >= 0:
-                    raise Exception(ex)
-                else:
-                    return str(x.value) + y.value
-
-            return xs.pipe(ops.join(ys,
-                lambda x: rx.timer(x.interval),
-                lambda y: rx.timer(y.interval),
-                result_mapper,
-                ))
+            return xs.pipe(
+                ops.join(
+                    ys,
+                    lambda x: rx.timer(x.interval),
+                    right_duration_mapper,
+                    ),
+                ops.map(mapper),
+                )
 
         results = scheduler.start(create=create)
 


### PR DESCRIPTION
Removes *result_mapper* argument for `join` & `group_join` operators. As `zip`, elements are zipped in a tuple.

Regarding `group_join`, the try/except is still there because of the call to the function *add_ref*.

Tests relying on an exception raised in *result_mapper* are removed.
