### PR TITLE
Scheduler tweaks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,11 @@ pip-log.txt
 .tox
 nosetests.xml
 coverage.xml
+.mypy_cache
+.pytest_cache
+
+# Virtual env
+venv
 
 # Translations
 *.mo
@@ -50,8 +55,6 @@ UpgradeLog.htm
 TestResults/Rx.TE.Tests.mdf
 TestResults/Rx.TE.Tests_log.ldf
 *.user
-
-.mypy_cache
 
 # Cloud9
 .c9

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,7 @@ matrix:
         - sudo apt-get install -y libgirepository1.0-dev gir1.2-gtk-3.0
         - pip3 install pycairo pygobject
       script:
-        - coverage run --source=rx setup.py test
-      after_success:
-        - coveralls
+        - coverage run --source=rx setup.py test && coveralls
 
     - os: linux
       dist: xenial
@@ -46,3 +44,5 @@ install:
 script:
   - python3 setup.py test
 
+after_success:
+  - cp ./.travis/bench.sh ./_bench && ./_bench master

--- a/.travis/bench.sh
+++ b/.travis/bench.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+
+# This script runs a subset of unit tests (minus concurrency, which does too
+# much hard sleeps to be a useful benchmark) a couple of times, averaging the
+# durations as parsed from pytest output.
+#
+# It does this for each of the branches passed as commandline arguments, plus
+# the branch we were on when invoked.
+
+testargs="--cache-clear --ignore=tests/test_concurrency"
+rounds=10
+
+git remote add upstream https://github.com/ReactiveX/RxPY.git
+
+git stash | grep "^No"
+pop=$?
+
+head=$(git status | head -n 1 | grep -o "[^ ]*$")
+
+for branch in $* $head
+do
+  echo ""
+  if [[ "$branch" != "$head" ]]
+  then
+    git fetch upstream $branch
+    git checkout "upstream/$branch"
+  else
+    git checkout "$branch"
+  fi
+
+  sum=0
+  for round in $(seq $rounds)
+  do
+    echo -n " - Round $round of $rounds"
+    sec=$(pytest $testargs | grep -o "passed in .* s")
+    ret=$?
+    echo -n " | $sec"
+
+    sec=$(echo $sec | sed -e "s/[^0-9]//g")
+    sum=$(($sum + $sec))
+    avg=$((((($sum * 10) / $round) + 5) / 10))
+
+    echo -n " | total $(echo $sum | sed -e "s/\([0-9]\{2\}\)$/.\1/") s"
+    echo -n " | average $(echo $avg | sed -e "s/\([0-9]\{2\}\)$/.\1/") s"
+
+    if [[ $ret == 0 ]]; then echo " | OK"; else echo " | FAIL"; fi
+  done
+done
+
+if [[ $pop != 0 ]]; then git stash pop; fi

--- a/rx/concurrency/__init__.py
+++ b/rx/concurrency/__init__.py
@@ -5,10 +5,7 @@ from .currentthreadscheduler import CurrentThreadScheduler, current_thread_sched
 from .virtualtimescheduler import VirtualTimeScheduler
 from .timeoutscheduler import TimeoutScheduler, timeout_scheduler
 from .newthreadscheduler import NewThreadScheduler
-try:
-    from .threadpoolscheduler import ThreadPoolScheduler
-except ImportError:
-    pass
+from .threadpoolscheduler import ThreadPoolScheduler
 from .eventloopscheduler import EventLoopScheduler
 from .historicalscheduler import HistoricalScheduler
 from .catchscheduler import CatchScheduler

--- a/rx/concurrency/currentthreadscheduler.py
+++ b/rx/concurrency/currentthreadscheduler.py
@@ -2,7 +2,6 @@
 import time
 import logging
 import threading
-from typing import Dict
 from datetime import timedelta
 
 from rx.core import typing
@@ -13,22 +12,23 @@ from .scheduleditem import ScheduledItem
 
 log = logging.getLogger('Rx')
 
+DELTA_ZERO = timedelta(0)
+
 
 class Trampoline(object):
     @classmethod
     def run(cls, queue: PriorityQueue[ScheduledItem[typing.TState]]) -> None:
         while queue:
-            item: ScheduledItem = queue.dequeue()
-            if not item.is_cancelled():
+            item: ScheduledItem = queue.peek()
+            if item.is_cancelled():
+                queue.dequeue()
+            else:
                 diff = item.duetime - item.scheduler.now
-                while diff > timedelta(0):
-                    seconds = diff.seconds + diff.microseconds / 1E6 + diff.days * 86400
-                    log.warning("Do not schedule blocking work!")
-                    time.sleep(seconds)
-                    diff = item.duetime - item.scheduler.now
-
-                if not item.is_cancelled():
+                if diff <= DELTA_ZERO:
                     item.invoke()
+                    queue.dequeue()
+                else:
+                    time.sleep(diff.total_seconds())
 
 
 class CurrentThreadScheduler(SchedulerBase):
@@ -38,65 +38,58 @@ class CurrentThreadScheduler(SchedulerBase):
     waiting.
     """
 
+    class _Local(threading.local):
+        __slots__ = 'idle', 'queue'
+
+        def __init__(self):
+            self.idle: bool = True
+            self.queue: PriorityQueue[ScheduledItem[typing.TState]] = PriorityQueue()
+
     def __init__(self) -> None:
         """Creates a scheduler that schedules work as soon as possible
         on the current thread."""
 
-        self.lock = threading.RLock()
-        self.queues: Dict[int, PriorityQueue[[ScheduledItem[typing.TState]]]] = dict()
-        self.queue: PriorityQueue[ScheduledItem[typing.TState]] = None
+        self._local = CurrentThreadScheduler._Local()
 
     def schedule(self, action: typing.ScheduledAction, state: typing.TState = None) -> typing.Disposable:
         """Schedules an action to be executed."""
 
         #log.debug("CurrentThreadScheduler.schedule(state=%s)", state)
-        return self.schedule_relative(timedelta(0), action, state)
+        return self.schedule_absolute(self.now, action, state=state)
 
     def schedule_relative(self, duetime: typing.RelativeTime, action: typing.ScheduledAction,
                           state: typing.TState = None) -> typing.Disposable:
         """Schedules an action to be executed after duetime."""
 
-        duetime = self.to_timedelta(duetime)
+        duetime = SchedulerBase.normalize(self.to_timedelta(duetime))
 
-        dt = self.now + SchedulerBase.to_timedelta(SchedulerBase.normalize(duetime))
-        si: ScheduledItem[typing.TState] = ScheduledItem(self, state, action, dt)
+        if duetime > DELTA_ZERO:
+            log.warning("Do not schedule blocking work!")
 
-        with self.lock:
-            queue: PriorityQueue[ScheduledItem[typing.TState]] = self.queue
-            if queue is None:
-                queue = PriorityQueue()
-                queue.enqueue(si)
-
-                self.queue = queue
-                try:
-                    Trampoline.run(queue)
-                finally:
-                    self.queue = None
-            else:
-                queue.enqueue(si)
-
-        return si.disposable
+        return self.schedule_absolute(self.now + duetime, action, state=state)
 
     def schedule_absolute(self, duetime: typing.AbsoluteTime, action: typing.ScheduledAction,
                           state: typing.TState = None) -> typing.Disposable:
         """Schedules an action to be executed at duetime."""
 
         duetime = self.to_datetime(duetime)
-        return self.schedule_relative(duetime - self.now, action, state=state)
 
-    def _get_queue(self) -> PriorityQueue[ScheduledItem[typing.TState]]:
-        ident = threading.current_thread().ident
+        if duetime > self.now:
+            log.warning("Do not schedule blocking work!")
 
-        with self.lock:
-            return self.queues.get(ident)
+        si: ScheduledItem[typing.TState] = ScheduledItem(self, state, action, duetime)
 
-    def _set_queue(self, queue: PriorityQueue[ScheduledItem[typing.TState]]):
-        ident = threading.current_thread().ident
+        local: CurrentThreadScheduler._Local = self._local
+        local.queue.enqueue(si)
+        if local.idle:
+            local.idle = False
+            try:
+                Trampoline.run(local.queue)
+            finally:
+                local.idle = True
+                local.queue.clear()
 
-        with self.lock:
-            self.queues[ident] = queue
-
-    queue = property(_get_queue, _set_queue)
+        return si.disposable
 
     def schedule_required(self) -> bool:
         """Test if scheduling is required.
@@ -106,8 +99,7 @@ class CurrentThreadScheduler(SchedulerBase):
         False; otherwise, if the trampoline is not active, then it
         returns True.
         """
-        with self.lock:
-            return self.queue is None
+        return self._local.idle
 
     def ensure_trampoline(self, action):
         """Method for testing the CurrentThreadScheduler."""

--- a/rx/concurrency/currentthreadscheduler.py
+++ b/rx/concurrency/currentthreadscheduler.py
@@ -3,6 +3,8 @@ import time
 import logging
 import threading
 from datetime import timedelta
+from weakref import WeakKeyDictionary
+from typing import MutableMapping
 
 from rx.core import typing
 from rx.internal import PriorityQueue
@@ -38,12 +40,24 @@ class CurrentThreadScheduler(SchedulerBase):
     waiting.
     """
 
+    _global: MutableMapping[threading.Thread, 'CurrentThreadScheduler'] = WeakKeyDictionary()
+
     class _Local(threading.local):
         __slots__ = 'idle', 'queue'
 
         def __init__(self):
             self.idle: bool = True
             self.queue: PriorityQueue[ScheduledItem[typing.TState]] = PriorityQueue()
+
+    def __new__(cls) -> 'CurrentThreadScheduler':
+        """Ensure that each thread has at most a single instance."""
+
+        thread = threading.current_thread()
+        self: 'CurrentThreadScheduler' = CurrentThreadScheduler._global.get(thread)
+        if not self:
+            self = super().__new__(cls)
+            CurrentThreadScheduler._global[thread] = self
+        return self
 
     def __init__(self) -> None:
         """Creates a scheduler that schedules work as soon as possible

--- a/rx/concurrency/currentthreadscheduler.py
+++ b/rx/concurrency/currentthreadscheduler.py
@@ -2,19 +2,16 @@
 import time
 import logging
 import threading
-from datetime import timedelta
 from weakref import WeakKeyDictionary
 from typing import MutableMapping
 
 from rx.core import typing
 from rx.internal import PriorityQueue
 
-from .schedulerbase import SchedulerBase
+from .schedulerbase import SchedulerBase, DELTA_ZERO
 from .scheduleditem import ScheduledItem
 
 log = logging.getLogger('Rx')
-
-DELTA_ZERO = timedelta(0)
 
 
 class Trampoline(object):

--- a/rx/concurrency/currentthreadscheduler.py
+++ b/rx/concurrency/currentthreadscheduler.py
@@ -62,7 +62,7 @@ class CurrentThreadScheduler(SchedulerBase):
 
         queue = self.queue
         if queue is None:
-            queue = PriorityQueue(4)
+            queue = PriorityQueue()
             queue.enqueue(si)
 
             self.queue = queue

--- a/rx/concurrency/eventloopscheduler.py
+++ b/rx/concurrency/eventloopscheduler.py
@@ -94,6 +94,11 @@ class EventLoopScheduler(SchedulerBase, typing.Disposable):
 
         return Disposable(dispose)
 
+    def _has_thread(self) -> bool:
+        """Checks if there is an event loop thread running."""
+        with self._condition:
+            return not self._is_disposed and self._thread is not None
+
     def _ensure_thread(self) -> None:
         """Ensures there is an event loop thread running. Should be
         called under the gate."""

--- a/rx/concurrency/historicalscheduler.py
+++ b/rx/concurrency/historicalscheduler.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from .schedulerbase import UTC_ZERO
 from .virtualtimescheduler import VirtualTimeScheduler
 
 
@@ -18,7 +18,7 @@ class HistoricalScheduler(VirtualTimeScheduler):
         def compare_datetimes(a, b):
             return (a > b) - (a < b)
 
-        clock = initial_clock or datetime.utcfromtimestamp(0)
+        clock = initial_clock or UTC_ZERO
         comparer = comparer or compare_datetimes
 
         super(HistoricalScheduler, self).__init__(clock)

--- a/rx/concurrency/immediatescheduler.py
+++ b/rx/concurrency/immediatescheduler.py
@@ -3,6 +3,7 @@ from typing import Any
 
 from rx.core import typing
 from rx.internal.exceptions import WouldBlockException
+
 from .schedulerbase import SchedulerBase
 
 

--- a/rx/concurrency/immediatescheduler.py
+++ b/rx/concurrency/immediatescheduler.py
@@ -1,10 +1,9 @@
-from datetime import timedelta
 from typing import Any
 
 from rx.core import typing
 from rx.internal.exceptions import WouldBlockException
 
-from .schedulerbase import SchedulerBase
+from .schedulerbase import SchedulerBase, DELTA_ZERO
 
 
 class ImmediateScheduler(SchedulerBase):
@@ -18,7 +17,7 @@ class ImmediateScheduler(SchedulerBase):
         """Schedules an action to be executed after duetime."""
 
         duetime = self.to_timedelta(duetime)
-        if duetime > timedelta(0):
+        if duetime > DELTA_ZERO:
             raise WouldBlockException()
 
         return self.invoke_action(action, state)

--- a/rx/concurrency/mainloopscheduler/asyncioscheduler.py
+++ b/rx/concurrency/mainloopscheduler/asyncioscheduler.py
@@ -1,12 +1,15 @@
 import logging
 import asyncio
-from datetime import datetime
-from concurrent.futures import Future
 
-from rx.disposable import Disposable
+from concurrent.futures import Future
+from datetime import datetime
+from typing import Optional
+
 from rx.core import typing
-from rx.disposable import SingleAssignmentDisposable, CompositeDisposable
-from rx.concurrency.schedulerbase import SchedulerBase
+from rx.disposable import CompositeDisposable, Disposable, SingleAssignmentDisposable
+
+from ..schedulerbase import SchedulerBase
+
 
 log = logging.getLogger("Rx")
 
@@ -14,22 +17,40 @@ log = logging.getLogger("Rx")
 class AsyncIOScheduler(SchedulerBase):
     """A scheduler that schedules work via the asyncio mainloop."""
 
-    def __init__(self, loop=None, threadsafe=False):
-        self.loop = loop or asyncio.get_event_loop()
-        self.threadsafe = threadsafe
+    def __init__(self,
+                 loop: Optional[asyncio.AbstractEventLoop] = None,
+                 threadsafe: bool = False
+                 ) -> None:
+        self.loop: asyncio.AbstractEventLoop = loop or asyncio.get_event_loop()
+        self.threadsafe: bool = threadsafe
 
-    def schedule(self, action: typing.ScheduledAction, state: typing.TState = None) -> typing.Disposable:
-        """Schedules an action to be executed."""
+    def schedule(self,
+                 action: typing.ScheduledAction,
+                 state: Optional[typing.TState] = None
+                 ) -> typing.Disposable:
+        """Schedules an action to be executed.
+
+        Args:
+            action: Action to be executed.
+            state: [Optional] state to be given to the action function.
+
+        Returns:
+            The disposable object used to cancel the scheduled action
+            (best effort).
+        """
         if self.threadsafe is False:
-            return self._schedule(action, state)
+            return self._schedule(action, state=state)
 
-        return self._schedule_threadsafe(action, state)
+        return self._schedule_threadsafe(action, state=state)
 
-    def _schedule(self, action: typing.ScheduledAction, state: typing.TState = None) -> typing.Disposable:
+    def _schedule(self,
+                  action: typing.ScheduledAction,
+                  state: Optional[typing.TState] = None
+                  ) -> typing.Disposable:
         sad = SingleAssignmentDisposable()
 
         def interval():
-            sad.disposable = self.invoke_action(action, state)
+            sad.disposable = self.invoke_action(action, state=state)
         handle = self.loop.call_soon(interval)
 
         def dispose():
@@ -37,11 +58,14 @@ class AsyncIOScheduler(SchedulerBase):
 
         return CompositeDisposable(sad, Disposable(dispose))
 
-    def _schedule_threadsafe(self, action, state=None):
+    def _schedule_threadsafe(self,
+                             action: typing.ScheduledAction,
+                             state: Optional[typing.TState] = None
+                             ) -> typing.Disposable:
         sad = SingleAssignmentDisposable()
 
         def interval():
-            sad.disposable = self.invoke_action(action, state)
+            sad.disposable = self.invoke_action(action, state=state)
 
         handle = self.loop.call_soon_threadsafe(interval)
 
@@ -57,29 +81,35 @@ class AsyncIOScheduler(SchedulerBase):
 
         return CompositeDisposable(sad, Disposable(dispose))
 
-    def schedule_relative(self, duetime: typing.RelativeTime, action: typing.ScheduledAction,
-                          state: typing.TState = None) -> typing.Disposable:
-        """Schedules an action to be executed at duetime.
+    def schedule_relative(self,
+                          duetime: typing.RelativeTime,
+                          action: typing.ScheduledAction,
+                          state: Optional[typing.TState] = None
+                          ) -> typing.Disposable:
+        """Schedules an action to be executed after duetime.
 
         Args:
-            duetime: Relative time after which to execute the
-                action.
+            duetime: Relative time after which to execute the action.
             action: Action to be executed.
+            state: [Optional] state to be given to the action function.
 
         Returns:
             The disposable object used to cancel the scheduled action
             (best effort).
         """
         if self.threadsafe is False:
-            return self._schedule_relative(duetime, action, state)
+            return self._schedule_relative(duetime, action, state=state)
         else:
-            return self._schedule_relative_threadsafe(duetime, action, state)
+            return self._schedule_relative_threadsafe(duetime, action, state=state)
 
-    def _schedule_relative(self, duetime, action, state=None):
-        scheduler = self
+    def _schedule_relative(self,
+                           duetime: typing.RelativeTime,
+                           action: typing.ScheduledAction,
+                           state: Optional[typing.TState] = None
+                           ) -> typing.Disposable:
         seconds = self.to_seconds(duetime)
         if seconds == 0:
-            return scheduler.schedule(action, state)
+            return self.schedule(action, state)
 
         sad = SingleAssignmentDisposable()
 
@@ -93,16 +123,19 @@ class AsyncIOScheduler(SchedulerBase):
 
         return CompositeDisposable(sad, Disposable(dispose))
 
-    def _schedule_relative_threadsafe(self, duetime, action, state=None):
-        scheduler = self
+    def _schedule_relative_threadsafe(self,
+                                      duetime: typing.RelativeTime,
+                                      action: typing.ScheduledAction,
+                                      state: Optional[typing.TState] = None
+                                      ) -> typing.Disposable:
         seconds = self.to_seconds(duetime)
         if seconds == 0:
-            return scheduler.schedule(action, state)
+            return self.schedule(action, state=state)
 
         sad = SingleAssignmentDisposable()
 
         def interval():
-            sad.disposable = self.invoke_action(action, state)
+            sad.disposable = self.invoke_action(action, state=state)
 
         # the operations on the list used here are atomic, so there is no
         # need to protect its access with a lock
@@ -129,15 +162,17 @@ class AsyncIOScheduler(SchedulerBase):
 
         return CompositeDisposable(sad, Disposable(dispose))
 
-    def schedule_absolute(self, duetime: typing.AbsoluteTime, action: typing.ScheduledAction,
-                          state: typing.TState = None) -> typing.Disposable:
+    def schedule_absolute(self,
+                          duetime: typing.AbsoluteTime,
+                          action: typing.ScheduledAction,
+                          state: Optional[typing.TState] = None
+                          ) -> typing.Disposable:
         """Schedules an action to be executed at duetime.
 
         Args:
-            duetime: Absolute time after which to execute the
-            action.
+            duetime: Absolute time after which to execute the action.
             action: Action to be executed.
-            state: Optional state to be given to the action function.
+            state: [Optional] state to be given to the action function.
 
         Returns:
             The disposable object used to cancel the scheduled action
@@ -145,7 +180,7 @@ class AsyncIOScheduler(SchedulerBase):
         """
 
         duetime = self.to_datetime(duetime)
-        return self.schedule_relative(duetime - self.now, action, state)
+        return self.schedule_relative(duetime - self.now, action, state=state)
 
     @property
     def now(self) -> datetime:
@@ -154,4 +189,4 @@ class AsyncIOScheduler(SchedulerBase):
         property.
         """
 
-        return self.to_datetime(self.loop.time()*1000)
+        return self.to_datetime(self.loop.time() * 1000)

--- a/rx/concurrency/mainloopscheduler/geventscheduler.py
+++ b/rx/concurrency/mainloopscheduler/geventscheduler.py
@@ -1,10 +1,16 @@
 import logging
 
-from rx.disposable import Disposable
-from rx.disposable import SingleAssignmentDisposable, CompositeDisposable
-from rx.concurrency.schedulerbase import SchedulerBase
+from datetime import datetime
+from typing import Optional
+
+from rx.core import typing
+from rx.disposable import CompositeDisposable, Disposable, SingleAssignmentDisposable
+
+from ..schedulerbase import SchedulerBase
+
 
 log = logging.getLogger("Rx")
+
 
 gevent = None
 
@@ -15,71 +21,96 @@ class GEventScheduler(SchedulerBase):
     http://www.gevent.org/
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         # Lazy import gevent
         global gevent
         import gevent
 
-    def schedule(self, action, state=None):
-        """Schedules an action to be executed."""
+    def schedule(self,
+                 action: typing.ScheduledAction,
+                 state: Optional[typing.TState] = None
+                 ) -> typing.Disposable:
+        """Schedules an action to be executed.
+
+        Args:
+            action: Action to be executed.
+            state: [Optional] state to be given to the action function.
+
+        Returns:
+            The disposable object used to cancel the scheduled action
+            (best effort).
+        """
 
         sad = SingleAssignmentDisposable()
 
         def interval():
-            sad.disposable = self.invoke_action(action, state)
+            sad.disposable = self.invoke_action(action, state=state)
 
-        timer = [gevent.spawn(interval)]
+        timer = gevent.spawn(interval)
 
         def dispose():
-            timer[0].kill()
+            timer.kill()
 
         return CompositeDisposable(sad, Disposable(dispose))
 
-    def schedule_relative(self, duetime, action, state=None):
+    def schedule_relative(self,
+                          duetime: typing.RelativeTime,
+                          action: typing.ScheduledAction,
+                          state: Optional[typing.TState] = None
+                          ) -> typing.Disposable:
         """Schedules an action to be executed after duetime.
 
-        Keyword arguments:
-        duetime -- {timedelta} Relative time after which to execute the action.
-        action -- {Function} Action to be executed.
+        Args:
+            duetime: Relative time after which to execute the action.
+            action: Action to be executed.
+            state: [Optional] state to be given to the action function.
 
-        Returns {Disposable} The disposable object used to cancel the scheduled
-        action (best effort)."""
+        Returns:
+            The disposable object used to cancel the scheduled action
+            (best effort).
+        """
 
-        scheduler = self
         seconds = self.to_seconds(duetime)
         if not seconds:
-            return scheduler.schedule(action, state)
+            return self.schedule(action, state=state)
 
         sad = SingleAssignmentDisposable()
 
         def interval():
-            sad.disposable = action(scheduler, state)
+            sad.disposable = self.invoke_action(action, state=state)
 
         log.debug("timeout: %s", seconds)
-        timer = [gevent.spawn_later(seconds, interval)]
+        timer = gevent.spawn_later(seconds, interval)
 
         def dispose():
-            # nonlocal timer
-            timer[0].kill()
+            timer.kill()
 
         return CompositeDisposable(sad, Disposable(dispose))
 
-    def schedule_absolute(self, duetime, action, state=None):
+    def schedule_absolute(self, duetime: typing.AbsoluteTime,
+                          action: typing.ScheduledAction,
+                          state: Optional[typing.TState] = None
+                          ) -> typing.Disposable:
         """Schedules an action to be executed at duetime.
 
-        Keyword arguments:
-        duetime -- {datetime} Absolute time after which to execute the action.
-        action -- {Function} Action to be executed.
+        Args:
+            duetime: Absolute time after which to execute the action.
+            action: Action to be executed.
+            state: [Optional] state to be given to the action function.
 
-        Returns {Disposable} The disposable object used to cancel the scheduled
-        action (best effort)."""
+        Returns:
+            The disposable object used to cancel the scheduled action
+            (best effort).
+        """
 
         duetime = self.to_datetime(duetime)
-        return self.schedule_relative(duetime - self.now, action, state)
+        return self.schedule_relative(duetime - self.now, action, state=state)
 
     @property
-    def now(self):
-        """Represents a notion of time for this scheduler. Tasks being scheduled
-        on a scheduler will adhere to the time denoted by this property."""
+    def now(self) -> datetime:
+        """Represents a notion of time for this scheduler. Tasks being
+        scheduled on a scheduler will adhere to the time denoted by this
+        property.
+        """
 
         return self.to_datetime(gevent.get_hub().loop.now())

--- a/rx/concurrency/mainloopscheduler/gtkscheduler.py
+++ b/rx/concurrency/mainloopscheduler/gtkscheduler.py
@@ -1,6 +1,9 @@
+from typing import Optional
+
 from rx.core import typing
-from rx.disposable import SingleAssignmentDisposable, CompositeDisposable, Disposable
-from rx.concurrency.schedulerbase import SchedulerBase
+from rx.disposable import CompositeDisposable, Disposable, SingleAssignmentDisposable
+
+from ..schedulerbase import SchedulerBase
 
 
 class GtkScheduler(SchedulerBase):
@@ -10,48 +13,70 @@ class GtkScheduler(SchedulerBase):
     See https://wiki.gnome.org/Projects/PyGObject
     """
 
-    def _gtk_schedule(self, time, action, state, periodic=False):
+    def _gtk_schedule(self,
+                      time: typing.AbsoluteOrRelativeTime,
+                      action: typing.ScheduledSingleOrPeriodicAction,
+                      state: Optional[typing.TState] = None,
+                      periodic: bool = False
+                      ) -> typing.Disposable:
         # Do not import GLib into global scope because Qt and GLib
         # don't like each other there
         from gi.repository import GLib
 
-        scheduler = self
-        msecs = int(self.to_seconds(time)*1000)
+        msecs = int(self.to_seconds(time) * 1000.0)
 
         sad = SingleAssignmentDisposable()
 
-        periodic_state = [state]
-        stopped = [False]
+        periodic_state = state
+        stopped = False
 
         def timer_handler(_):
-            if stopped[0]:
+            if stopped:
                 return False
 
             if periodic:
-                periodic_state[0] = action(periodic_state[0])
+                nonlocal periodic_state
+                periodic_state = action(periodic_state)
             else:
-                sad.disposable = action(scheduler, state)
+                sad.disposable = self.invoke_action(action, state=state)
 
             return periodic
 
         GLib.timeout_add(msecs, timer_handler, None)
 
         def dispose():
-            stopped[0] = True
+            nonlocal stopped
+            stopped = True
 
         return CompositeDisposable(sad, Disposable(dispose))
 
-    def schedule(self, action: typing.ScheduledAction, state: typing.TState = None) -> typing.Disposable:
-        """Schedules an action to be executed."""
-        return self._gtk_schedule(0, action, state)
+    def schedule(self,
+                 action: typing.ScheduledAction,
+                 state: Optional[typing.TState] = None
+                 ) -> typing.Disposable:
+        """Schedules an action to be executed.
 
-    def schedule_relative(self, duetime: typing.RelativeTime, action: typing.ScheduledAction,
-                          state: typing.TState = None) -> typing.Disposable:
+        Args:
+            action: Action to be executed.
+            state: [Optional] state to be given to the action function.
+
+        Returns:
+            The disposable object used to cancel the scheduled action
+            (best effort).
+        """
+        return self._gtk_schedule(0.0, action, state)
+
+    def schedule_relative(self,
+                          duetime: typing.RelativeTime,
+                          action: typing.ScheduledAction,
+                          state: Optional[typing.TState] = None
+                          ) -> typing.Disposable:
         """Schedules an action to be executed after duetime.
 
         Args:
-            duetime: {timedelta} Relative time after which to execute the action.
-            action: {Function} Action to be executed.
+            duetime: Relative time after which to execute the action.
+            action: Action to be executed.
+            state: [Optional] state to be given to the action function.
 
         Returns:
             The disposable object used to cancel the scheduled action
@@ -59,13 +84,17 @@ class GtkScheduler(SchedulerBase):
         """
         return self._gtk_schedule(duetime, action, state)
 
-    def schedule_absolute(self, duetime: typing.AbsoluteTime, action: typing.ScheduledAction,
-                          state: typing.TState = None) -> typing.Disposable:
+    def schedule_absolute(self,
+                          duetime: typing.AbsoluteTime,
+                          action: typing.ScheduledAction,
+                          state: Optional[typing.TState] = None
+                          ) -> typing.Disposable:
         """Schedules an action to be executed at duetime.
 
         Args:
-            duetime: {datetime} Absolute time after which to execute the action.
-            action: {Function} Action to be executed.
+            duetime: Absolute time after which to execute the action.
+            action: Action to be executed.
+            state: [Optional] state to be given to the action function.
 
         Returns:
             The disposable object used to cancel the scheduled action
@@ -75,21 +104,21 @@ class GtkScheduler(SchedulerBase):
         duetime = self.to_datetime(duetime)
         return self._gtk_schedule(duetime, action, state)
 
-    def schedule_periodic(self, period: typing.RelativeTime, action: typing.ScheduledPeriodicAction,
-                          state: typing.TState = None):
-        """Schedules a periodic piece of work to be executed in the Qt
-        mainloop.
+    def schedule_periodic(self,
+                          period: typing.RelativeTime,
+                          action: typing.ScheduledPeriodicAction,
+                          state: Optional[typing.TState] = None
+                          ) -> typing.Disposable:
+        """Schedules a periodic piece of work to be executed in the loop.
 
-        Args:
-            period: Period in milliseconds for running the work
-                periodically.
+       Args:
+            period: Period in seconds for running the work repeatedly.
             action: Action to be executed.
-            state: [Optional] Initial state passed to the action upon
-                the first iteration.
+            state: [Optional] state to be given to the action function.
 
         Returns:
-            The disposable object used to cancel the scheduled
-            recurring action (best effort).
+            The disposable object used to cancel the scheduled action
+            (best effort).
         """
 
-        return self._gtk_schedule(period, action, state, periodic=True)
+        return self._gtk_schedule(period, action, state=state, periodic=True)

--- a/rx/concurrency/mainloopscheduler/ioloopscheduler.py
+++ b/rx/concurrency/mainloopscheduler/ioloopscheduler.py
@@ -1,9 +1,12 @@
 import logging
 from datetime import datetime
+from typing import Any, Optional
 
-from rx.disposable import Disposable
-from rx.disposable import SingleAssignmentDisposable, CompositeDisposable
-from rx.concurrency.schedulerbase import SchedulerBase
+from rx.core import typing
+from rx.disposable import CompositeDisposable, Disposable, SingleAssignmentDisposable
+
+from ..schedulerbase import SchedulerBase
+
 
 log = logging.getLogger("Rx")
 
@@ -11,49 +14,69 @@ log = logging.getLogger("Rx")
 class IOLoopScheduler(SchedulerBase):
     """A scheduler that schedules work via the Tornado I/O main event loop.
 
+    Note, as of Tornado 6, this is just a wrapper around the asyncio loop.
+
     http://tornado.readthedocs.org/en/latest/ioloop.html"""
 
-    def __init__(self, loop=None):
-        from tornado import ioloop  # Lazy import
-        self.loop = loop or ioloop.IOLoop.current()
+    def __init__(self, loop: Optional[Any] = None) -> None:
+        from tornado import ioloop
+        self.loop: ioloop.IOLoop = loop or ioloop.IOLoop.current()
 
-    def schedule(self, action, state=None):
-        """Schedules an action to be executed."""
+    def schedule(self,
+                 action: typing.ScheduledAction,
+                 state: Optional[typing.TState] = None
+                 ) -> typing.Disposable:
+        """Schedules an action to be executed.
+
+        Args:
+            action: Action to be executed.
+            state: [Optional] state to be given to the action function.
+
+        Returns:
+            The disposable object used to cancel the scheduled action
+            (best effort).
+        """
 
         sad = SingleAssignmentDisposable()
-        disposed = [False]
+        disposed = False
 
         def interval():
-            if not disposed[0]:
-                sad.disposable = self.invoke_action(action, state)
+            if not disposed:
+                sad.disposable = self.invoke_action(action, state=state)
 
         self.loop.add_callback(interval)
 
         def dispose():
-            # nonlocal
-            disposed[0] = True
+            nonlocal disposed
+            disposed = True
 
         return CompositeDisposable(sad, Disposable(dispose))
 
-    def schedule_relative(self, duetime, action, state=None):
+    def schedule_relative(self,
+                          duetime: typing.RelativeTime,
+                          action: typing.ScheduledAction,
+                          state: Optional[typing.TState] = None
+                          ) -> typing.Disposable:
         """Schedules an action to be executed after duetime.
 
-        Keyword arguments:
-        duetime -- {timedelta} Relative time after which to execute the action.
-        action -- {Function} Action to be executed.
+        Args:
+            duetime: Relative time after which to execute the action.
+            action: Action to be executed.
+            state: [Optional] state to be given to the action function.
 
-        Returns {Disposable} The disposable object used to cancel the scheduled
-        action (best effort)."""
+        Returns:
+            The disposable object used to cancel the scheduled action
+            (best effort).
+        """
 
-        scheduler = self
-        seconds = scheduler.to_seconds(duetime)
+        seconds = self.to_seconds(duetime)
         if not seconds:
-            return scheduler.schedule(action, state)
+            return self.schedule(action, state=state)
 
         sad = SingleAssignmentDisposable()
 
         def interval():
-            sad.disposable = self.invoke_action(action, state)
+            sad.disposable = self.invoke_action(action, state=state)
 
         log.debug("timeout: %s", seconds)
         handle = self.loop.call_later(seconds, interval)
@@ -63,22 +86,31 @@ class IOLoopScheduler(SchedulerBase):
 
         return CompositeDisposable(sad, Disposable(dispose))
 
-    def schedule_absolute(self, duetime, action, state=None):
+    def schedule_absolute(self,
+                          duetime: typing.AbsoluteTime,
+                          action: typing.ScheduledAction,
+                          state: Optional[typing.TState] = None
+                          ) -> typing.Disposable:
         """Schedules an action to be executed at duetime.
 
-        Keyword arguments:
-        duetime -- {datetime} Absolute time after which to execute the action.
-        action -- {Function} Action to be executed.
+        Args:
+            duetime: Absolute time after which to execute the action.
+            action: Action to be executed.
+            state: [Optional] state to be given to the action function.
 
-        Returns {Disposable} The disposable object used to cancel the scheduled
-        action (best effort)."""
+        Returns:
+            The disposable object used to cancel the scheduled action
+            (best effort).
+        """
 
         duetime = self.to_datetime(duetime)
-        return self.schedule_relative(duetime - self.now, action, state)
+        return self.schedule_relative(duetime - self.now, action, state=state)
 
     @property
     def now(self) -> datetime:
-        """Represents a notion of time for this scheduler. Tasks being scheduled
-        on a scheduler will adhere to the time denoted by this property."""
+        """Represents a notion of time for this scheduler. Tasks being
+        scheduled on a scheduler will adhere to the time denoted by this
+        property.
+        """
 
         return self.to_datetime(self.loop.time())

--- a/rx/concurrency/mainloopscheduler/pygamescheduler.py
+++ b/rx/concurrency/mainloopscheduler/pygamescheduler.py
@@ -24,7 +24,7 @@ class PyGameScheduler(SchedulerBase):
         self.timer = None
         self.event_id = event_id or pygame.USEREVENT
 
-        self.queue = PriorityQueue()
+        self.queue: PriorityQueue[ScheduledItem[typing.TState]] = PriorityQueue()
 
     def schedule(self, action: typing.ScheduledAction, state: Any = None) -> typing.Disposable:
         """Schedules an action to be executed."""
@@ -34,7 +34,7 @@ class PyGameScheduler(SchedulerBase):
 
     def run(self) -> None:
         while self.queue:
-            item = self.queue.peek()
+            item: ScheduledItem[typing.TState] = self.queue.peek()
             diff = item.duetime - self.now
 
             if diff > timedelta(0):

--- a/rx/concurrency/mainloopscheduler/pygamescheduler.py
+++ b/rx/concurrency/mainloopscheduler/pygamescheduler.py
@@ -1,12 +1,12 @@
 import logging
-from datetime import timedelta, datetime
+from datetime import datetime
 from typing import Any
 import threading
 
 from rx.internal import PriorityQueue
 from rx.core import typing
 from rx.concurrency import ScheduledItem
-from rx.concurrency.schedulerbase import SchedulerBase
+from rx.concurrency.schedulerbase import SchedulerBase, DELTA_ZERO
 
 pygame = None
 log = logging.getLogger("Rx")
@@ -83,7 +83,7 @@ class PyGameScheduler(SchedulerBase):
                 item: ScheduledItem[typing.TState] = self.queue.peek()
                 diff = item.duetime - self.now
 
-                if diff > timedelta(0):
+                if diff > DELTA_ZERO:
                     break
 
                 item = self.queue.dequeue()

--- a/rx/concurrency/mainloopscheduler/pygamescheduler.py
+++ b/rx/concurrency/mainloopscheduler/pygamescheduler.py
@@ -1,46 +1,65 @@
 import logging
-from datetime import datetime
-from typing import Any
 import threading
+
+from datetime import datetime
+from typing import Optional
 
 from rx.internal import PriorityQueue
 from rx.core import typing
-from rx.concurrency import ScheduledItem
-from rx.concurrency.schedulerbase import SchedulerBase, DELTA_ZERO
+
+from ..scheduleditem import ScheduledItem
+from ..schedulerbase import SchedulerBase, DELTA_ZERO
+
 
 pygame = None
 log = logging.getLogger("Rx")
 
 
 class PyGameScheduler(SchedulerBase):
-    """A scheduler that schedules works for PyGame. Note that this class expects
-    the caller to invoke run() repeatedly.
+    """A scheduler that schedules works for PyGame.
+
+    Note that this class expects the caller to invoke run() repeatedly.
 
     http://www.pygame.org/docs/ref/time.html
     http://www.pygame.org/docs/ref/event.html"""
 
-    def __init__(self, event_id=None):
+    def __init__(self) -> None:
         global pygame
         import pygame
 
         self.timer = None
-        self.event_id = event_id or pygame.USEREVENT  # TODO not used?
         self.lock = threading.RLock()
         self.queue: PriorityQueue[ScheduledItem[typing.TState]] = PriorityQueue()
 
-    def schedule(self, action: typing.ScheduledAction, state: Any = None) -> typing.Disposable:
-        """Schedules an action to be executed."""
+    def schedule(self,
+                 action: typing.ScheduledAction,
+                 state: Optional[typing.TState] = None
+                 ) -> typing.Disposable:
+        """Schedules an action to be executed.
+
+        Args:
+            action: Action to be executed.
+            state: [Optional] state to be given to the action function.
+
+        Returns:
+            The disposable object used to cancel the scheduled action
+            (best effort).
+        """
 
         log.debug("PyGameScheduler.schedule(state=%s)", state)
-        return self.schedule_relative(0, action, state)
+        return self.schedule_relative(0.0, action, state=state)
 
-    def schedule_relative(self, duetime: typing.RelativeTime, action: typing.ScheduledAction,
-                          state: typing.TState = None) -> typing.Disposable:
+    def schedule_relative(self,
+                          duetime: typing.RelativeTime,
+                          action: typing.ScheduledAction,
+                          state: Optional[typing.TState] = None
+                          ) -> typing.Disposable:
         """Schedules an action to be executed after duetime.
 
         Args:
             duetime: Relative time after which to execute the action.
             action: Action to be executed.
+            state: [Optional] state to be given to the action function.
 
         Returns:
             The disposable object used to cancel the scheduled action
@@ -55,25 +74,31 @@ class PyGameScheduler(SchedulerBase):
 
         return si.disposable
 
-    def schedule_absolute(self, duetime: typing.AbsoluteTime, action: typing.ScheduledAction,
-                          state: typing.TState = None) -> typing.Disposable:
+    def schedule_absolute(self,
+                          duetime: typing.AbsoluteTime,
+                          action: typing.ScheduledAction,
+                          state: Optional[typing.TState] = None
+                          ) -> typing.Disposable:
         """Schedules an action to be executed at duetime.
 
         Args:
             duetime: Absolute time after which to execute the action.
             action: Action to be executed.
+            state: [Optional] state to be given to the action function.
 
         Returns:
             The disposable object used to cancel the scheduled action
-            (best effort)."""
+            (best effort).
+        """
 
-        return self.schedule_relative(duetime - self.now, action, state)
+        return self.schedule_relative(duetime - self.now, action, state=state)
 
     @property
     def now(self) -> datetime:
         """Represents a notion of time for this scheduler. Tasks being
-        scheduled on a scheduler will adhere to the time denoted by
-        this property."""
+        scheduled on a scheduler will adhere to the time denoted by this
+        property.
+        """
 
         return datetime.utcnow()
 

--- a/rx/concurrency/mainloopscheduler/qtscheduler.py
+++ b/rx/concurrency/mainloopscheduler/qtscheduler.py
@@ -105,7 +105,7 @@ class QtScheduler(SchedulerBase):
             The disposable object used to cancel the scheduled action
             (best effort).
         """
-        msecs = int(self.to_seconds(period)) * 1000
+        msecs = int(self.to_seconds(period) * 1000.0)
         sad = SingleAssignmentDisposable()
 
         periodic_state = state

--- a/rx/concurrency/mainloopscheduler/qtscheduler.py
+++ b/rx/concurrency/mainloopscheduler/qtscheduler.py
@@ -1,9 +1,12 @@
 import logging
 
-from rx.disposable import Disposable
+from typing import Optional
+
 from rx.core import typing
-from rx.disposable import SingleAssignmentDisposable, CompositeDisposable
-from rx.concurrency.schedulerbase import SchedulerBase
+from rx.disposable import CompositeDisposable, Disposable, SingleAssignmentDisposable
+
+from ..schedulerbase import SchedulerBase
+
 
 log = logging.getLogger(__name__)
 
@@ -15,30 +18,45 @@ class QtScheduler(SchedulerBase):
         self.qtcore = qtcore
         self._periodic_timers = set()
 
-    def schedule(self, action: typing.ScheduledAction, state: typing.TState = None) -> typing.Disposable:
-        """Schedules an action to be executed."""
-        return self.schedule_relative(0.0, action, state)
-
-    def schedule_relative(self, duetime: typing.RelativeTime, action: typing.ScheduledAction,
-                          state: typing.TState = None) -> typing.Disposable:
-        """Schedules an action to be executed after duetime.
+    def schedule(self,
+                 action: typing.ScheduledAction,
+                 state: Optional[typing.TState] = None
+                 ) -> typing.Disposable:
+        """Schedules an action to be executed.
 
         Args:
-            duetime: Relative time after which to execute the action.
             action: Action to be executed.
+            state: [Optional] state to be given to the action function.
 
         Returns:
             The disposable object used to cancel the scheduled action
             (best effort).
         """
-        scheduler = self
-        msecs = int(self.to_seconds(duetime)*1000.0)
+        return self.schedule_relative(0.0, action, state=state)
+
+    def schedule_relative(self,
+                          duetime: typing.RelativeTime,
+                          action: typing.ScheduledAction,
+                          state: Optional[typing.TState] = None
+                          ) -> typing.Disposable:
+        """Schedules an action to be executed after duetime.
+
+        Args:
+            duetime: Relative time after which to execute the action.
+            action: Action to be executed.
+            state: [Optional] state to be given to the action function.
+
+        Returns:
+            The disposable object used to cancel the scheduled action
+            (best effort).
+        """
+        msecs = int(self.to_seconds(duetime) * 1000.0)
         sad = SingleAssignmentDisposable()
         is_disposed = False
 
         def invoke_action():
             if not is_disposed:
-                sad.disposable = action(scheduler, state)
+                sad.disposable = action(self, state)
 
         log.debug("relative timeout: %sms", msecs)
 
@@ -51,13 +69,17 @@ class QtScheduler(SchedulerBase):
 
         return CompositeDisposable(sad, Disposable(dispose))
 
-    def schedule_absolute(self, duetime: typing.AbsoluteTime, action: typing.ScheduledAction,
-                          state: typing.TState = None) -> typing.Disposable:
+    def schedule_absolute(self,
+                          duetime: typing.AbsoluteTime,
+                          action: typing.ScheduledAction,
+                          state: Optional[typing.TState] = None
+                          ) -> typing.Disposable:
         """Schedules an action to be executed at duetime.
 
         Args:
             duetime: Absolute time after which to execute the action.
             action: Action to be executed.
+            state: [Optional] state to be given to the action function.
 
         Returns:
             The disposable object used to cancel the scheduled action
@@ -65,25 +87,25 @@ class QtScheduler(SchedulerBase):
         """
 
         duetime = self.to_datetime(duetime) - self.now
-        return self.schedule_relative(duetime, action, state)
+        return self.schedule_relative(duetime, action, state=state)
 
-    def schedule_periodic(self, period: typing.RelativeTime, action: typing.ScheduledPeriodicAction,
-                          state: typing.TState = None):
-        """Schedules a periodic piece of work to be executed in the Qt
-        mainloop.
+    def schedule_periodic(self,
+                          period: typing.RelativeTime,
+                          action: typing.ScheduledPeriodicAction,
+                          state: Optional[typing.TState] = None
+                          ) -> typing.Disposable:
+        """Schedules a periodic piece of work to be executed in the loop.
 
-        Args:
-            period: Period in milliseconds for running the work
-                periodically.
+       Args:
+            period: Period in seconds for running the work repeatedly.
             action: Action to be executed.
-            state: [Optional] Initial state passed to the action upon
-                the first iteration.
+            state: [Optional] state to be given to the action function.
 
         Returns:
-            The disposable object used to cancel the scheduled
-            recurring action (best effort).
+            The disposable object used to cancel the scheduled action
+            (best effort).
         """
-        msecs = int(self.to_seconds(period)*1000.0)
+        msecs = int(self.to_seconds(period)) * 1000
         sad = SingleAssignmentDisposable()
 
         periodic_state = state

--- a/rx/concurrency/mainloopscheduler/tkinterscheduler.py
+++ b/rx/concurrency/mainloopscheduler/tkinterscheduler.py
@@ -1,9 +1,9 @@
-from typing import Any
+from typing import Optional
 
-from rx.disposable import Disposable
 from rx.core import typing
-from rx.disposable import SingleAssignmentDisposable, CompositeDisposable
-from rx.concurrency.schedulerbase import SchedulerBase
+from rx.disposable import CompositeDisposable, Disposable, SingleAssignmentDisposable
+
+from ..schedulerbase import SchedulerBase
 
 
 class TkinterScheduler(SchedulerBase):
@@ -12,21 +12,37 @@ class TkinterScheduler(SchedulerBase):
     http://infohost.nmt.edu/tcc/help/pubs/tkinter/web/universal.html
     http://effbot.org/tkinterbook/widget.htm"""
 
-    def __init__(self, master):
+    def __init__(self, master) -> None:
         self.master = master
 
-    def schedule(self, action: typing.ScheduledAction, state: Any = None) -> typing.Disposable:
-        """Schedules an action to be executed."""
+    def schedule(self,
+                 action: typing.ScheduledAction,
+                 state: Optional[typing.TState] = None
+                 ) -> typing.Disposable:
+        """Schedules an action to be executed.
+
+        Args:
+            action: Action to be executed.
+            state: [Optional] state to be given to the action function.
+
+        Returns:
+            The disposable object used to cancel the scheduled action
+            (best effort).
+        """
 
         return self.schedule_relative(0.0, action, state)
 
-    def schedule_relative(self, duetime: typing.RelativeTime, action: typing.ScheduledAction,
-                          state: typing.TState = None) -> typing.Disposable:
+    def schedule_relative(self,
+                          duetime: typing.RelativeTime,
+                          action: typing.ScheduledAction,
+                          state: Optional[typing.TState] = None
+                          ) -> typing.Disposable:
         """Schedules an action to be executed after duetime.
 
         Args:
             duetime: Relative time after which to execute the action.
             action: Action to be executed.
+            state: [Optional] state to be given to the action function.
 
         Returns:
             The disposable object used to cancel the scheduled action
@@ -36,9 +52,9 @@ class TkinterScheduler(SchedulerBase):
         sad = SingleAssignmentDisposable()
 
         def invoke_action():
-            sad.disposable = self.invoke_action(action, state)
+            sad.disposable = self.invoke_action(action, state=state)
 
-        msecs = int(self.to_seconds(duetime)*1000.0)
+        msecs = int(self.to_seconds(duetime) * 1000.0)
         alarm = self.master.after(msecs, invoke_action)
 
         def dispose():
@@ -46,13 +62,17 @@ class TkinterScheduler(SchedulerBase):
 
         return CompositeDisposable(sad, Disposable(dispose))
 
-    def schedule_absolute(self, duetime: typing.AbsoluteTime, action: typing.ScheduledAction,
-                          state: typing.TState = None) -> typing.Disposable:
+    def schedule_absolute(self,
+                          duetime: typing.AbsoluteTime,
+                          action: typing.ScheduledAction,
+                          state: Optional[typing.TState] = None
+                          ) -> typing.Disposable:
         """Schedules an action to be executed at duetime.
 
         Args:
             duetime: Absolute time after which to execute the action.
             action: Action to be executed.
+            state: [Optional] state to be given to the action function.
 
         Returns:
             The disposable object used to cancel the scheduled action
@@ -60,4 +80,4 @@ class TkinterScheduler(SchedulerBase):
         """
 
         duetime = self.to_datetime(duetime)
-        return self.schedule_relative(duetime - self.now, action, state)
+        return self.schedule_relative(duetime - self.now, action, state=state)

--- a/rx/concurrency/mainloopscheduler/wxscheduler.py
+++ b/rx/concurrency/mainloopscheduler/wxscheduler.py
@@ -1,25 +1,24 @@
 import logging
-from typing import Any
+from typing import Optional
 
-from rx.disposable import Disposable
 from rx.core import typing
-from rx.disposable import SingleAssignmentDisposable, CompositeDisposable
-from rx.concurrency.schedulerbase import SchedulerBase
+from rx.disposable import CompositeDisposable, Disposable, SingleAssignmentDisposable
+
+from ..schedulerbase import SchedulerBase
 
 log = logging.getLogger("Rx")
 
 
 class WxScheduler(SchedulerBase):
-
     """A scheduler for a wxPython event loop."""
 
-    def __init__(self, wx):
+    def __init__(self, wx) -> None:
         self.wx = wx
         self._timers = set()
 
         class Timer(wx.Timer):
 
-            def __init__(self, callback):
+            def __init__(self, callback) -> None:
                 super(Timer, self).__init__()
                 self.callback = callback
 
@@ -28,7 +27,7 @@ class WxScheduler(SchedulerBase):
 
         self._timer_class = Timer
 
-    def cancel_all(self):
+    def cancel_all(self) -> None:
         """Cancel all scheduled actions.
 
         Should be called when destroying wx controls to prevent
@@ -37,20 +36,25 @@ class WxScheduler(SchedulerBase):
         for timer in self._timers:
             timer.Stop()
 
-    def _wxtimer_schedule(self, time, action, state, periodic=False):
+    def _wxtimer_schedule(self,
+                          time: typing.AbsoluteOrRelativeTime,
+                          action: typing.ScheduledSingleOrPeriodicAction,
+                          state: Optional[typing.TState] = None,
+                          periodic: bool = False
+                          ) -> typing.Disposable:
         scheduler = self
 
         sad = SingleAssignmentDisposable()
-
-        periodic_state = [state]
+        periodic_state = state
 
         def interval():
             if periodic:
-                periodic_state[0] = action(periodic_state[0])
+                nonlocal periodic_state
+                periodic_state = action(periodic_state)
             else:
                 sad.disposable = action(scheduler, state)
 
-        msecs = int(self.to_seconds(time)*1000.0)
+        msecs = int(self.to_seconds(time) * 1000.0)
         if msecs == 0:
             msecs = 1  # wx.Timer doesn't support zero.
 
@@ -69,55 +73,76 @@ class WxScheduler(SchedulerBase):
 
         return CompositeDisposable(sad, Disposable(dispose))
 
-    def schedule(self, action: typing.ScheduledAction, state: Any = None) -> typing.Disposable:
-        """Schedules an action to be executed."""
-
-        return self._wxtimer_schedule(0, action, state)
-
-    def schedule_relative(self, duetime: typing.RelativeTime, action: typing.ScheduledAction,
-                          state: typing.TState = None) -> typing.Disposable:
-        """Schedules an action to be executed after duetime.
+    def schedule(self,
+                 action: typing.ScheduledAction,
+                 state: Optional[typing.TState] = None
+                 ) -> typing.Disposable:
+        """Schedules an action to be executed.
 
         Args:
-            duetime: Relative time after which to execute the action.
             action: Action to be executed.
+            state: [Optional] state to be given to the action function.
 
         Returns:
             The disposable object used to cancel the scheduled action
             (best effort).
         """
-        return self._wxtimer_schedule(duetime, action, state)
 
-    def schedule_absolute(self, duetime: typing.AbsoluteTime, action: typing.ScheduledAction,
-                          state: typing.TState = None) -> typing.Disposable:
+        return self._wxtimer_schedule(0.0, action, state=state)
+
+    def schedule_relative(self,
+                          duetime: typing.RelativeTime,
+                          action: typing.ScheduledAction,
+                          state: Optional[typing.TState] = None
+                          ) -> typing.Disposable:
+        """Schedules an action to be executed after duetime.
+
+        Args:
+            duetime: Relative time after which to execute the action.
+            action: Action to be executed.
+            state: [Optional] state to be given to the action function.
+
+        Returns:
+            The disposable object used to cancel the scheduled action
+            (best effort).
+        """
+        return self._wxtimer_schedule(duetime, action, state=state)
+
+    def schedule_absolute(self,
+                          duetime: typing.AbsoluteTime,
+                          action: typing.ScheduledAction,
+                          state: Optional[typing.TState] = None
+                          ) -> typing.Disposable:
         """Schedules an action to be executed at duetime.
 
         Args:
             duetime: Absolute time after which to execute the action.
             action: Action to be executed.
+            state: [Optional] state to be given to the action function.
 
         Returns:
-            The disposable object used to cancel the scheduled
-        action (best effort).
+            The disposable object used to cancel the scheduled action
+            (best effort).
         """
 
         duetime = self.to_datetime(duetime)
-        return self._wxtimer_schedule(duetime, action, state)
+        return self._wxtimer_schedule(duetime, action, state=state)
 
-    def schedule_periodic(self, period: typing.RelativeTime, action: typing.ScheduledPeriodicAction,
-                          state: typing.TState = None):
-        """Schedules a periodic piece of work to be executed in the Qt
-        mainloop.
+    def schedule_periodic(self,
+                          period: typing.RelativeTime,
+                          action: typing.ScheduledPeriodicAction,
+                          state: Optional[typing.TState] = None
+                          ) -> typing.Disposable:
+        """Schedules a periodic piece of work to be executed in the loop.
 
-        Args:
-            period: Period in milliseconds for running the work
-                periodically.
+       Args:
+            period: Period in seconds for running the work repeatedly.
             action: Action to be executed.
-            state: [Optional] Initial state passed to the action upon
-                the first iteration.
+            state: [Optional] state to be given to the action function.
 
         Returns:
-            The disposable object used to cancel the scheduled
-            recurring action (best effort)."""
+            The disposable object used to cancel the scheduled action
+            (best effort).
+        """
 
-        return self._wxtimer_schedule(period, action, state, periodic=True)
+        return self._wxtimer_schedule(period, action, state=state, periodic=True)

--- a/rx/concurrency/newthreadscheduler.py
+++ b/rx/concurrency/newthreadscheduler.py
@@ -1,12 +1,13 @@
 import time
 import logging
-import threading
 from typing import List
 
 from rx.disposable import Disposable
 from rx.core import typing
-from .schedulerbase import SchedulerBase
+from rx.internal.concurrency import default_thread_factory
+
 from .eventloopscheduler import EventLoopScheduler
+from .schedulerbase import SchedulerBase
 
 log = logging.getLogger('Rx')
 
@@ -15,15 +16,9 @@ class NewThreadScheduler(SchedulerBase):
     """Creates an object that schedules each unit of work on a separate thread.
     """
 
-    def __init__(self, thread_factory=None) -> None:
+    def __init__(self, thread_factory: typing.StartableFactory = None) -> None:
         super(NewThreadScheduler, self).__init__()
-
-        def default_factory(target, args=None) -> threading.Thread:
-            t = threading.Thread(target=target, args=args or [])
-            t.setDaemon(True)
-            return t
-
-        self.thread_factory = thread_factory or default_factory
+        self.thread_factory = thread_factory or default_thread_factory
 
     def schedule(self, action: typing.ScheduledAction, state: typing.TState = None) -> typing.Disposable:
         """Schedules an action to be executed."""

--- a/rx/concurrency/scheduleditem.py
+++ b/rx/concurrency/scheduleditem.py
@@ -20,7 +20,7 @@ class ScheduledItem(Generic[typing.TState]):  # pylint: disable=unsubscriptable-
         self.disposable = SingleAssignmentDisposable()
 
     def invoke(self) -> None:
-        ret = self.scheduler.invoke_action(self.action, self.state)
+        ret = self.scheduler.invoke_action(self.action, state=self.state)
         self.disposable.disposable = ret
 
     def cancel(self) -> None:

--- a/rx/concurrency/schedulerbase.py
+++ b/rx/concurrency/schedulerbase.py
@@ -7,6 +7,10 @@ from rx.disposable import Disposable, MultipleAssignmentDisposable
 from rx.internal.basic import default_now
 
 
+DELTA_ZERO = timedelta(0)
+UTC_ZERO = datetime.utcfromtimestamp(0)
+
+
 class SchedulerBase(typing.Scheduler):
     """Provides a set of static properties to access commonly used
     schedulers.
@@ -75,7 +79,7 @@ class SchedulerBase(typing.Scheduler):
         """Converts time value to seconds"""
 
         if isinstance(timespan, datetime):
-            timespan = timespan - datetime.utcfromtimestamp(0)
+            timespan = timespan - UTC_ZERO
             timespan = timespan.total_seconds()
         elif isinstance(timespan, timedelta):
             timespan = timespan.total_seconds()
@@ -87,7 +91,7 @@ class SchedulerBase(typing.Scheduler):
         """Converts time value to datetime"""
 
         if isinstance(duetime, timedelta):
-            duetime = datetime.utcfromtimestamp(0) + duetime
+            duetime = UTC_ZERO + duetime
         elif not isinstance(duetime, datetime):
             duetime = datetime.utcfromtimestamp(duetime)
 
@@ -98,7 +102,7 @@ class SchedulerBase(typing.Scheduler):
         """Converts time value to timedelta"""
 
         if isinstance(timespan, datetime):
-            timespan = timespan - datetime.utcfromtimestamp(0)
+            timespan = timespan - UTC_ZERO
         elif not isinstance(timespan, timedelta):
             timespan = timedelta(seconds=timespan)
 
@@ -117,9 +121,8 @@ class SchedulerBase(typing.Scheduler):
         """
 
         if isinstance(timespan, timedelta):
-            nospan = timedelta(0)
-            if not timespan or timespan < nospan:
-                return nospan
+            if not timespan or timespan < DELTA_ZERO:
+                return DELTA_ZERO
 
         elif isinstance(timespan, float):
             if not timespan or timespan < 0.0:

--- a/rx/concurrency/threadpoolscheduler.py
+++ b/rx/concurrency/threadpoolscheduler.py
@@ -1,12 +1,13 @@
 from concurrent.futures import ThreadPoolExecutor
 
+from rx.core.abc import Startable
 from .newthreadscheduler import NewThreadScheduler
 
 
 class ThreadPoolScheduler(NewThreadScheduler):
     """A scheduler that schedules work via the thread pool."""
 
-    class ThreadPoolThread:
+    class ThreadPoolThread(Startable):
         """Wraps a concurrent future as a thread."""
 
         def __init__(self, executor, run):
@@ -23,7 +24,7 @@ class ThreadPoolScheduler(NewThreadScheduler):
     def __init__(self, max_workers=None):
         self.executor = ThreadPoolExecutor(max_workers=max_workers)
 
-        def thread_factory(target, *args):
+        def thread_factory(target):
             return self.ThreadPoolThread(self.executor, target)
 
         super().__init__(thread_factory)

--- a/rx/concurrency/timeoutscheduler.py
+++ b/rx/concurrency/timeoutscheduler.py
@@ -1,10 +1,9 @@
 from threading import Timer
-from datetime import timedelta
 
 from rx.core import typing
 from rx.disposable import SingleAssignmentDisposable, CompositeDisposable, Disposable
 
-from .schedulerbase import SchedulerBase
+from .schedulerbase import SchedulerBase, DELTA_ZERO
 
 
 class TimeoutScheduler(SchedulerBase):
@@ -31,7 +30,7 @@ class TimeoutScheduler(SchedulerBase):
 
         scheduler = self
         timespan = self.to_timedelta(duetime)
-        if timespan == timedelta(0):
+        if timespan == DELTA_ZERO:
             return scheduler.schedule(action, state)
 
         sad = SingleAssignmentDisposable()

--- a/rx/concurrency/virtualtimescheduler.py
+++ b/rx/concurrency/virtualtimescheduler.py
@@ -28,7 +28,7 @@ class VirtualTimeScheduler(SchedulerBase):
         self.clock = initial_clock
 
         self.is_enabled = False
-        self.queue = PriorityQueue()
+        self.queue: PriorityQueue[ScheduledItem[typing.TState]] = PriorityQueue()
 
         super().__init__()
 
@@ -78,7 +78,7 @@ class VirtualTimeScheduler(SchedulerBase):
 
         spinning = 0
         while self.is_enabled:
-            item = self.get_next()
+            item: ScheduledItem[typing.TState] = self.get_next()
             if not item:
                 break
 
@@ -169,7 +169,7 @@ class VirtualTimeScheduler(SchedulerBase):
         """Returns the next scheduled item to be executed."""
 
         while self.queue:
-            item = self.queue.dequeue()
+            item: ScheduledItem[typing.TState] = self.queue.dequeue()
             if not item.is_cancelled():
                 return item
 

--- a/rx/concurrency/virtualtimescheduler.py
+++ b/rx/concurrency/virtualtimescheduler.py
@@ -28,7 +28,7 @@ class VirtualTimeScheduler(SchedulerBase):
         self.clock = initial_clock
 
         self.is_enabled = False
-        self.queue = PriorityQueue(1024)
+        self.queue = PriorityQueue()
 
         super().__init__()
 

--- a/rx/core/abc/__init__.py
+++ b/rx/core/abc/__init__.py
@@ -2,4 +2,5 @@ from .disposable import Disposable
 from .observable import Observable
 from .observer import Observer
 from .scheduler import Scheduler
+from .startable import Startable
 from .subject import Subject

--- a/rx/core/abc/startable.py
+++ b/rx/core/abc/startable.py
@@ -1,0 +1,10 @@
+from abc import ABC, abstractmethod
+
+
+class Startable(ABC):
+    """Abstract base class for Thread- and Process-like objects."""
+    __slots__ = ()
+
+    @abstractmethod
+    def start(self):
+        raise NotImplementedError

--- a/rx/core/typing.py
+++ b/rx/core/typing.py
@@ -1,6 +1,7 @@
 from abc import abstractmethod
-from typing import Generic, TypeVar, Callable, Any, Union, Optional
+from typing import Any, Callable, Generic, Optional, Tuple, TypeVar, Union
 from datetime import datetime, timedelta
+from threading import Thread
 
 from . import abc
 
@@ -60,6 +61,11 @@ class Scheduler(abc.Scheduler):
     @abstractmethod
     def schedule_absolute(self, duetime: AbsoluteTime, action: ScheduledAction, state: TState = None) -> Disposable:
         return NotImplemented
+
+
+Startable = Union[abc.Startable, Thread]
+StartableTarget = Callable[..., None]
+StartableFactory = Callable[[StartableTarget, Optional[Tuple]], Startable]
 
 
 class Observer(Generic[T_in], abc.Observer):

--- a/rx/core/typing.py
+++ b/rx/core/typing.py
@@ -40,7 +40,7 @@ class Disposable(abc.Disposable):
 
 ScheduledAction = Callable[['Scheduler', TState], Optional[Disposable]]
 ScheduledPeriodicAction = Callable[[TState], TState]
-
+ScheduledSingleOrPeriodicAction = Union[ScheduledAction, ScheduledPeriodicAction]
 
 class Scheduler(abc.Scheduler):
     __slots__ = ()

--- a/rx/internal/concurrency.py
+++ b/rx/internal/concurrency.py
@@ -1,3 +1,13 @@
+from threading import Thread
+from typing import Optional, Tuple
+
+from rx.core.typing import StartableTarget
+
+
+def default_thread_factory(target: StartableTarget, args: Optional[Tuple] = None) -> Thread:
+    return Thread(target=target, args=args or (), daemon=True)
+
+
 def synchronized(lock):
     """A decorator for synchronizing access to a given function."""
 

--- a/rx/internal/priorityqueue.py
+++ b/rx/internal/priorityqueue.py
@@ -47,3 +47,8 @@ class PriorityQueue(Generic[T1]):
                 return True
 
         return False
+
+    def clear(self):
+        """Remove all items from the queue."""
+        self.items = []
+        self.count = PriorityQueue.MIN_COUNT

--- a/rx/internal/priorityqueue.py
+++ b/rx/internal/priorityqueue.py
@@ -1,18 +1,15 @@
 import heapq
 from typing import Generic, List
-from threading import RLock
 
 from rx.core.typing import T1
 
 
 class PriorityQueue(Generic[T1]):
-    """Priority queue for scheduling"""
+    """Priority queue for scheduling. Note that methods aren't thread-safe."""
 
     def __init__(self) -> None:
         self.items: List[T1] = []
         self.count = 0  # Monotonic increasing for sort stability
-
-        self.lock = RLock()
 
     def __len__(self):
         """Returns length of queue"""
@@ -26,25 +23,21 @@ class PriorityQueue(Generic[T1]):
     def dequeue(self) -> T1:
         """Returns and removes item with lowest priority from queue"""
 
-        with self.lock:
-            item = heapq.heappop(self.items)[0]
-        return item
+        return heapq.heappop(self.items)[0]
 
     def enqueue(self, item: T1) -> None:
         """Adds item to queue"""
 
-        with self.lock:
-            heapq.heappush(self.items, (item, self.count))
-            self.count += 1
+        heapq.heappush(self.items, (item, self.count))
+        self.count += 1
 
     def remove(self, item: T1) -> bool:
         """Remove given item from queue"""
 
-        with self.lock:
-            for index, _item in enumerate(self.items):
-                if _item[0] == item:
-                    self.items.pop(index)
-                    heapq.heapify(self.items)
-                    return True
+        for index, _item in enumerate(self.items):
+            if _item[0] == item:
+                self.items.pop(index)
+                heapq.heapify(self.items)
+                return True
 
         return False

--- a/rx/internal/priorityqueue.py
+++ b/rx/internal/priorityqueue.py
@@ -1,13 +1,15 @@
 import heapq
-from typing import List, Any
+from typing import Generic, List
 from threading import RLock
 
+from rx.core.typing import T1
 
-class PriorityQueue:
+
+class PriorityQueue(Generic[T1]):
     """Priority queue for scheduling"""
 
     def __init__(self) -> None:
-        self.items: List[Any] = []
+        self.items: List[T1] = []
         self.count = 0  # Monotonic increasing for sort stability
 
         self.lock = RLock()
@@ -17,25 +19,25 @@ class PriorityQueue:
 
         return len(self.items)
 
-    def peek(self) -> Any:
+    def peek(self) -> T1:
         """Returns first item in queue without removing it"""
         return self.items[0][0]
 
-    def dequeue(self) -> Any:
+    def dequeue(self) -> T1:
         """Returns and removes item with lowest priority from queue"""
 
         with self.lock:
             item = heapq.heappop(self.items)[0]
         return item
 
-    def enqueue(self, item: Any) -> None:
+    def enqueue(self, item: T1) -> None:
         """Adds item to queue"""
 
         with self.lock:
             heapq.heappush(self.items, (item, self.count))
             self.count += 1
 
-    def remove(self, item: Any) -> bool:
+    def remove(self, item: T1) -> bool:
         """Remove given item from queue"""
 
         with self.lock:

--- a/rx/internal/priorityqueue.py
+++ b/rx/internal/priorityqueue.py
@@ -26,14 +26,6 @@ class PriorityQueue:
         except IndexError:
             raise InvalidOperationException("Queue is empty")
 
-    def remove_at(self, index: int) -> Any:
-        """Removes item at given index"""
-
-        with self.lock:
-            item = self.items.pop(index)[0]
-            heapq.heapify(self.items)
-        return item
-
     def dequeue(self) -> Any:
         """Returns and removes item with lowest priority from queue"""
 

--- a/rx/internal/priorityqueue.py
+++ b/rx/internal/priorityqueue.py
@@ -8,7 +8,7 @@ from rx.internal.exceptions import InvalidOperationException
 class PriorityQueue:
     """Priority queue for scheduling"""
 
-    def __init__(self, capacity=None) -> None:
+    def __init__(self) -> None:
         self.items: List[Any] = []
         self.count = 0  # Monotonic increasing for sort stability
 

--- a/rx/internal/priorityqueue.py
+++ b/rx/internal/priorityqueue.py
@@ -1,4 +1,5 @@
 import heapq
+from sys import maxsize
 from typing import Generic, List
 
 from rx.core.typing import T1
@@ -7,9 +8,11 @@ from rx.core.typing import T1
 class PriorityQueue(Generic[T1]):
     """Priority queue for scheduling. Note that methods aren't thread-safe."""
 
+    MIN_COUNT = ~maxsize
+
     def __init__(self) -> None:
         self.items: List[T1] = []
-        self.count = 0  # Monotonic increasing for sort stability
+        self.count = PriorityQueue.MIN_COUNT  # Monotonic increasing for sort stability
 
     def __len__(self):
         """Returns length of queue"""
@@ -23,7 +26,10 @@ class PriorityQueue(Generic[T1]):
     def dequeue(self) -> T1:
         """Returns and removes item with lowest priority from queue"""
 
-        return heapq.heappop(self.items)[0]
+        item: T1 = heapq.heappop(self.items)[0]
+        if not self.items:
+            self.count = PriorityQueue.MIN_COUNT
+        return item
 
     def enqueue(self, item: T1) -> None:
         """Adds item to queue"""

--- a/rx/internal/priorityqueue.py
+++ b/rx/internal/priorityqueue.py
@@ -2,8 +2,6 @@ import heapq
 from typing import List, Any
 from threading import RLock
 
-from rx.internal.exceptions import InvalidOperationException
-
 
 class PriorityQueue:
     """Priority queue for scheduling"""
@@ -21,10 +19,7 @@ class PriorityQueue:
 
     def peek(self) -> Any:
         """Returns first item in queue without removing it"""
-        try:
-            return self.items[0][0]
-        except IndexError:
-            raise InvalidOperationException("Queue is empty")
+        return self.items[0][0]
 
     def dequeue(self) -> Any:
         """Returns and removes item with lowest priority from queue"""

--- a/tests/test_concurrency/test_currentthreadscheduler.py
+++ b/tests/test_concurrency/test_currentthreadscheduler.py
@@ -16,17 +16,32 @@ class TestCurrentThreadScheduler(unittest.TestCase):
         res = scheduler.now - datetime.utcnow()
         assert res < timedelta(milliseconds=1000)
 
-    def test_currentthread_scheduleaction(self):
+    def test_currentthread_schedule(self):
         scheduler = CurrentThreadScheduler()
-        ran = [False]
+        ran = False
 
         def action(scheduler, state=None):
-            ran[0] = True
+            nonlocal ran
+            ran = True
 
         scheduler.schedule(action)
-        assert ran[0] is True
+        assert ran is True
 
-    def test_currentthread_scheduleactionerror(self):
+    def test_currentthread_schedule_block(self):
+        scheduler = CurrentThreadScheduler()
+        ran = False
+
+        def action(scheduler, state=None):
+            nonlocal ran
+            ran = True
+
+        t = scheduler.now
+        scheduler.schedule_relative(0.2, action)
+        t = scheduler.now - t
+        assert ran is True
+        assert t >= timedelta(seconds=0.2)
+
+    def test_currentthread_schedule_error(self):
         scheduler = CurrentThreadScheduler()
 
         class MyException(Exception):
@@ -35,72 +50,82 @@ class TestCurrentThreadScheduler(unittest.TestCase):
         def action(scheduler, state=None):
             raise MyException()
 
+        exc = None
         try:
-            return scheduler.schedule(action)
-        except MyException:
-            assert True
+            scheduler.schedule(action)
+        except Exception as e:
+            exc = e
+        finally:
+            assert isinstance(exc, MyException)
 
-    def test_currentthread_scheduleactionnested(self):
+    def test_currentthread_schedule_nested(self):
         scheduler = CurrentThreadScheduler()
-        ran = [False]
+        ran = False
 
         def action(scheduler, state=None):
             def inner_action(scheduler, state=None):
-                ran[0] = True
+                nonlocal ran
+                ran = True
 
             return scheduler.schedule(inner_action)
         scheduler.schedule(action)
 
-        assert ran[0] == True
+        assert ran is True
 
     def test_currentthread_ensuretrampoline(self):
         scheduler = CurrentThreadScheduler()
-        ran1, ran2 = [False], [False]
+        ran1, ran2 = False, False
 
         def outer_action(scheduer, state=None):
             def action1(scheduler, state=None):
-                ran1[0] = True
+                nonlocal ran1
+                ran1 = True
 
             scheduler.schedule(action1)
 
             def action2(scheduler, state=None):
-                ran2[0] = True
+                nonlocal ran2
+                ran2 = True
 
             return scheduler.schedule(action2)
 
         scheduler.ensure_trampoline(outer_action)
-        assert ran1[0] == True
-        assert ran2[0] == True
+        assert ran1 is True
+        assert ran2 is True
 
     def test_currentthread_ensuretrampoline_nested(self):
         scheduler = CurrentThreadScheduler()
-        ran1, ran2 = [False], [False]
+        ran1, ran2 = False, False
 
         def outer_action(scheduler, state):
             def inner_action1(scheduler, state):
-                ran1[0] = True
+                nonlocal ran1
+                ran1 = True
 
             scheduler.ensure_trampoline(inner_action1)
 
             def inner_action2(scheduler, state):
-                ran2[0] = True
+                nonlocal ran2
+                ran2 = True
 
             return scheduler.ensure_trampoline(inner_action2)
 
         scheduler.ensure_trampoline(outer_action)
-        assert ran1[0] == True
-        assert ran2[0] == True
+        assert ran1 is True
+        assert ran2 is True
 
     def test_currentthread_ensuretrampoline_and_cancel(self):
         scheduler = CurrentThreadScheduler()
-        ran1, ran2 = [False], [False]
+        ran1, ran2 = False, False
 
         def outer_action(scheduler, state):
             def inner_action1(scheduler, state):
-                ran1[0] = True
+                nonlocal ran1
+                ran1 = True
 
                 def inner_action2(scheduler, state):
-                    ran2[0] = True
+                    nonlocal ran2
+                    ran2 = True
 
                 d = scheduler.schedule(inner_action2)
                 d.dispose()
@@ -108,25 +133,28 @@ class TestCurrentThreadScheduler(unittest.TestCase):
             return scheduler.schedule(inner_action1)
 
         scheduler.ensure_trampoline(outer_action)
-        assert ran1[0] == True
-        assert ran2[0] == False
+        assert ran1 is True
+        assert ran2 is False
 
     def test_currentthread_ensuretrampoline_and_canceltimed(self):
         scheduler = CurrentThreadScheduler()
-        ran1, ran2 = [False], [False]
+        ran1, ran2 = False, False
 
         def outer_action(scheduler, state):
             def inner_action1(scheduler, state):
-                ran1[0] = True
+                nonlocal ran1
+                ran1 = True
 
                 def inner_action2(scheduler, state):
-                    ran2[0] = True
+                    nonlocal ran2
+                    ran2 = True
 
-                d = scheduler.schedule_relative(timedelta(milliseconds=500), inner_action2)
+                t = scheduler.now + timedelta(seconds=0.5)
+                d = scheduler.schedule_absolute(t, inner_action2)
                 d.dispose()
 
             return scheduler.schedule(inner_action1)
 
         scheduler.ensure_trampoline(outer_action)
-        assert ran1[0] == True
-        assert ran2[0] == False
+        assert ran1 is True
+        assert ran2 is False

--- a/tests/test_concurrency/test_currentthreadscheduler.py
+++ b/tests/test_concurrency/test_currentthreadscheduler.py
@@ -6,6 +6,11 @@ from rx.concurrency import CurrentThreadScheduler
 
 class TestCurrentThreadScheduler(unittest.TestCase):
 
+    def test_currentthread_singleton(self):
+        scheduler1 = CurrentThreadScheduler()
+        scheduler2 = CurrentThreadScheduler()
+        assert scheduler1 is scheduler2
+
     def test_currentthread_now(self):
         scheduler = CurrentThreadScheduler()
         res = scheduler.now - datetime.utcnow()

--- a/tests/test_concurrency/test_eventloopscheduler.py
+++ b/tests/test_concurrency/test_eventloopscheduler.py
@@ -2,40 +2,47 @@ import unittest
 
 from datetime import datetime, timedelta
 import threading
+from time import sleep
 from rx.concurrency import EventLoopScheduler
+from rx.internal import DisposedException
 
 
 class TestEventLoopScheduler(unittest.TestCase):
     def test_event_loop_now(self):
         scheduler = EventLoopScheduler()
         res = scheduler.now - datetime.utcnow()
+
         assert res < timedelta(microseconds=1000)
 
     def test_event_loop_schedule_action(self):
         scheduler = EventLoopScheduler(exit_if_empty=True)
-        ran = [False]
+        ran = False
         gate = threading.Semaphore(0)
 
         def action(scheduler, state):
-            ran[0] = True
+            nonlocal ran
+            ran = True
             gate.release()
 
         scheduler.schedule(action)
         gate.acquire()
-        assert (ran[0] is True)
+        assert ran is True
+        assert scheduler._has_thread() is False
 
     def test_event_loop_different_thread(self):
-        thread_id = [None]
+        thread_id = None
         scheduler = EventLoopScheduler(exit_if_empty=True)
         gate = threading.Semaphore(0)
 
         def action(scheduler, state):
-            thread_id[0] = threading.current_thread().ident
+            nonlocal thread_id
+            thread_id = threading.current_thread().ident
             gate.release()
 
         scheduler.schedule(action)
         gate.acquire()
-        assert (thread_id[0] != threading.current_thread().ident)
+        assert thread_id != threading.current_thread().ident
+        assert scheduler._has_thread() is False
 
     def test_event_loop_schedule_ordered_actions(self):
         scheduler = EventLoopScheduler(exit_if_empty=True)
@@ -50,39 +57,174 @@ class TestEventLoopScheduler(unittest.TestCase):
 
         scheduler.schedule(action)
         gate.acquire()
-        assert (result == [1, 2])
+        assert result == [1, 2]
+        assert scheduler._has_thread() is False
 
-    def test_event_loop_schedule_action_due(self):
+    def test_event_loop_schedule_ordered_actions_due(self):
+        scheduler = EventLoopScheduler(exit_if_empty=True)
+        gate = threading.Semaphore(0)
+        result = []
+
+        def action(scheduler, state):
+            result.append(3)
+            gate.release()
+
+        scheduler.schedule_relative(0.10, action)
+        scheduler.schedule_relative(0.05, lambda s, t: result.append(2))
+        scheduler.schedule(lambda s, t: result.append(1))
+
+        gate.acquire()
+        assert result == [1, 2, 3]
+        assert scheduler._has_thread() is False
+
+    def test_event_loop_schedule_ordered_actions_due_mixed(self):
+        scheduler = EventLoopScheduler(exit_if_empty=True)
+        gate = threading.Semaphore(0)
+        result = []
+
+        def action(scheduler, state):
+            result.append(1)
+            scheduler.schedule(action2)
+            scheduler.schedule_relative(0.10, action3)
+            sleep(0.10)
+
+        def action2(scheduler, state):
+            result.append(2)
+
+        def action3(scheduler, state):
+            result.append(3)
+            gate.release()
+
+        scheduler.schedule(action)
+
+        gate.acquire()
+        assert result == [1, 2, 3]
+        assert scheduler._has_thread() is False
+
+    def test_event_loop_schedule_action_relative_due(self):
         scheduler = EventLoopScheduler(exit_if_empty=True)
         gate = threading.Semaphore(0)
         starttime = datetime.utcnow()
-        endtime = [None]
+        endtime = None
 
         def action(scheduler, state):
-            endtime[0] = datetime.utcnow()
+            nonlocal endtime
+            endtime = datetime.utcnow()
             gate.release()
 
         scheduler.schedule_relative(timedelta(milliseconds=200), action)
         gate.acquire()
-        diff = endtime[0]-starttime
-        assert(diff > timedelta(milliseconds=180))
+        diff = endtime - starttime
+        assert diff > timedelta(milliseconds=180)
+        assert scheduler._has_thread() is False
+
+    def test_event_loop_schedule_action_absolute_due(self):
+        scheduler = EventLoopScheduler(exit_if_empty=True)
+        gate = threading.Semaphore(0)
+        starttime = datetime.utcnow()
+        endtime = None
+
+        def action(scheduler, state):
+            nonlocal endtime
+            endtime = datetime.utcnow()
+            gate.release()
+
+        scheduler.schedule_absolute(scheduler.now, action)
+        gate.acquire()
+        diff = endtime - starttime
+        assert diff < timedelta(milliseconds=180)
+        assert scheduler._has_thread() is False
 
     def test_eventloop_schedule_action_periodic(self):
-        scheduler = EventLoopScheduler()
+        scheduler = EventLoopScheduler(exit_if_empty=False)
         gate = threading.Semaphore(0)
-        period = 0.050
-        counter = [3]
+        period = 0.05
+        counter = 3
 
         def action(state):
+            nonlocal counter
             if state:
-                counter[0] -= 1
+                counter -= 1
                 return state - 1
-            if counter[0] == 0:
+            if counter == 0:
                 gate.release()
 
-        scheduler.schedule_periodic(period, action, counter[0])
+        disp = scheduler.schedule_periodic(period, action, counter)
 
-        def done():
-            assert counter[0] == 0
+        def dispose(scheduler, state):
+            disp.dispose()
+            gate.release()
 
         gate.acquire()
+        assert counter == 0
+        assert scheduler._has_thread() is True
+        scheduler.schedule(dispose)
+        gate.acquire()
+        assert scheduler._has_thread() is True
+        sleep(period)
+        scheduler.dispose()
+        sleep(period)
+        assert scheduler._has_thread() is False
+
+    def test_eventloop_schedule_dispose(self):
+        scheduler = EventLoopScheduler(exit_if_empty=False)
+
+        scheduler.dispose()
+
+        ran = False
+
+        def action(scheduler, state):
+            nonlocal ran
+            ran = True
+
+        exc = None
+        try:
+            scheduler.schedule(action)
+        except Exception as e:
+            exc = e
+        finally:
+            assert isinstance(exc, DisposedException)
+            assert ran is False
+            assert scheduler._has_thread() is False
+
+    def test_eventloop_schedule_absolute_dispose(self):
+        scheduler = EventLoopScheduler(exit_if_empty=False)
+
+        scheduler.dispose()
+
+        ran = False
+
+        def action(scheduler, state):
+            nonlocal ran
+            ran = True
+
+        exc = None
+        try:
+            scheduler.schedule_absolute(scheduler.now, action)
+        except Exception as e:
+            exc = e
+        finally:
+            assert isinstance(exc, DisposedException)
+            assert ran is False
+            assert scheduler._has_thread() is False
+
+    def test_eventloop_schedule_periodic_dispose(self):
+        scheduler = EventLoopScheduler(exit_if_empty=False)
+
+        scheduler.dispose()
+
+        ran = False
+
+        def action(scheduler, state):
+            nonlocal ran
+            ran = True
+
+        exc = None
+        try:
+            scheduler.schedule_periodic(0.1, scheduler.now, action)
+        except Exception as e:
+            exc = e
+        finally:
+            assert isinstance(exc, DisposedException)
+            assert ran is False
+            assert scheduler._has_thread() is False

--- a/tests/test_concurrency/test_eventloopscheduler.py
+++ b/tests/test_concurrency/test_eventloopscheduler.py
@@ -1,7 +1,6 @@
 import unittest
 
 from datetime import datetime, timedelta
-from time import sleep
 import threading
 from rx.concurrency import EventLoopScheduler
 
@@ -18,8 +17,8 @@ class TestEventLoopScheduler(unittest.TestCase):
         gate = threading.Semaphore(0)
 
         def action(scheduler, state):
-            gate.release()
             ran[0] = True
+            gate.release()
 
         scheduler.schedule(action)
         gate.acquire()
@@ -31,8 +30,8 @@ class TestEventLoopScheduler(unittest.TestCase):
         gate = threading.Semaphore(0)
 
         def action(scheduler, state):
-            gate.release()
             thread_id[0] = threading.current_thread().ident
+            gate.release()
 
         scheduler.schedule(action)
         gate.acquire()
@@ -46,8 +45,8 @@ class TestEventLoopScheduler(unittest.TestCase):
         scheduler.schedule(lambda s, t: result.append(1))
 
         def action(scheduler, state):
-            gate.release()
             result.append(2)
+            gate.release()
 
         scheduler.schedule(action)
         gate.acquire()
@@ -64,7 +63,6 @@ class TestEventLoopScheduler(unittest.TestCase):
             gate.release()
 
         scheduler.schedule_relative(timedelta(milliseconds=200), action)
-
         gate.acquire()
         diff = endtime[0]-starttime
         assert(diff > timedelta(milliseconds=180))

--- a/tests/test_core/test_priorityqueue.py
+++ b/tests/test_core/test_priorityqueue.py
@@ -131,19 +131,3 @@ class TestPriorityQueue(unittest.TestCase):
         assert p.peek() == 41
         p.enqueue(43)
         assert p.peek() == 41
-
-    def test_priorityqueue_remove_at(self):
-        """Remove item at index"""
-
-        p = PriorityQueue()
-
-        self.assertRaises(IndexError, p.remove_at, 42)
-        p.enqueue(42)
-        p.enqueue(41)
-        p.enqueue(43)
-
-        assert p.remove_at(2) == 43
-        assert p.remove_at(1) == 42
-        assert p.remove_at(0) == 41
-
-        self.assertRaises(IndexError, p.remove_at, 0)

--- a/tests/test_core/test_priorityqueue.py
+++ b/tests/test_core/test_priorityqueue.py
@@ -1,7 +1,6 @@
 import unittest
 
 from rx.internal import PriorityQueue
-from rx.internal.exceptions import InvalidOperationException
 
 
 class TestItem():
@@ -124,7 +123,7 @@ class TestPriorityQueue(unittest.TestCase):
 
         p = PriorityQueue()
 
-        self.assertRaises(InvalidOperationException, p.peek)
+        self.assertRaises(IndexError, p.peek)
         p.enqueue(42)
         assert p.peek() == 42
         p.enqueue(41)

--- a/tests/test_core/test_priorityqueue.py
+++ b/tests/test_core/test_priorityqueue.py
@@ -33,6 +33,10 @@ class TestItem():
 
 
 class TestPriorityQueue(unittest.TestCase):
+
+    def test_priorityqueue_count(self):
+        assert PriorityQueue.MIN_COUNT < 0
+
     def test_priorityqueue_empty(self):
         """Must be empty on construction"""
 


### PR DESCRIPTION
I wanted to submit this now, before things get even further out of hand...

Looking at the priority queue and the "basic" schedulers (the ones used by operators) I believe I found a few improvements. I tried to keep each commit self-explanatory, and went to the trouble of running all of them through Travis incrementally. You can see everything passes, [here](https://github.com/erikkemperman/RxPY/commits/scheduler-tweaks).

But in total this is perhaps a little too big for a single PR. However, since each commit builds on the previous, I did not think it would be feasible to submit multiple PRs. Sorry about that. If it helps, reviewing the commits one at a time might be easier than reviewing the whole diff at once.

I've added a crude benchmark at the end -- basically timing the unit tests minus test_concurrency several times -- to demonstrate that these changes (particularly to `CurrentThreadScheduler` and `EventLoopScheduler`) offer a significant perfomance boost.

This is mostly due to preventing a bunch of threads where they aren't strictly needed -- threads are cheap on Linux, not so on Mac or Windows. Compared to the master branch:

~6% faster on [Linux](https://travis-ci.org/erikkemperman/RxPY/jobs/504088612#L1087)
~21% faster on [MacOS](https://travis-ci.org/erikkemperman/RxPY/jobs/504088614#L985)
~43% faster on [Windows](https://travis-ci.org/erikkemperman/RxPY/jobs/504088615#L949)

Additionally, I polished the mainloop schedulers a bit in terms of typing and docstrings.

I would like to propose additional tweaks to the `TimeoutScheduler`, which could also prevent a lot of spurious threads. Or alternatively make a new scheduler, something like `TimerPoolScheduler`, to be used internally by the operators. But that will have to wait and I didn't want to keep postponing submitting what I have at this point.
