### PR TITLE
Refactor timeflies Qt, WX, GTK 

### DIFF
--- a/examples/timeflies/timeflies_gtk.py
+++ b/examples/timeflies/timeflies_gtk.py
@@ -39,6 +39,7 @@ def main():
     def on_next(info):
         label, (x, y), i = info
         container.move(label, x + i*12 + 15, y)
+        label.show()
 
     def handle_label(label, i):
         delayer = ops.delay(i*0.100)
@@ -52,7 +53,7 @@ def main():
     def make_label(char):
         label = Gtk.Label(label=char)
         container.put(label, 0, 0)
-        label.show()
+        label.hide()
         return label
 
     mapper = ops.map(make_label)


### PR DESCRIPTION
Rewritting timeflies examples in a more 'reactive' way as suggested in PR #317.

 Regarding timeflies for Qt, `Pyside2` has been added. PyQt5 & Pyside2 are confirmed to work. This is related to #241.
