### PR TITLE
fix default mapper for map and map_indexed

### DIFF
--- a/rx/core/operators/map.py
+++ b/rx/core/operators/map.py
@@ -21,10 +21,15 @@ def _map(mapper: Mapper = None) -> Callable[[Observable], Observable]:
             result of invoking the transform function on each element
             of the source.
         """
+
+        def identity(value): return value
+
+        mapper_ = mapper or identity
+
         def subscribe(obv: Observer, scheduler: Scheduler) -> Disposable:
             def on_next(value: Any) -> None:
                 try:
-                    result = mapper(value)
+                    result = mapper_(value)
                 except Exception as err:  # pylint: disable=broad-except
                     obv.on_error(err)
                 else:
@@ -54,6 +59,10 @@ def _map_indexed(mapper_indexed: MapperIndexed = None) -> Callable[[Observable],
             of the source.
         """
 
+        def identity(value, index): return value
+
+        mapper_indexed_ = mapper_indexed or identity
+
         def subscribe(obv: Observer, scheduler: Scheduler) -> Disposable:
             count = 0
 
@@ -61,7 +70,7 @@ def _map_indexed(mapper_indexed: MapperIndexed = None) -> Callable[[Observable],
                 nonlocal count
 
                 try:
-                    result = mapper_indexed(value, count)
+                    result = mapper_indexed_(value, count)
                 except Exception as err:  # pylint: disable=broad-except
                     obv.on_error(err)
                 else:

--- a/tests/test_observable/test_map.py
+++ b/tests/test_observable/test_map.py
@@ -108,6 +108,31 @@ class TestSelect(unittest.TestCase):
         assert xs.subscriptions == [ReactiveTest.subscribe(200, 400)]
         assert invoked[0] == 4
 
+    def test_map_default_mapper(self):
+        scheduler = TestScheduler()
+        xs = scheduler.create_hot_observable(
+            on_next(180, 1),
+            on_next(210, 2),
+            on_next(240, 3),
+            on_next(290, 4),
+            on_next(350, 5),
+            on_completed(400),
+            on_next(410, -1),
+            on_completed(420),
+            on_error(430, 'ex'))
+
+        def factory():
+            return xs.pipe(map())
+
+        results = scheduler.start(factory)
+        assert results.messages == [
+            on_next(210, 2),
+            on_next(240, 3),
+            on_next(290, 4),
+            on_next(350, 5),
+            on_completed(400)]
+        assert xs.subscriptions == [ReactiveTest.subscribe(200, 400)]
+
     def test_map_completed_two(self):
         for i in range(100):
             scheduler = TestScheduler()
@@ -260,6 +285,32 @@ class TestSelect(unittest.TestCase):
             240, 14), on_next(290, 23), on_next(350, 32), on_completed(400)]
         assert xs.subscriptions == [subscribe(200, 400)]
         assert invoked[0] == 4
+
+    def test_map_with_index_default_mapper(self):
+        scheduler = TestScheduler()
+        xs = scheduler.create_hot_observable(
+            on_next(180, 5),
+            on_next(210, 4),
+            on_next(240, 3),
+            on_next(290, 2),
+            on_next(350, 1),
+            on_completed(400),
+            on_next(410, -1),
+            on_completed(420),
+            on_error(430, 'ex'))
+
+        def factory():
+            return xs.pipe(map_indexed())
+
+        results = scheduler.start(factory)
+        assert results.messages == [
+            on_next(210, 4),
+            on_next(240, 3),
+            on_next(290, 2),
+            on_next(350, 1),
+            on_completed(400)]
+
+        assert xs.subscriptions == [subscribe(200, 400)]
 
     def test_map_with_index_not_completed(self):
         scheduler = TestScheduler()


### PR DESCRIPTION
`map` and `map_indexed` crash when mapper is None. The proposal:

- For `map`, the default *mapper* just returns the value.
- For `map`, the default *mapper* just returns the value and drops the index.

Two tests case are added.
 