### PR TITLE
QtScheduler

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,14 @@ matrix:
       python: 3.6
       # Coverage for the baseline 3.6 build: include some optional packages
       before_script:
-        - pip install eventlet gevent pyyaml tornado twisted
+        - pip3 install eventlet gevent pyyaml tornado twisted
         # pycairo / pygobject need native libraries
         - sudo apt-get install -y libgirepository1.0-dev gir1.2-gtk-3.0
-        - pip install pycairo pygobject
+        - pip3 install pycairo pygobject
+      script:
+        - coverage run --source=rx setup.py test
+      after_success:
+        - coveralls
 
     - os: linux
       dist: xenial
@@ -22,27 +26,23 @@ matrix:
       python: 3.8-dev
 
     - os: osx
-      osx_image: xcode8.3
-      language: python
-      python: 3.7-dev
+      osx_image: xcode10.1
+      language: sh
+      python: 3.7
 
     - os: windows
-      python: 3.7-dev
       language: sh
+      python: 3.7
       before_install:
         - choco install python3
-        - export PATH="/c/Python37:/c/Python37/Scripts:$PATH"
+        - ln -s "/c/Python37/python.exe" "/c/Python37/python3.exe"
+        - export PATH="/c/Python37:/c/Python37/Scripts/:$PATH"
 
 install:
-  - python setup.py install
-  - pip install coveralls coverage
-  - pip install pytest>=3.0.2 pytest-asyncio pytest-cov --upgrade
+  - python3 setup.py install
+  - pip3 install coveralls coverage
+  - pip3 install pytest>=3.0.2 pytest-asyncio pytest-cov --upgrade
 
 script:
-  - coverage run --source=rx setup.py test
+  - python3 setup.py test
 
-after_success:
-  - if [[ "$TRAVIS_OS_NAME" == "linux" && "$TRAVIS_PYTHON_VERSION" == 3.6* ]];
-    then
-      coveralls;
-    fi

--- a/examples/timeflies/timeflies_qt.py
+++ b/examples/timeflies/timeflies_qt.py
@@ -13,12 +13,8 @@ except ImportError:
         from PySide2 import QtCore
         from PySide2.QtWidgets import QApplication, QLabel, QWidget
     except ImportError:
-        try:
-            from PyQt4 import QtCore
-            from PyQt4.QtGui import QWidget, QLabel, QApplication
-        except ImportError:
-            from PySide import QtCore
-            from PySide.QtGui import QWidget, QLabel, QApplication
+        from PyQt4 import QtCore
+        from PyQt4.QtGui import QWidget, QLabel, QApplication
 
 
 class Window(QWidget):

--- a/rx/concurrency/mainloopscheduler/qtscheduler.py
+++ b/rx/concurrency/mainloopscheduler/qtscheduler.py
@@ -75,8 +75,8 @@ class QtScheduler(SchedulerBase):
             (best effort).
         """
 
-        duetime = self.to_datetime(duetime)
-        return self._qtimer_schedule(duetime, action, state)
+        duetime = self.to_datetime(duetime) - self.now
+        return self.schedule_relative(duetime, action, state)
 
     def schedule_periodic(self, period: typing.RelativeTime, action: typing.ScheduledPeriodicAction,
                           state: typing.TState = None):


### PR DESCRIPTION
I made the import precedence for QtScheduler tests consistent with the example, and I fixed an error as well (schedule_absolute was throwing overflow errors). Added a test case for that.

Tried to get PyQt working in Travis as well, but I am still getting core dumps for some reason... Locally all works very well. But I did wind up making the Travis config just a little bit cleaner, the builds on Mac and Windows now use regular 3.7 instead of odd 3.7-dev versions.