### PR TITLE
Fix timeflies examples for GTK, QT, WX

### DIFF
--- a/examples/timeflies/timeflies_gtk.py
+++ b/examples/timeflies/timeflies_gtk.py
@@ -1,6 +1,6 @@
+from rx import operators as ops
 from rx.subjects import Subject
-from rx.concurrency import GtkScheduler
-import sys
+from rx.concurrency.mainloopscheduler import GtkScheduler
 
 import gi
 gi.require_version('Gtk', '3.0')
@@ -24,16 +24,18 @@ class Window(Gtk.Window):
 
 def main():
     scheduler = GtkScheduler()
+    scrolled_window = Gtk.ScrolledWindow()
 
     window = Window()
     window.connect("delete-event", Gtk.main_quit)
 
     container = Gtk.Fixed()
-    window.add(container)
 
+    scrolled_window.add(container)
+    window.add(scrolled_window)
     text = 'TIME FLIES LIKE AN ARROW'
 
-    labels = [Gtk.Label(char) for char in text]
+    labels = [Gtk.Label(label=char) for char in text]
     for label in labels:
         container.put(label, 0, 0)
 
@@ -43,7 +45,9 @@ def main():
             x, y = pos
             container.move(label, x + i*12 + 15, y)
 
-        window.mousemove.delay(i*100, scheduler=scheduler).subscribe(on_next)
+        window.mousemove.pipe(
+            ops.delay(i*0.100, scheduler=scheduler),
+            ).subscribe(on_next)
 
     for i, label in enumerate(labels):
         handle_label(i, label)

--- a/examples/timeflies/timeflies_qt.py
+++ b/examples/timeflies/timeflies_qt.py
@@ -1,5 +1,6 @@
 from rx.subjects import Subject
-from rx.concurrency import QtScheduler
+from rx import operators as ops
+from rx.concurrency.mainloopscheduler import QtScheduler
 import sys
 
 try:
@@ -48,7 +49,9 @@ def main():
             label.move(x + i*12 + 15, y)
             label.show()
 
-        window.mousemove.delay(i*100, scheduler=scheduler).subscribe(on_next)
+        window.mousemove.pipe(
+            ops.delay(i*0.100, scheduler=scheduler)
+            ).subscribe(on_next)
 
     for i, label in enumerate(labels):
         handle_label(i, label)

--- a/examples/timeflies/timeflies_wx.py
+++ b/examples/timeflies/timeflies_wx.py
@@ -1,5 +1,6 @@
+from rx import operators as ops
 from rx.subjects import Subject
-from rx.concurrency import WxScheduler
+from rx.concurrency.mainloopscheduler import WxScheduler
 
 import wx
 
@@ -37,7 +38,9 @@ def main():
             label.MoveXY(x + i*12 + 15, y)
             label.Show()
 
-        frame.mousemove.delay(i*100, scheduler=scheduler).subscribe(on_next)
+        frame.mousemove.pipe(
+            ops.delay(i*0.100, scheduler=scheduler),
+            ).subscribe(on_next)
 
     for i, label in enumerate(labels):
         handle_label(i, label)

--- a/rx/concurrency/mainloopscheduler/wxscheduler.py
+++ b/rx/concurrency/mainloopscheduler/wxscheduler.py
@@ -50,11 +50,11 @@ class WxScheduler(SchedulerBase):
             else:
                 sad.disposable = action(scheduler, state)
 
-        log.debug("timeout: %s", msecs)
-
         msecs = int(self.to_seconds(time)*1000.0)
         if msecs == 0:
             msecs = 1  # wx.Timer doesn't support zero.
+
+        log.debug("timeout: %s", msecs)
 
         timer = self._timer_class(interval)
         timer.Start(


### PR DESCRIPTION
This PR fixes timeflies examples for GTK, Qt & Wx. 

## Qt:
- fix: imports, pipe, time in seconds.

## GTK:
- fix: imports, pipe, time in seconds.
- fix: main window is constantly auto resized. The width/height of the main window keep growing when the mouse cursor gets close to the right or bottom borders. The labels which are drawn outside of the main window force an auto resize of the container. Quick fix: wrap the container in a `Gtk.ScrolledWindow`.
- Deprecation: specify *label* as a keyword argument in `Gtk.Label` constructor.

```python
/home/jehf/DEV/pyprojects/RxPY/examples/timeflies/timeflies_gtk.py:38: PyGTKDeprecationWarning: Using positional arguments with the GObject constructor has been deprecated. Please specify keyword(s) for "label" or use a class specific constructor. See: https://wiki.gnome.org/PyGObject/InitializerDeprecations
  labels = [Gtk.Label(char) for char in text]
```

## Wx:
- fix: imports, pipe, time in seconds.
- Deprecation: change MoveXY() to Move()
```python
/home/jehf/DEV/pyprojects/RxPY/examples/timeflies/timeflies_wx.py:38: wxPyDeprecationWarning: Call to deprecated item. Use Move instead.
  label.MoveXY(x + i*12 + 15, y)
 ```
## Wx scheduler:
- fix `msecs` variable referenced before assignment.