### PR TITLE
Remove Iterable argument for amb, combine_latest, on_error_resume_next, merge operators 

### DIFF
--- a/rx/__init__.py
+++ b/rx/__init__.py
@@ -490,20 +490,19 @@ def of(*args: Any) -> Observable:
     return from_iterable(args)
 
 
-def on_error_resume_next(*args) -> Observable:
+def on_error_resume_next(*sources: Observable) -> Observable:
     """Continues an observable sequence that is terminated normally or
     by an exception with the next observable sequence.
 
     Examples:
         >>> res = rx.on_error_resume_next(xs, ys, zs)
-        >>> res = rx.on_error_resume_next([xs, ys, zs])
 
     Returns:
         An observable sequence that concatenates the source sequences,
         even if a sequence terminates exceptionally.
     """
     from .core.observable.onerrorresumenext import _on_error_resume_next
-    return _on_error_resume_next(*args)
+    return _on_error_resume_next(*sources)
 
 
 def range(start: int, stop: int = None, step: int = None, scheduler: typing.Scheduler = None) -> Observable:

--- a/rx/__init__.py
+++ b/rx/__init__.py
@@ -68,21 +68,20 @@ def create(subscribe: Callable[[typing.Observer, Optional[typing.Scheduler]], ty
     return Observable(subscribe)
 
 
-def combine_latest(*args: Union[Observable, Iterable[Observable]]) -> Observable:
+def combine_latest(*sources: Observable) -> Observable:
     """Merges the specified observable sequences into one observable
     sequence by creating a tuple whenever any of the
     observable sequences produces an element.
 
     Examples:
         >>> obs = rx.combine_latest(obs1, obs2, obs3)
-        >>> obs = rx.combine_latest([obs1, obs2, obs3])
 
     Returns:
         An observable sequence containing the result of combining
         elements of the sources into a tuple.
     """
     from .core.observable.combinelatest import _combine_latest
-    return _combine_latest(*args)
+    return _combine_latest(*sources)
 
 
 def concat(*args: Union[Observable, Iterable[Observable]]) -> Observable:

--- a/rx/__init__.py
+++ b/rx/__init__.py
@@ -450,19 +450,19 @@ def interval(period, scheduler: typing.Scheduler = None) -> Observable:
     return _interval(period, scheduler)
 
 
-def merge(*args: Observable) -> Observable:
+def merge(*sources: Observable) -> Observable:
     """Merges all the observable sequences into a single observable
     sequence.
 
-    1 - merged = rx.merge(xs, ys, zs)
-    2 - merged = rx.merge([xs, ys, zs])
+    Example:
+        >>> res = rx.merge(obs1, obs2, obs3)
 
     Returns:
         The observable sequence that merges the elements of the
         observable sequences.
     """
     from .core.observable.merge import _merge
-    return _merge(*args)
+    return _merge(*sources)
 
 
 def never() -> Observable:

--- a/rx/__init__.py
+++ b/rx/__init__.py
@@ -8,7 +8,7 @@ from .core import Observable, abc, typing, pipe
 from . import disposable
 
 
-def amb(*args: Observable) -> Observable:
+def amb(*sources: Observable) -> Observable:
     """Propagates the observable sequence that reacts first.
 
     Example:
@@ -19,7 +19,7 @@ def amb(*args: Observable) -> Observable:
         sequences, whichever reacted first.
     """
     from .core.observable.amb import _amb
-    return _amb(*args)
+    return _amb(*sources)
 
 
 def case(mapper, sources, default_source=None) -> Observable:

--- a/rx/core/observable/amb.py
+++ b/rx/core/observable/amb.py
@@ -4,7 +4,7 @@ from rx import operators as _
 from rx.core import Observable
 
 
-def _amb(*args: Observable) -> Observable:
+def _amb(*sources: Observable) -> Observable:
     """Propagates the observable sequence that reacts first.
 
     Example:
@@ -16,15 +16,11 @@ def _amb(*args: Observable) -> Observable:
     """
 
     acc = never()
-    if isinstance(args[0], list):
-        items = args[0]
-    else:
-        items = list(args)
 
     def func(previous, current):
         return _.amb(previous)(current)
 
-    for item in items:
-        acc = func(acc, item)
+    for source in sources:
+        acc = func(acc, source)
 
     return acc

--- a/rx/core/observable/combinelatest.py
+++ b/rx/core/observable/combinelatest.py
@@ -4,28 +4,19 @@ from rx.core import Observable, typing
 from rx.disposable import CompositeDisposable, SingleAssignmentDisposable
 
 
-def _combine_latest(*args: Union[Observable, Iterable[Observable]]) -> Observable:
+def _combine_latest(*sources: Observable) -> Observable:
     """Merges the specified observable sequences into one observable
     sequence by creating a tuple whenever any of the
     observable sequences produces an element.
 
     Examples:
         >>> obs = combine_latest(obs1, obs2, obs3)
-        >>> obs = combine_latest([obs1, obs2, obs3])
 
     Returns:
         An observable sequence containing the result of combining
         elements of the sources into a tuple.
     """
 
-    sources: List[Observable] = []
-
-    if isinstance(args[0], Iterable):
-        sources += list(args[0])
-    else:
-        sources += list(cast(Iterable[Observable], args))
-
-#    result_mapper = mapper
     parent = sources[0]
 
     def subscribe(observer: typing.Observer, scheduler: typing.Scheduler = None):

--- a/rx/core/observable/merge.py
+++ b/rx/core/observable/merge.py
@@ -1,15 +1,8 @@
-from typing import Iterable, Union
 
 import rx
 from rx import operators as ops
 from rx.core import Observable
 
 
-
-def _merge(*args: Union[Observable, Iterable[Observable]]) -> Observable:
-    sources = args[:]
-
-    if isinstance(sources[0], Iterable):
-        sources = sources[0]
-
+def _merge(*sources: Observable) -> Observable:
     return rx.from_iterable(sources).pipe(ops.merge_all())

--- a/rx/core/observable/onerrorresumenext.py
+++ b/rx/core/observable/onerrorresumenext.py
@@ -5,23 +5,19 @@ from rx.disposable import CompositeDisposable, SingleAssignmentDisposable, Seria
 from rx.internal.utils import is_future
 
 
-def _on_error_resume_next(*args) -> Observable:
+def _on_error_resume_next(*sources: Observable) -> Observable:
     """Continues an observable sequence that is terminated normally or
     by an exception with the next observable sequence.
 
     Examples:
         >>> res = rx.on_error_resume_next(xs, ys, zs)
-        >>> res = rx.on_error_resume_next([xs, ys, zs])
 
     Returns:
         An observable sequence that concatenates the source sequences,
         even if a sequence terminates exceptionally.
     """
 
-    if args and isinstance(args[0], list):
-        sources = iter(args[0])
-    else:
-        sources = iter(args)
+    sources_ = iter(sources)
 
     def subscribe(observer, scheduler=None):
 
@@ -32,7 +28,7 @@ def _on_error_resume_next(*args) -> Observable:
 
         def action(scheduler, state=None):
             try:
-                source = next(sources)
+                source = next(sources_)
             except StopIteration:
                 observer.on_completed()
                 return

--- a/rx/core/operators/combinelatest.py
+++ b/rx/core/operators/combinelatest.py
@@ -4,8 +4,7 @@ import rx
 from rx.core import Observable, typing
 
 
-def _combine_latest(other: Union[Observable, Iterable[Observable]],
-                    ) -> Callable[[Observable], Observable]:
+def _combine_latest(*others: Observable) -> Callable[[Observable], Observable]:
     def combine_latest(source: Observable) -> Observable:
         """Merges the specified observable sequences into one
         observable sequence by creating a tuple whenever any
@@ -18,12 +17,8 @@ def _combine_latest(other: Union[Observable, Iterable[Observable]],
             An observable sequence containing the result of combining
             elements of the sources into a tuple.
         """
-        sources: List[Observable] = [source]
 
-        if isinstance(other, typing.Observable):
-            sources += [other]
-        else:
-            sources += other
+        sources = (source,) + others
 
-        return rx.combine_latest(sources)
+        return rx.combine_latest(*sources)
     return combine_latest

--- a/rx/core/operators/merge.py
+++ b/rx/core/operators/merge.py
@@ -8,7 +8,7 @@ from rx.internal.concurrency import synchronized
 from rx.internal.utils import is_future
 
 
-def _merge(*args, max_concurrent: int = None) -> Callable[[Observable], Observable]:
+def _merge(*sources, max_concurrent: int = None) -> Callable[[Observable], Observable]:
     def merge(source: Observable) -> Observable:
         """Merges an observable sequence of observable sequences into
         an observable sequence, limiting the number of concurrent
@@ -16,7 +16,7 @@ def _merge(*args, max_concurrent: int = None) -> Callable[[Observable], Observab
         sequences into a single observable sequence.
 
         Examples:
-            >>> merged = merge(sources)
+            >>> res = merge(sources)
 
         Args:
             source: Source observable.
@@ -27,8 +27,8 @@ def _merge(*args, max_concurrent: int = None) -> Callable[[Observable], Observab
         """
 
         if max_concurrent is None:
-            sources = tuple([source]) + args
-            return rx.merge(*sources)
+            sources_ = tuple([source]) + sources
+            return rx.merge(*sources_)
 
         def subscribe(observer, scheduler=None):
             active_count = [0]

--- a/rx/core/operators/onerrorresumenext.py
+++ b/rx/core/operators/onerrorresumenext.py
@@ -4,7 +4,7 @@ import rx
 from rx.core import Observable
 
 
-def _on_error_resume_next(second) -> Callable[[Observable], Observable]:
+def _on_error_resume_next(second: Observable) -> Callable[[Observable], Observable]:
     def on_error_resume_next(source: Observable) -> Observable:
-        return rx.on_error_resume_next([source, second])
+        return rx.on_error_resume_next(source, second)
     return on_error_resume_next

--- a/rx/operators/__init__.py
+++ b/rx/operators/__init__.py
@@ -1118,15 +1118,15 @@ def max_by(key_mapper, comparer=None) -> Callable[[Observable], Observable]:
     return _max_by(key_mapper, comparer)
 
 
-def merge(*args, max_concurrent: int = None) -> Callable[[Observable], Observable]:
+def merge(*sources, max_concurrent: int = None) -> Callable[[Observable], Observable]:
     """Merges an observable sequence of observable sequences into an
     observable sequence, limiting the number of concurrent
     subscriptions to inner sequences. Or merges two observable
     sequences into a single observable sequence.
 
     Examples:
-        >>> merged = merge(max_concurrent=1)
-        >>> merged = merge(other_source)
+        >>> op = merge(max_concurrent=1)
+        >>> op = merge(other_source)
 
     Args:
         max_concurrent: [Optional] Maximum number of inner observable
@@ -1139,7 +1139,7 @@ def merge(*args, max_concurrent: int = None) -> Callable[[Observable], Observabl
         inner sequences.
     """
     from rx.core.operators.merge import _merge
-    return _merge(*args, max_concurrent=max_concurrent)
+    return _merge(*sources, max_concurrent=max_concurrent)
 
 
 def merge_all() -> Callable[[Observable], Observable]:

--- a/rx/operators/__init__.py
+++ b/rx/operators/__init__.py
@@ -201,15 +201,14 @@ def catch(second: Observable = None, handler: Callable[[Exception, Observable], 
     return _catch(second, handler)
 
 
-def combine_latest(other: Union[Observable, Iterable[Observable]],
-                  ) -> Callable[[Observable], Observable]:
+def combine_latest(*others: Observable) -> Callable[[Observable], Observable]:
     """Merges the specified observable sequences into one observable
     sequence by creating a tuple whenever any of the
     observable sequences produces an element.
 
     Examples:
         >>> obs = combine_latest(other)
-        >>> obs = combine_latest([obs1, obs2, obs3])
+        >>> obs = combine_latest(obs1, obs2, obs3)
 
     Returns:
         An operator function that takes an observable sources and
@@ -217,7 +216,7 @@ def combine_latest(other: Union[Observable, Iterable[Observable]],
         combining elements of the sources into a tuple.
     """
     from rx.core.operators.combinelatest import _combine_latest
-    return _combine_latest(other)
+    return _combine_latest(*others)
 
 
 def concat(*args: Union[Observable, Iterable[Observable]]) -> Callable[[Observable], Observable]:

--- a/rx/operators/__init__.py
+++ b/rx/operators/__init__.py
@@ -1254,7 +1254,7 @@ def observe_on(scheduler) -> Callable[[Observable], Observable]:
     from rx.core.operators.observeon import _observe_on
     return _observe_on(scheduler)
 
-def on_error_resume_next(second) -> Callable[[Observable], Observable]:
+def on_error_resume_next(second: Observable) -> Callable[[Observable], Observable]:
     """Continues an observable sequence that is terminated normally
     or by an exception with the next observable sequence.
 


### PR DESCRIPTION
This PR removes first argument that accept Iterable[Observable] for operators:
- `amb` 
- `combine_latest` 
- `on_error_resume_next`
- `merge` (replacing PR #300 )  