### PR TITLE
fix: leak relative to QtScheduler 

### DIFF
--- a/rx/concurrency/mainloopscheduler/qtscheduler.py
+++ b/rx/concurrency/mainloopscheduler/qtscheduler.py
@@ -5,7 +5,7 @@ from rx.core import typing
 from rx.disposable import SingleAssignmentDisposable, CompositeDisposable
 from rx.concurrency.schedulerbase import SchedulerBase
 
-log = logging.getLogger("Rx")
+log = logging.getLogger(__name__)
 
 
 class QtScheduler(SchedulerBase):
@@ -13,40 +13,11 @@ class QtScheduler(SchedulerBase):
 
     def __init__(self, qtcore):
         self.qtcore = qtcore
-        self._timers = set()
-
-    def _qtimer_schedule(self, time, action, state, periodic=False):
-        scheduler = self
-        msecs = int(self.to_seconds(time)*1000.0)
-
-        sad = SingleAssignmentDisposable()
-
-        periodic_state = [state]
-
-        def interval():
-            if periodic:
-                periodic_state[0] = action(periodic_state[0])
-            else:
-                sad.disposable = action(scheduler, state)
-
-        log.debug("timeout: %s", msecs)
-
-        timer = self.qtcore.QTimer()
-        timer.setSingleShot(not periodic)
-        timer.timeout.connect(interval)
-        timer.setInterval(msecs)
-        timer.start()
-        self._timers.add(timer)
-
-        def dispose():
-            timer.stop()
-            self._timers.remove(timer)
-
-        return CompositeDisposable(sad, Disposable(dispose))
+        self._periodic_timers = set()
 
     def schedule(self, action: typing.ScheduledAction, state: typing.TState = None) -> typing.Disposable:
         """Schedules an action to be executed."""
-        return self._qtimer_schedule(0, action, state)
+        return self.schedule_relative(0.0, action, state)
 
     def schedule_relative(self, duetime: typing.RelativeTime, action: typing.ScheduledAction,
                           state: typing.TState = None) -> typing.Disposable:
@@ -60,7 +31,25 @@ class QtScheduler(SchedulerBase):
             The disposable object used to cancel the scheduled action
             (best effort).
         """
-        return self._qtimer_schedule(duetime, action, state)
+        scheduler = self
+        msecs = int(self.to_seconds(duetime)*1000.0)
+        sad = SingleAssignmentDisposable()
+        is_disposed = False
+
+        def invoke_action():
+            if not is_disposed:
+                sad.disposable = action(scheduler, state)
+
+        log.debug("relative timeout: %sms", msecs)
+
+        # Use static method, let Qt C++ handle QTimer lifetime
+        self.qtcore.QTimer.singleShot(msecs, invoke_action)
+
+        def dispose():
+            nonlocal is_disposed
+            is_disposed = True
+
+        return CompositeDisposable(sad, Disposable(dispose))
 
     def schedule_absolute(self, duetime: typing.AbsoluteTime, action: typing.ScheduledAction,
                           state: typing.TState = None) -> typing.Disposable:
@@ -75,8 +64,8 @@ class QtScheduler(SchedulerBase):
             (best effort).
         """
 
-        duetime = self.to_datetime(duetime)
-        return self._qtimer_schedule(duetime, action, state)
+        duetime = self.to_datetime(duetime) - self.now
+        return self.schedule_relative(duetime, action, state)
 
     def schedule_periodic(self, period: typing.RelativeTime, action: typing.ScheduledPeriodicAction,
                           state: typing.TState = None):
@@ -94,5 +83,27 @@ class QtScheduler(SchedulerBase):
             The disposable object used to cancel the scheduled
             recurring action (best effort).
         """
+        msecs = int(self.to_seconds(period)*1000.0)
+        sad = SingleAssignmentDisposable()
 
-        return self._qtimer_schedule(period, action, state, periodic=True)
+        periodic_state = state
+
+        def interval():
+            nonlocal periodic_state
+            periodic_state = action(periodic_state)
+
+        log.debug("periodic timeout: %sms", msecs)
+
+        timer = self.qtcore.QTimer()
+        timer.setSingleShot(False)
+        timer.timeout.connect(interval)
+        timer.setInterval(msecs)
+        self._periodic_timers.add(timer)
+        timer.start()
+
+        def dispose():
+            timer.stop()
+            self._periodic_timers.remove(timer)
+            timer.deleteLater()
+
+        return CompositeDisposable(sad, Disposable(dispose))


### PR DESCRIPTION
This PR attempts to fix an issue with QtScheduler.

## Issue
Actually, we keep references to QTimer objects in a set `self._timers` and remove them on dispose. This is a problem for non-periodic scheduling because QTimer objects are accumulated in the set and never removed if `dispose` is not called.
It can be easily demonstrated with the timeflies examples. Just add a print statement to display the length of the set on mouse move:
```python
def on_next(info):
    label, (x, y), i = info
    label.move(x + i*12 + 15, y)
    print(len(scheduler._timers))
    label.show()
```
See full script [here](https://gist.github.com/jcafhe/9295d50e7f98b9b834d4b70c129caaa5).
E.g. by moving the mouse during ~5s, I get about 12000 timers in `self._timers`.

## Fix
In theory, there should be no need to keep reference to QTimer objects since a reference is captured anyway in the local `dispose` function. 

However, if we remove `self._timers`, a problem arises when one uses directly the scheduler and sheduling method (`shedule`, `schedule_relative`, ...) and doesn't keep a reference to the returned disposable, as seen in tests.

For whatever reason, the timer will never fire `timeout` signal and the action will not be invoked. E.g.:
- `>>> disp = schedule.shedule_relative(1.0, action, state)` would work
- `>>> schedule.shedule_relative(1.0, action, state)` wouldn't.

So in addition to the `dispose` function, we need to reference timer objects to keep them alive. By using `QTimer.singleShot` static method, we don't need to manage manually QTimer lifetime for non-periodic scheduling, Qt C++ will handle this for us. 

**drawback**: we can't stop the timer to cancel the action before it is invoked. Thus, the action will be cancelled at invocation time. If you think this is not acceptable, I've came to an other solution relying on manual destruction of QTimer object, but it's a big 'ugly' (we keep a python object wrapping a C++ timer which has potentially already been deleted). Please feel free to share your thoughts on this.

For periodic scheduling, we still construct a Qtimer object and keep a reference in a set. Periodic timers will only be deleted on dispose. IMO it makes sense to tight the removing of periodic timer to the returned `disposable`.

By the way, I've divided `_qtimer_schedule` into `schedule_relative` and `schedule_periodic` for clarity. I've also included the fix suggested by @erikkemperman for `schedule_absolute`.