### PR TITLE
Feature/marble

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -44,6 +44,7 @@ extensions = [
     'sphinx.ext.napoleon',
     'sphinx_autodoc_typehints',
     'guzzle_sphinx_theme',
+    'sphinxcontrib_dooble',
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/requirements_doc.txt
+++ b/requirements_doc.txt
@@ -1,3 +1,4 @@
 sphinx
 sphinx-autodoc-typehints
 guzzle_sphinx_theme
+sphinxcontrib_dooble

--- a/rx/operators/__init__.py
+++ b/rx/operators/__init__.py
@@ -180,6 +180,14 @@ def catch(second: Observable = None, handler: Callable[[Exception, Observable], 
     """Continues an observable sequence that is terminated by an
     exception with the next observable sequence.
 
+    .. marble::
+        :alt: catch
+
+        ---1---2---3---*
+                  a-7-8-|
+        [      catch(a)    ]
+        ---1---2---3---7-8-|
+
     Examples:
         >>> catch(ys)
         >>> catch(lambda ex: ys(ex))
@@ -1025,6 +1033,14 @@ def map(mapper: Mapper = None) -> Callable[[Observable], Observable]:
     """The map operator.
 
     Project each element of an observable sequence into a new form.
+
+    .. marble::
+        :alt: map
+
+        ---1---2---3---4--->
+        [   map(i: i*2)    ]
+        ---2---4---6---8--->
+
 
     Example:
         >>> map(lambda value: value * 10)
@@ -2509,6 +2525,15 @@ def window(window_openings=None, window_closing_mapper=None) -> Callable[[Observ
 def window_with_count(count: int, skip: int = None) -> Callable[[Observable], Observable]:
     """Projects each element of an observable sequence into zero or more
     windows which are produced based on element count information.
+
+    .. marble::
+        :alt: window_with_count
+
+        ---a-b-c---d-e-f--->
+        [    window(3)     ]
+        --+-------+-------->
+                  +d-e-f-|
+          +a-b-c-|
 
     Examples:
         >>> window_with_count(10)


### PR DESCRIPTION
This PR contains three examples of marbles diagrams that are generated with dooble and its sphinx extension: map, catch, window. The three examples cover all features supported by dooble.

This PR is for continuation of #270 