### PR TITLE
remove iterable argument for concat operator

### DIFF
--- a/rx/__init__.py
+++ b/rx/__init__.py
@@ -84,19 +84,36 @@ def combine_latest(*sources: Observable) -> Observable:
     return _combine_latest(*sources)
 
 
-def concat(*args: Union[Observable, Iterable[Observable]]) -> Observable:
+def concat(*sources: Observable) -> Observable:
     """Concatenates all the observable sequences.
 
     Examples:
         >>> res = rx.concat(xs, ys, zs)
-        >>> res = rx.concat([xs, ys, zs])
 
     Returns:
         An observable sequence that contains the elements of each given
         sequence, in sequential order.
     """
-    from .core.observable.concat import _concat
-    return _concat(*args)
+    from .core.observable.concat import _concat_with_iterable
+    return _concat_with_iterable(sources)
+
+
+def concat_with_iterable(sources: Iterable[Observable]) -> Observable:
+    """Concatenates all the observable sequences.
+
+    Examples:
+        >>> res = rx.concat_with_iterable([xs, ys, zs])
+        >>> res = rx.concat_with_iterable(for src in [xs, ys, zs])
+
+    Args:
+        sources: an Iterable of observables. Thus a generator is accepted.
+
+    Returns:
+        An observable sequence that contains the elements of each given
+        sequence, in sequential order.
+    """
+    from .core.observable.concat import _concat_with_iterable
+    return _concat_with_iterable(sources)
 
 
 def defer(observable_factory: Callable[[abc.Scheduler], Observable]) -> Observable:
@@ -150,7 +167,7 @@ def for_in(values, mapper) -> Observable:
         An observable sequence from the concatenated observable
         sequences.
     """
-    return concat(map(mapper, values))
+    return concat_with_iterable(map(mapper, values))
 
 
 def from_callable(supplier: Callable, scheduler: typing.Scheduler = None) -> Observable:

--- a/rx/core/observable/concat.py
+++ b/rx/core/observable/concat.py
@@ -1,4 +1,4 @@
-from typing import Iterable, Union, cast
+from typing import Iterable
 
 from rx.disposable import Disposable
 from rx.core import Observable
@@ -6,11 +6,9 @@ from rx.disposable import SingleAssignmentDisposable, CompositeDisposable, Seria
 from rx.concurrency import current_thread_scheduler
 
 
-def _concat(*args: Union[Observable, Iterable[Observable]]) -> Observable:
-    if args and isinstance(args[0], Iterable):
-        sources = iter(args[0])
-    else:
-        sources = iter(cast(Iterable, args))
+def _concat_with_iterable(sources: Iterable[Observable]) -> Observable:
+
+    sources_ = iter(sources)
 
     def subscribe(observer, scheduler=None):
         scheduler = scheduler or current_thread_scheduler
@@ -28,7 +26,7 @@ def _concat(*args: Union[Observable, Iterable[Observable]]) -> Observable:
                 cancelable.disposable = scheduler.schedule(action)
 
             try:
-                current = next(sources)
+                current = next(sources_)
             except StopIteration:
                 observer.on_completed()
             except Exception as ex:  # pylint: disable=broad-except

--- a/rx/core/operators/concat.py
+++ b/rx/core/operators/concat.py
@@ -1,15 +1,20 @@
-from typing import Iterable, Callable, Union, cast
+from typing import Callable
 
 import rx
 from rx.core import Observable
 
 
-def _concat(*args: Union[Observable, Iterable[Observable]]) -> Callable[[Observable], Observable]:
-    if args and isinstance(args[0], Iterable):
-        sources = iter(args[0])
-    else:
-        sources = iter(cast(Iterable, args))
-
+def _concat(*sources: Observable) -> Callable[[Observable], Observable]:
     def concat(source: Observable) -> Observable:
+        """Concatenates all the observable sequences.
+
+        Examples:
+            >>> op = concat(xs, ys, zs)
+
+        Returns:
+            An operator function that takes one or more observable sources and
+            returns an observable sequence that contains the elements of
+            each given sequence, in sequential order.
+        """
         return rx.concat(source, *sources)
     return concat

--- a/rx/core/operators/repeat.py
+++ b/rx/core/operators/repeat.py
@@ -31,5 +31,5 @@ def _repeat(repeat_count=None) -> Callable[[Observable], Observable]:
         else:
             gen = range(repeat_count)
 
-        return rx.defer(lambda _: rx.concat(source for _ in  gen))
+        return rx.defer(lambda _: rx.concat_with_iterable(source for _ in  gen))
     return repeat

--- a/rx/core/operators/whiledo.py
+++ b/rx/core/operators/whiledo.py
@@ -21,5 +21,5 @@ def _while_do(condition: Callable[[Any], bool]) -> Callable[[Observable], Observ
             condition holds.
         """
         source = rx.from_future(source) if is_future(source) else source
-        return rx.concat(itertools.takewhile(condition, (source for x in infinite())))
+        return rx.concat_with_iterable(itertools.takewhile(condition, (source for x in infinite())))
     return while_do

--- a/rx/operators/__init__.py
+++ b/rx/operators/__init__.py
@@ -219,20 +219,19 @@ def combine_latest(*others: Observable) -> Callable[[Observable], Observable]:
     return _combine_latest(*others)
 
 
-def concat(*args: Union[Observable, Iterable[Observable]]) -> Callable[[Observable], Observable]:
+def concat(*sources: Observable) -> Callable[[Observable], Observable]:
     """Concatenates all the observable sequences.
 
     Examples:
-        >>> res = concat(xs, ys, zs)
-        >>> res = concat([xs, ys, zs])
+        >>> op = concat(xs, ys, zs)
 
     Returns:
-        An operator function that takes an observable source and
+        An operator function that takes one or more observable sources and
         returns an observable sequence that contains the elements of
         each given sequence, in sequential order.
     """
     from rx.core.operators.concat import _concat
-    return _concat(*args)
+    return _concat(*sources)
 
 
 def contains(value: Any, comparer=None) -> Callable[[Observable], Observable]:


### PR DESCRIPTION
This PR is for removing the first argument of `concat` operator which accepts an Iterable[Observable].

A new operator `rx.concat_with_iterable` has been added for operators which need to concat an iterable of observables:
- `repeat`
- `for_in`
- `while_do`

