### PR TITLE
Fix with_latest_from operator with numpy arrays

### DIFF
--- a/rx/core/observable/withlatestfrom.py
+++ b/rx/core/observable/withlatestfrom.py
@@ -3,8 +3,13 @@ from rx.disposable import CompositeDisposable, SingleAssignmentDisposable
 from rx.core import Observable
 
 
+class NoValue():
+    def __eq__(self, other):
+        return self is other
+
+
 def _with_latest_from(parent: Observable, *sources: Observable) -> Observable:
-    NO_VALUE = object()
+    NO_VALUE = NoValue()
 
     def subscribe(observer, scheduler=None):
         def subscribe_all(parent, *children):
@@ -24,8 +29,7 @@ def _with_latest_from(parent: Observable, *sources: Observable) -> Observable:
 
             def on_next(value):
                 with parent.lock:
-                    # test identity instead of (possibly) equality
-                    if all([NO_VALUE is not value for value in values]):
+                    if NO_VALUE not in values:
                         result = (value,) + tuple(values)
                         observer.on_next(result)
 

--- a/rx/core/observable/withlatestfrom.py
+++ b/rx/core/observable/withlatestfrom.py
@@ -1,15 +1,11 @@
 from rx.disposable import CompositeDisposable, SingleAssignmentDisposable
 
 from rx.core import Observable
-
-
-class NoValue():
-    def __eq__(self, other):
-        return self is other
+from rx.internal.utils import NotSet
 
 
 def _with_latest_from(parent: Observable, *sources: Observable) -> Observable:
-    NO_VALUE = NoValue()
+    NO_VALUE = NotSet()
 
     def subscribe(observer, scheduler=None):
         def subscribe_all(parent, *children):

--- a/rx/core/observable/withlatestfrom.py
+++ b/rx/core/observable/withlatestfrom.py
@@ -24,7 +24,8 @@ def _with_latest_from(parent: Observable, *sources: Observable) -> Observable:
 
             def on_next(value):
                 with parent.lock:
-                    if NO_VALUE not in values:
+                    # test identity instead of (possibly) equality
+                    if all([NO_VALUE is not value for value in values]):
                         result = (value,) + tuple(values)
                         observer.on_next(result)
 

--- a/rx/internal/utils.py
+++ b/rx/internal/utils.py
@@ -26,5 +26,8 @@ def infinite() -> Iterable[int]:
 class NotSet:
     """Sentinel value."""
 
+    def __eq__(self, other):
+        return self is other
+
     def __repr__(self):
         return 'NotSet'


### PR DESCRIPTION
This PR is for fixing an issue with `with_latest_from` operator when using numpy arrays as items in observables.

## Example

```python
import numpy as np
import rx
import rx.operators as ops

values = rx.interval(0.050).pipe(ops.map(lambda i: np.repeat(i, 3)))
triggers = rx.interval(0.100)
results = rx.with_latest_from(triggers, values)
results.pipe(
    ops.take(4),
    ops.do_action(print),
    ).run()
```

### result
```python
Traceback (most recent call last):
  File "C:\anaconda3\envs\rxdev\lib\threading.py", line 917, in _bootstrap_inner
    self.run()
  File "C:\anaconda3\envs\rxdev\lib\threading.py", line 1158, in run
    self.function(*self.args, **self.kwargs)
  File "c:\dev\pyprojects\rxpy\rx\concurrency\timeoutscheduler.py", line 40, in interval
    sad.disposable = self.invoke_action(action, state)
  File "c:\dev\pyprojects\rxpy\rx\concurrency\schedulerbase.py", line 16, in invoke_action
    ret = action(self, state)
  File "c:\dev\pyprojects\rxpy\rx\concurrency\schedulerbase.py", line 49, in invoke_periodic
    new_state = action(state)
  File "c:\dev\pyprojects\rxpy\rx\core\observable\timer.py", line 68, in action
    observer.on_next(count)
  File "c:\dev\pyprojects\rxpy\rx\core\observer\autodetachobserver.py", line 24, in on_next
    self._on_next(value)
  File "c:\dev\pyprojects\rxpy\rx\core\observable\withlatestfrom.py", line 27, in on_next
    if NO_VALUE not in values:
ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()
```

 ### expected
```python
(0, array([0, 0, 0]))
(1, array([2, 2, 2]))
(2, array([4, 4, 4]))
(3, array([6, 6, 6]))
```

## Details
In numpy array, the magic method  `__eq__` is not implemented in a standard way. In Python, [in](https://docs.python.org/3/reference/expressions.html#in) is defined as:
>For container types such as list, tuple, set, frozenset, dict, or collections.deque, the expression x in y is equivalent to any(x is e or x == e for e in y)

 I assume this is why it fails to test if a custom object defined as `myobject = object()` is in a list that contains a numpy array:

```python
>>> import numpy as np
>>> array = np.array([0, 1, 2])    
>>> myobject = object()
>>> myobject in ['foo', 2, array, myobject]
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()
```

This PR will implement `__eq__` for `rx.internal.utils.NotSet`  as a test for identity instead of equality.

I've came to this issue with rx1.6.1. I can make a PR later to backport this fix to rx1.6.