### PR TITLE
remove Iterable argument for merge

### DIFF
--- a/rx/__init__.py
+++ b/rx/__init__.py
@@ -322,19 +322,19 @@ def interval(period, scheduler: typing.Scheduler = None) -> Observable:
     return _interval(period, scheduler)
 
 
-def merge(*args: Observable) -> Observable:
+def merge(*sources: Observable) -> Observable:
     """Merges all the observable sequences into a single observable
     sequence.
 
-    1 - merged = rx.merge(xs, ys, zs)
-    2 - merged = rx.merge([xs, ys, zs])
+    Example:
+        >>> res = rx.merge(obs1, obs2, obs3)
 
     Returns:
         The observable sequence that merges the elements of the
         observable sequences.
     """
     from .core.observable.merge import _merge
-    return _merge(*args)
+    return _merge(*sources)
 
 
 def never() -> Observable:

--- a/rx/core/observable/merge.py
+++ b/rx/core/observable/merge.py
@@ -1,15 +1,8 @@
-from typing import Iterable, Union
 
 import rx
 from rx import operators as ops
 from rx.core import Observable
 
 
-
-def _merge(*args: Union[Observable, Iterable[Observable]]) -> Observable:
-    sources = args[:]
-
-    if isinstance(sources[0], Iterable):
-        sources = sources[0]
-
+def _merge(*sources: Observable) -> Observable:
     return rx.from_iterable(sources).pipe(ops.merge_all())

--- a/rx/core/operators/merge.py
+++ b/rx/core/operators/merge.py
@@ -8,7 +8,7 @@ from rx.internal.concurrency import synchronized
 from rx.internal.utils import is_future
 
 
-def _merge(*args, max_concurrent: int = None) -> Callable[[Observable], Observable]:
+def _merge(*sources, max_concurrent: int = None) -> Callable[[Observable], Observable]:
     def merge(source: Observable) -> Observable:
         """Merges an observable sequence of observable sequences into
         an observable sequence, limiting the number of concurrent
@@ -16,7 +16,7 @@ def _merge(*args, max_concurrent: int = None) -> Callable[[Observable], Observab
         sequences into a single observable sequence.
 
         Examples:
-            >>> merged = merge(sources)
+            >>> res = merge(sources)
 
         Args:
             source: Source observable.
@@ -27,8 +27,8 @@ def _merge(*args, max_concurrent: int = None) -> Callable[[Observable], Observab
         """
 
         if max_concurrent is None:
-            sources = tuple([source]) + args
-            return rx.merge(*sources)
+            sources_ = tuple([source]) + sources
+            return rx.merge(*sources_)
 
         def subscribe(observer, scheduler=None):
             active_count = [0]

--- a/rx/operators/__init__.py
+++ b/rx/operators/__init__.py
@@ -1119,15 +1119,15 @@ def max_by(key_mapper, comparer=None) -> Callable[[Observable], Observable]:
     return _max_by(key_mapper, comparer)
 
 
-def merge(*args, max_concurrent: int = None) -> Callable[[Observable], Observable]:
+def merge(*sources, max_concurrent: int = None) -> Callable[[Observable], Observable]:
     """Merges an observable sequence of observable sequences into an
     observable sequence, limiting the number of concurrent
     subscriptions to inner sequences. Or merges two observable
     sequences into a single observable sequence.
 
     Examples:
-        >>> merged = merge(max_concurrent=1)
-        >>> merged = merge(other_source)
+        >>> op = merge(max_concurrent=1)
+        >>> op = merge(other_source)
 
     Args:
         max_concurrent: [Optional] Maximum number of inner observable
@@ -1140,7 +1140,7 @@ def merge(*args, max_concurrent: int = None) -> Callable[[Observable], Observabl
         inner sequences.
     """
     from rx.core.operators.merge import _merge
-    return _merge(*args, max_concurrent=max_concurrent)
+    return _merge(*sources, max_concurrent=max_concurrent)
 
 
 def merge_all() -> Callable[[Observable], Observable]:


### PR DESCRIPTION
Remove first argument as Iterable for `merge` operator.

NB: I prefer to PR for each operator since there could be some issues (`concat` seems to be tricky to update).