### PR TITLE
remove (result) mapper for combine_latest operator

### DIFF
--- a/rx/__init__.py
+++ b/rx/__init__.py
@@ -67,22 +67,21 @@ def create(subscribe: Callable[[typing.Observer, Optional[typing.Scheduler]], ty
     return _AnonymousObservable(subscribe)
 
 
-def combine_latest(*args: Union[Observable, Iterable[Observable]], mapper: Callable[[Any], Any]) -> Observable:
+def combine_latest(*args: Union[Observable, Iterable[Observable]]) -> Observable:
     """Merges the specified observable sequences into one observable
-    sequence by using the mapper function whenever any of the
+    sequence by creating a tuple whenever any of the
     observable sequences produces an element.
 
     Examples:
-        >>> obs = rx.combine_latest(obs1, obs2, obs3, lambda o1, o2, o3: o1 + o2 + o3)
-        >>> obs = rx.combine_latest([obs1, obs2, obs3], lambda o1, o2, o3: o1 + o2 + o3)
+        >>> obs = rx.combine_latest(obs1, obs2, obs3)
+        >>> obs = rx.combine_latest([obs1, obs2, obs3])
 
     Returns:
         An observable sequence containing the result of combining
-        elements of the sources using the specified result mapper
-        function.
+        elements of the sources into a tuple.
     """
     from .core.observable.combinelatest import _combine_latest
-    return _combine_latest(*args, mapper=mapper)
+    return _combine_latest(*args)
 
 
 def concat(*args: Union[Observable, Iterable[Observable]]) -> Observable:

--- a/rx/core/operators/combinelatest.py
+++ b/rx/core/operators/combinelatest.py
@@ -5,10 +5,10 @@ from rx.core import Observable, typing
 
 
 def _combine_latest(other: Union[Observable, Iterable[Observable]],
-                    mapper: Callable[[Any], Any]) -> Callable[[Observable], Observable]:
+                    ) -> Callable[[Observable], Observable]:
     def combine_latest(source: Observable) -> Observable:
         """Merges the specified observable sequences into one
-        observable sequence by using the mapper function whenever any
+        observable sequence by creating a tuple whenever any
         of the observable sequences produces an element.
 
         Examples:
@@ -16,8 +16,7 @@ def _combine_latest(other: Union[Observable, Iterable[Observable]],
 
         Returns:
             An observable sequence containing the result of combining
-            elements of the sources using the specified result mapper
-            function.
+            elements of the sources into a tuple.
         """
         sources: List[Observable] = [source]
 
@@ -26,5 +25,5 @@ def _combine_latest(other: Union[Observable, Iterable[Observable]],
         else:
             sources += other
 
-        return rx.combine_latest(sources, mapper=mapper)
+        return rx.combine_latest(sources)
     return combine_latest

--- a/rx/operators/__init__.py
+++ b/rx/operators/__init__.py
@@ -199,24 +199,23 @@ def catch_exception(second: Observable = None, handler=None) -> Callable[[Observ
     return _catch_exception(second, handler)
 
 
-def combine_latest(other: Union[Observable, Iterable[Observable]], mapper: Callable[[Any], Any]
+def combine_latest(other: Union[Observable, Iterable[Observable]],
                   ) -> Callable[[Observable], Observable]:
     """Merges the specified observable sequences into one observable
-    sequence by using the mapper function whenever any of the
+    sequence by creating a tuple whenever any of the
     observable sequences produces an element.
 
     Examples:
-        >>> obs = combine_latest(other, lambda o1, o2, o3: o1 + o2 + o3)
-        >>> obs = combine_latest([obs1, obs2, obs3], lambda o1, o2, o3: o1 + o2 + o3)
+        >>> obs = combine_latest(other)
+        >>> obs = combine_latest([obs1, obs2, obs3])
 
     Returns:
         An operator function that takes an observable sources and
         returns an observable sequence containing the result of
-        combining elements of the sources using the specified result
-        mapper function.
+        combining elements of the sources into a tuple.
     """
     from rx.core.operators.combinelatest import _combine_latest
-    return _combine_latest(other, mapper)
+    return _combine_latest(other)
 
 
 def concat(*args: Union[Observable, Iterable[Observable]]) -> Callable[[Observable], Observable]:

--- a/tests/test_observable/test_combinelatest.py
+++ b/tests/test_observable/test_combinelatest.py
@@ -30,7 +30,10 @@ class TestCombineLatest(unittest.TestCase):
         e2 = rx.never()
 
         def create():
-            return e1.pipe(ops.combine_latest(e2, lambda x, y: x + y))
+            return e1.pipe(
+                ops.combine_latest(e2),
+                ops.map(sum),
+                )
 
         results = scheduler.start(create)
         assert results.messages == []
@@ -42,7 +45,10 @@ class TestCombineLatest(unittest.TestCase):
         e2 = scheduler.create_hot_observable(msgs)
 
         def create():
-            return e1.pipe(ops.combine_latest(e2, lambda x, y: x + y))
+            return e1.pipe(
+                ops.combine_latest(e2),
+                ops.map(sum),
+                )
 
         results = scheduler.start(create)
         assert results.messages == []
@@ -54,7 +60,10 @@ class TestCombineLatest(unittest.TestCase):
         e2 = scheduler.create_hot_observable(msgs)
 
         def create():
-            return e2.pipe(ops.combine_latest(e1, lambda x, y: x + y))
+            return e2.pipe(
+                ops.combine_latest(e1),
+                ops.map(sum),
+                )
 
         results = scheduler.start(create)
         assert results.messages == []
@@ -67,7 +76,10 @@ class TestCombineLatest(unittest.TestCase):
         e2 = scheduler.create_hot_observable(msgs2)
 
         def create():
-            return e2.pipe(ops.combine_latest(e1, lambda x, y: x + y))
+            return e2.pipe(
+                ops.combine_latest(e1),
+                ops.map(sum),
+                )
 
         results = scheduler.start(create)
         assert results.messages == [on_completed(210)]
@@ -80,7 +92,10 @@ class TestCombineLatest(unittest.TestCase):
         e2 = scheduler.create_hot_observable(msgs2)
 
         def create():
-            return e1.pipe(ops.combine_latest(e2, lambda x, y: x + y))
+            return e1.pipe(
+                ops.combine_latest(e2),
+                ops.map(sum),
+                )
 
         results = scheduler.start(create)
         assert results.messages == [on_completed(215)]
@@ -93,7 +108,10 @@ class TestCombineLatest(unittest.TestCase):
         e2 = scheduler.create_hot_observable(msgs2)
 
         def create():
-            return e2.pipe(ops.combine_latest(e1, lambda x, y: x + y))
+            return e2.pipe(
+                ops.combine_latest(e1),
+                ops.map(sum),
+                )
 
         results = scheduler.start(create)
         assert results.messages == [on_completed(215)]
@@ -105,7 +123,10 @@ class TestCombineLatest(unittest.TestCase):
         e2 = rx.never()
 
         def create():
-            return e1.pipe(ops.combine_latest(e2, lambda x, y: x + y))
+            return e1.pipe(
+                ops.combine_latest(e2),
+                ops.map(sum),
+                )
 
         results = scheduler.start(create)
         assert results.messages == []
@@ -117,7 +138,10 @@ class TestCombineLatest(unittest.TestCase):
         e2 = rx.never()
 
         def create():
-            return e2.pipe(ops.combine_latest(e1, lambda x, y: x + y))
+            return e2.pipe(
+                ops.combine_latest(e1),
+                ops.map(sum),
+                )
 
         results = scheduler.start(create)
         assert results.messages == []
@@ -130,7 +154,10 @@ class TestCombineLatest(unittest.TestCase):
         e2 = scheduler.create_hot_observable(msgs2)
 
         def create():
-            return e1.pipe(ops.combine_latest(e2, lambda x, y: x + y))
+            return e1.pipe(
+                ops.combine_latest(e2),
+                ops.map(sum),
+                )
 
         results = scheduler.start(create)
         assert results.messages == [on_next(220, 2 + 3), on_completed(240)]
@@ -144,7 +171,10 @@ class TestCombineLatest(unittest.TestCase):
         e2 = scheduler.create_hot_observable(msgs2)
 
         def create():
-            return e1.pipe(ops.combine_latest(e2, lambda x, y: x + y))
+            return e1.pipe(
+                ops.combine_latest(e2),
+                ops.map(sum),
+                )
 
         results = scheduler.start(create)
         assert results.messages == [on_error(220, ex)]
@@ -158,7 +188,10 @@ class TestCombineLatest(unittest.TestCase):
         e2 = scheduler.create_hot_observable(msgs2)
 
         def create():
-            return e2.pipe(ops.combine_latest(e1, lambda x, y: x + y))
+            return e2.pipe(
+                ops.combine_latest(e1),
+                ops.map(sum),
+                )
 
         results = scheduler.start(create)
         assert results.messages == [on_error(220, ex)]
@@ -172,7 +205,10 @@ class TestCombineLatest(unittest.TestCase):
         e2 = scheduler.create_hot_observable(msgs2)
 
         def create():
-            return e1.pipe(ops.combine_latest(e2, lambda x, y: x + y))
+            return e1.pipe(
+                ops.combine_latest(e2),
+                ops.map(sum),
+                )
 
         results = scheduler.start(create)
         assert results.messages == [on_error(220, ex)]
@@ -186,7 +222,10 @@ class TestCombineLatest(unittest.TestCase):
         e2 = scheduler.create_hot_observable(msgs2)
 
         def create():
-            return e2.pipe(ops.combine_latest(e1, lambda x, y: x + y))
+            return e2.pipe(
+                ops.combine_latest(e1),
+                ops.map(sum),
+                )
 
         results = scheduler.start(create)
         assert results.messages == [on_error(220, ex)]
@@ -201,7 +240,10 @@ class TestCombineLatest(unittest.TestCase):
         e2 = scheduler.create_hot_observable(msgs2)
 
         def create():
-            return e1.pipe(ops.combine_latest(e2, lambda x, y: x + y))
+            return e1.pipe(
+                ops.combine_latest(e2),
+                ops.map(sum),
+                )
 
         results = scheduler.start(create)
         assert results.messages == [on_error(220, ex1)]
@@ -216,7 +258,10 @@ class TestCombineLatest(unittest.TestCase):
         e2 = scheduler.create_hot_observable(msgs2)
 
         def create():
-            return e1.pipe(ops.combine_latest(e2, lambda x, y: x + y))
+            return e1.pipe(
+                ops.combine_latest(e2),
+                ops.map(sum),
+                )
 
         results = scheduler.start(create)
         assert results.messages == [on_error(220, ex1)]
@@ -231,7 +276,10 @@ class TestCombineLatest(unittest.TestCase):
         e2 = scheduler.create_hot_observable(msgs2)
 
         def create():
-            return e2.pipe(ops.combine_latest(e1, lambda x, y: x + y))
+            return e2.pipe(
+                ops.combine_latest(e1),
+                ops.map(sum),
+                )
 
         results = scheduler.start(create)
         assert results.messages == [on_error(220, ex1)]
@@ -244,7 +292,10 @@ class TestCombineLatest(unittest.TestCase):
         e2 = scheduler.create_hot_observable(msgs)
 
         def create():
-            return e1.pipe(ops.combine_latest(e2, lambda x, y: x + y))
+            return e1.pipe(
+                ops.combine_latest(e2),
+                ops.map(sum),
+                )
 
         results = scheduler.start(create)
         assert results.messages == [on_error(220, ex)]
@@ -257,7 +308,10 @@ class TestCombineLatest(unittest.TestCase):
         e2 = scheduler.create_hot_observable(msgs)
 
         def create():
-            return e2.pipe(ops.combine_latest(e1, lambda x, y: x + y))
+            return e2.pipe(
+                ops.combine_latest(e1),
+                ops.map(sum),
+                )
 
         results = scheduler.start(create)
         assert results.messages == [on_error(220, ex)]
@@ -271,7 +325,10 @@ class TestCombineLatest(unittest.TestCase):
         e2 = scheduler.create_hot_observable(msgs2)
 
         def create():
-            return e1.pipe(ops.combine_latest(e2, lambda x, y: x + y))
+            return e1.pipe(
+                ops.combine_latest(e2),
+                ops.map(sum),
+                )
 
         results = scheduler.start(create)
         assert results.messages == [on_error(220, ex)]
@@ -285,7 +342,10 @@ class TestCombineLatest(unittest.TestCase):
         e2 = scheduler.create_hot_observable(msgs2)
 
         def create():
-            return e2.pipe(ops.combine_latest(e1, lambda x, y: x + y))
+            return e2.pipe(
+                ops.combine_latest(e1),
+                ops.map(sum),
+                )
 
         results = scheduler.start(create)
         assert results.messages == [on_error(220, ex)]
@@ -299,7 +359,10 @@ class TestCombineLatest(unittest.TestCase):
         e2 = scheduler.create_hot_observable(msgs2)
 
         def create():
-            return e1.pipe(ops.combine_latest(e2, lambda x, y: x + y))
+            return e1.pipe(
+                ops.combine_latest(e2),
+                ops.map(sum),
+                )
 
         results = scheduler.start(create)
         assert results.messages == [on_error(230, ex)]
@@ -313,7 +376,10 @@ class TestCombineLatest(unittest.TestCase):
         e2 = scheduler.create_hot_observable(msgs2)
 
         def create():
-            return e2.pipe(ops.combine_latest(e1, lambda x, y: x + y))
+            return e2.pipe(
+                ops.combine_latest(e1),
+                ops.map(sum),
+                )
 
         results = scheduler.start(create)
         assert results.messages == [on_error(230, ex)]
@@ -327,7 +393,10 @@ class TestCombineLatest(unittest.TestCase):
         e2 = scheduler.create_hot_observable(msgs2)
 
         def create():
-            return e1.pipe(ops.combine_latest(e2, lambda x, y: x + y))
+            return e1.pipe(
+                ops.combine_latest(e2),
+                ops.map(sum),
+                )
 
         results = scheduler.start(create)
         assert results.messages == [
@@ -342,7 +411,10 @@ class TestCombineLatest(unittest.TestCase):
         e2 = scheduler.create_hot_observable(msgs2)
 
         def create():
-            return e1.pipe(ops.combine_latest(e2, lambda x, y: x + y))
+            return e1.pipe(
+                ops.combine_latest(e2),
+                ops.map(sum),
+                )
 
         results = scheduler.start(create)
         assert results.messages == [on_next(235, 4 + 6), on_next(240, 4 + 7), on_completed(250)]
@@ -356,7 +428,10 @@ class TestCombineLatest(unittest.TestCase):
         e2 = scheduler.create_hot_observable(msgs2)
 
         def create():
-            return e1.pipe(ops.combine_latest(e2, lambda x, y: x + y))
+            return e1.pipe(
+                ops.combine_latest(e2),
+                ops.map(sum),
+                )
 
         results = scheduler.start(create)
         assert results.messages == [on_error(230, ex)]
@@ -370,7 +445,10 @@ class TestCombineLatest(unittest.TestCase):
         e2 = scheduler.create_hot_observable(msgs2)
 
         def create():
-            return e2.pipe(ops.combine_latest(e1, lambda x, y: x + y))
+            return e2.pipe(
+                ops.combine_latest(e1),
+                ops.map(sum),
+                )
 
         results = scheduler.start(create)
         assert results.messages == [on_next(235, 4 + 6), on_next(240, 4 + 7), on_error(245, ex)]
@@ -384,7 +462,10 @@ class TestCombineLatest(unittest.TestCase):
         e2 = scheduler.create_hot_observable(msgs2)
 
         def create():
-            return e1.pipe(ops.combine_latest(e2, lambda x, y: _raise(ex)))
+            return e1.pipe(
+                ops.combine_latest(e2),
+                ops.map(lambda xy: _raise(ex)),
+                )
 
         results = scheduler.start(create)
         assert results.messages == [on_error(220, ex)]


### PR DESCRIPTION
Remove *mapper* argument for `combine_latest` operator. Elements are now zipped in a tuple.
