### PR TITLE
remove iterable argument of catch operator

### DIFF
--- a/rx/__init__.py
+++ b/rx/__init__.py
@@ -45,21 +45,40 @@ def case(mapper, sources, default_source=None) -> Observable:
     return _case(mapper, sources, default_source)
 
 
-def catch(*args: Union[Iterable[Observable], Observable]) -> Observable:
+def catch(*sources: Observable) -> Observable:
     """Continues an observable sequence that is terminated by an
     exception with the next observable sequence.
 
     Examples:
         >>> res = rx.catch(xs, ys, zs)
-        >>> res = rx.catch([xs, ys, zs])
 
     Returns:
         An observable sequence containing elements from consecutive
         source sequences until a source sequence terminates
         successfully.
     """
-    from .core.observable.catch import _catch
-    return _catch(*args)
+    from .core.observable.catch import _catch_with_iterable
+    return _catch_with_iterable(sources)
+
+
+def catch_with_iterable(sources: Iterable[Observable]) -> Observable:
+    """Continues an observable sequence that is terminated by an
+    exception with the next observable sequence.
+
+    Examples:
+        >>> res = rx.catch([xs, ys, zs])
+        >>> res = rx.catch(src for src in [xs, ys, zs])
+
+    Args:
+        sources: an Iterable of observables. Thus a generator is accepted.
+
+    Returns:
+        An observable sequence containing elements from consecutive
+        source sequences until a source sequence terminates
+        successfully.
+    """
+    from .core.observable.catch import _catch_with_iterable
+    return _catch_with_iterable(sources)
 
 
 def create(subscribe: Callable[[typing.Observer, Optional[typing.Scheduler]], typing.Disposable]):

--- a/rx/core/operators/catch.py
+++ b/rx/core/operators/catch.py
@@ -42,8 +42,8 @@ def _catch(second: Observable = None, handler: Callable[[Exception, Observable],
         exception with the next observable sequence.
 
         Examples:
-            >>> catch(ys)
-            >>> catch(lambda ex, src: ys(ex))
+            >>> op = catch(ys)
+            >>> op = catch(lambda ex, src: ys(ex))
 
         Args:
             handler: Exception handler function that returns an
@@ -60,5 +60,5 @@ def _catch(second: Observable = None, handler: Callable[[Exception, Observable],
         if handler or not isinstance(second, typing.Observable):
             return catch_handler(source, handler or second)
 
-        return rx.catch([source, second])
+        return rx.catch(source, second)
     return catch

--- a/rx/core/operators/retry.py
+++ b/rx/core/operators/retry.py
@@ -29,5 +29,5 @@ def _retry(retry_count: int = None) -> Callable[[Observable], Observable]:
         gen = range(retry_count)
 
     def retry(source: Observable) -> Observable:
-        return rx.catch(source for _ in gen)
+        return rx.catch_with_iterable(source for _ in gen)
     return retry

--- a/rx/operators/__init__.py
+++ b/rx/operators/__init__.py
@@ -181,8 +181,8 @@ def catch(second: Observable = None, handler: Callable[[Exception, Observable], 
     exception with the next observable sequence.
 
     Examples:
-        >>> catch(ys)
-        >>> catch(lambda ex: ys(ex))
+        >>> op = catch(ys)
+        >>> op = catch(lambda ex: ys(ex))
 
     Args:
         handler: Exception handler function that returns an observable


### PR DESCRIPTION
This PR is for removing the first argument of `catch` operator which accepts an Iterable[Observable].

A new operator `rx.catch_with_iterable` has been added for `retry` which need to catch an iterable of observables.
