### PR TITLE
PriorityQueue and related Schedulers

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -3,5 +3,9 @@ omit =
     */python?.?/*
     */site-packages/nose/*
     *__init__*
+exclude_lines =
+    pragma: no cover
+    return NotImplemented
+    raise NotImplementedError
 [xml]
 output = coverage.xml

--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,11 @@ pip-log.txt
 .tox
 nosetests.xml
 coverage.xml
+.mypy_cache
+.pytest_cache
+
+# Virtual env
+venv
 
 # Translations
 *.mo
@@ -50,8 +55,6 @@ UpgradeLog.htm
 TestResults/Rx.TE.Tests.mdf
 TestResults/Rx.TE.Tests_log.ldf
 *.user
-
-.mypy_cache
 
 # Cloud9
 .c9

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ matrix:
       python: 3.6
       # Coverage for the baseline 3.6 build: include some optional packages
       before_script:
-        - pip3 install eventlet gevent tornado twisted
+        - pip3 install eventlet gevent pygame tornado twisted
         # pycairo / pygobject need native libraries
         - sudo apt-get install -y libgirepository1.0-dev gir1.2-gtk-3.0
         - pip3 install pycairo pygobject

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,7 @@ matrix:
         - sudo apt-get install -y libgirepository1.0-dev gir1.2-gtk-3.0
         - pip3 install pycairo pygobject
       script:
-        - coverage run --source=rx setup.py test
-      after_success:
-        - coveralls
+        - coverage run --source=rx setup.py test && coveralls
 
     - os: linux
       dist: xenial
@@ -46,3 +44,8 @@ install:
 script:
   - python3 setup.py test
 
+after_success:
+  # Run a crude benchmark (unit tests minus concurrency) a couple of times.
+  # Need to make a copy of the script first, because on Windows it disappears
+  # whilst switching git branches.
+  - cp ./.travis/bench.sh bench.sh && ./bench.sh

--- a/.travis/bench.sh
+++ b/.travis/bench.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+
+# This script runs a subset of unit tests (minus concurrency, which does too
+# many hard sleeps to be a useful benchmark) a couple of times, averaging the
+# durations as parsed from pytest output.
+#
+# It does this for a designated reference branch to compare with, and then again
+# for the situation we were in when invoked.
+#
+# If we're running locally, the reference is taken from an commandline arg, or
+# or if none is given we just bench-mark the present situation.
+#
+# When running on Travis CI, the reference will be the targeted branch in the
+# case of pull request builds, or default to "master" for push builds.
+#
+# Note that the script might switch the local git branch. To protect any unsaved
+# work when running locally, it does a git stash first, which is popped back
+# later.
+#
+# So if you kill the script before it's done, you may end up in the wrong branch
+# and/or you may find your work is stashed!
+
+testargs="--cache-clear --ignore=tests/test_concurrency"
+defref="master"
+rounds=5
+
+stat=$(git status | head -n 1)
+hash=$(git log -1 --format=%H)
+head=$(echo "$stat" | grep -o "[^ ]*$")
+ref=$1
+pop=0
+
+if [[ "$TRAVIS" ]]
+then
+  # Running on Travis; add explicit remote to upstream repository
+  git remote add upstream https://github.com/"$TRAVIS_REPO_SLUG".git
+
+  # Compare versus the PR target branch, if any, or the default ref otherwise
+  if [[ "$TRAVIS_PULL_REQUEST" != "false" ]]
+  then
+    head="$hash"
+    ref="$TRAVIS_BRANCH"
+  else
+    head="$TRAVIS_BRANCH"
+    ref="$defref"
+  fi
+
+else
+
+  # Running locally: save unsaved work, if any
+  if [[ $# != 0 ]]
+  then
+    git stash | grep "^No"
+    pop=$?
+    if [[ $pop != 0 ]]
+    then
+      echo "Note: stashed local unsaved changes, do NOT kill this script!"
+    fi
+  fi
+
+  # If our head is detached, use the hash so we can jump back correctly
+  if [[ $(echo "$stat" | grep -o " detached ") ]]
+  then
+    head="$hash"
+  fi
+
+fi
+
+
+# If $ref is equal to $head, ignore it
+if [[ "$ref" == "$head" ]]
+then
+  ref=""
+fi
+
+
+# All right, go!
+for branch in "$ref" "$head"
+do
+  if [[ $branch == "" ]]
+  then
+    continue
+  fi
+
+  # Checkout the branch / commit
+  echo ""
+  echo "Checking out $branch"
+  if [[ "$TRAVIS" && "$branch" != "$head" ]]
+  then
+    git fetch upstream $branch
+    git checkout upstream/"$branch"
+  else
+    git checkout "$branch"
+    if [[ $pop != 0 && "$branch" == "$head" ]]
+    then
+      git stash pop
+      echo "Note: restored local unsaved changes."
+    fi
+  fi
+
+  echo ""
+  git status | head -n 1
+
+  # Do one warm-up round, which doesn't count toward the average
+  echo -n " - Round 0 (warm-up)"
+  sec=$(pytest $testargs | grep -o "passed in .* s")
+  ret=$?
+  echo -n " | $sec"
+  if [[ $ret == 0 ]];
+  then
+    echo " | OK"
+  else
+    echo " | FAIL"
+    exit $ret
+  fi
+
+  # Main loop, run "pytest $testargs" $rounds times
+  sum=0
+  for round in $(seq $rounds)
+  do
+    echo -n " - Round $round of $rounds"
+    sec=$(pytest $testargs | grep -o "passed in .* s")
+    ret=$?
+    echo -n " | $sec"
+
+    sec=$(echo $sec | sed -e "s/[^0-9]//g")
+    sum=$(($sum + $sec))
+    avg=$((((($sum * 10) / $round) + 5) / 10))
+
+    echo -n " | total $(echo $sum | sed -e "s/\([0-9]\{2\}\)$/.\1/") s"
+    echo -n " | average $(echo $avg | sed -e "s/\([0-9]\{2\}\)$/.\1/") s"
+
+    if [[ $ret == 0 ]]
+    then
+      echo " | OK"
+    else
+      echo " | FAIL"
+      exit $ret
+    fi
+  done
+done

--- a/rx/concurrency/__init__.py
+++ b/rx/concurrency/__init__.py
@@ -5,10 +5,7 @@ from .currentthreadscheduler import CurrentThreadScheduler, current_thread_sched
 from .virtualtimescheduler import VirtualTimeScheduler
 from .timeoutscheduler import TimeoutScheduler, timeout_scheduler
 from .newthreadscheduler import NewThreadScheduler
-try:
-    from .threadpoolscheduler import ThreadPoolScheduler
-except ImportError:
-    pass
+from .threadpoolscheduler import ThreadPoolScheduler
 from .eventloopscheduler import EventLoopScheduler
 from .historicalscheduler import HistoricalScheduler
 from .catchscheduler import CatchScheduler

--- a/rx/concurrency/currentthreadscheduler.py
+++ b/rx/concurrency/currentthreadscheduler.py
@@ -3,10 +3,10 @@ import time
 import logging
 import threading
 from typing import Dict
-from datetime import timedelta
 
 from rx.core import typing
 from rx.internal import PriorityQueue
+from rx.internal.constants import DELTA_ZERO
 
 from .schedulerbase import SchedulerBase
 from .scheduleditem import ScheduledItem
@@ -21,7 +21,7 @@ class Trampoline(object):
             item: ScheduledItem = queue.dequeue()
             if not item.is_cancelled():
                 diff = item.duetime - item.scheduler.now
-                while diff > timedelta(0):
+                while diff > DELTA_ZERO:
                     seconds = diff.seconds + diff.microseconds / 1E6 + diff.days * 86400
                     log.warning("Do not schedule blocking work!")
                     time.sleep(seconds)
@@ -50,7 +50,7 @@ class CurrentThreadScheduler(SchedulerBase):
         """Schedules an action to be executed."""
 
         #log.debug("CurrentThreadScheduler.schedule(state=%s)", state)
-        return self.schedule_relative(timedelta(0), action, state)
+        return self.schedule_relative(DELTA_ZERO, action, state)
 
     def schedule_relative(self, duetime: typing.RelativeTime, action: typing.ScheduledAction,
                           state: typing.TState = None) -> typing.Disposable:

--- a/rx/concurrency/currentthreadscheduler.py
+++ b/rx/concurrency/currentthreadscheduler.py
@@ -62,7 +62,7 @@ class CurrentThreadScheduler(SchedulerBase):
 
         queue = self.queue
         if queue is None:
-            queue = PriorityQueue(4)
+            queue = PriorityQueue()
             queue.enqueue(si)
 
             self.queue = queue

--- a/rx/concurrency/currentthreadscheduler.py
+++ b/rx/concurrency/currentthreadscheduler.py
@@ -3,7 +3,7 @@ import time
 import logging
 import threading
 from weakref import WeakKeyDictionary
-from typing import MutableMapping
+from typing import MutableMapping, Optional
 
 from rx.core import typing
 from rx.internal import PriorityQueue
@@ -32,10 +32,9 @@ class Trampoline(object):
 
 
 class CurrentThreadScheduler(SchedulerBase):
-    """Represents an object that schedules units of work on the current
-    thread. You never want to schedule timeouts using the
-    CurrentThreadScheduler since it will block the current thread while
-    waiting.
+    """Represents an object that schedules units of work on the current thread.
+    You never want to schedule timeouts using the CurrentThreadScheduler since
+    that will block the current thread while waiting.
     """
 
     _global: MutableMapping[threading.Thread, 'CurrentThreadScheduler'] = WeakKeyDictionary()
@@ -63,21 +62,50 @@ class CurrentThreadScheduler(SchedulerBase):
 
         self._local = CurrentThreadScheduler._Local()
 
-    def schedule(self, action: typing.ScheduledAction, state: typing.TState = None) -> typing.Disposable:
-        """Schedules an action to be executed."""
+    def schedule(self,
+                 action: typing.ScheduledAction,
+                 state: Optional[typing.TState] = None
+                 ) -> typing.Disposable:
+        """Schedules an action to be executed.
+        Args:
+            action: Action to be executed.
+            state: [Optional] state to be given to the action function.
+        Returns:
+            The disposable object used to cancel the scheduled action
+            (best effort).
+        """
 
         return self.schedule_absolute(self.now, action, state=state)
 
-    def schedule_relative(self, duetime: typing.RelativeTime, action: typing.ScheduledAction,
-                          state: typing.TState = None) -> typing.Disposable:
-        """Schedules an action to be executed after duetime."""
+    def schedule_relative(self,
+                          duetime: typing.RelativeTime,
+                          action: typing.ScheduledAction,
+                          state: Optional[typing.TState] = None
+                          ) -> typing.Disposable:
+        """Schedules an action to be executed after duetime.
+        Args:
+            duetime: Relative time after which to execute the action.
+            action: Action to be executed.
+            state: [Optional] state to be given to the action function.
+        Returns:
+            The disposable object used to cancel the scheduled action
+            (best effort).
+        """
 
         duetime = SchedulerBase.normalize(self.to_timedelta(duetime))
         return self.schedule_absolute(self.now + duetime, action, state=state)
 
-    def schedule_absolute(self, duetime: typing.AbsoluteTime, action: typing.ScheduledAction,
-                          state: typing.TState = None) -> typing.Disposable:
-        """Schedules an action to be executed at duetime."""
+    def schedule_absolute(self, duetime: typing.AbsoluteTime,
+                          action: typing.ScheduledAction,
+                          state: Optional[typing.TState] = None
+                          ) -> typing.Disposable:
+        """Schedules an action to be executed at duetime.
+
+        Args:
+            duetime: Absolute time after which to execute the action.
+            action: Action to be executed.
+            state: [Optional] state to be given to the action function.
+        """
 
         duetime = self.to_datetime(duetime)
 

--- a/rx/concurrency/eventloopscheduler.py
+++ b/rx/concurrency/eventloopscheduler.py
@@ -94,6 +94,11 @@ class EventLoopScheduler(SchedulerBase, typing.Disposable):
 
         return Disposable(dispose)
 
+    def _has_thread(self) -> bool:
+        """Checks if there is an event loop thread running."""
+        with self._condition:
+            return not self._is_disposed and self._thread is not None
+
     def _ensure_thread(self) -> None:
         """Ensures there is an event loop thread running. Should be
         called under the gate."""

--- a/rx/concurrency/eventloopscheduler.py
+++ b/rx/concurrency/eventloopscheduler.py
@@ -32,21 +32,50 @@ class EventLoopScheduler(SchedulerBase, typing.Disposable):
 
         self._exit_if_empty = exit_if_empty
 
-    def schedule(self, action: typing.ScheduledAction, state: typing.TState = None) -> typing.Disposable:
-        """Schedules an action to be executed."""
+    def schedule(self,
+                 action: typing.ScheduledAction,
+                 state: Optional[typing.TState] = None
+                 ) -> typing.Disposable:
+        """Schedules an action to be executed.
+        Args:
+            action: Action to be executed.
+            state: [Optional] state to be given to the action function.
+        Returns:
+            The disposable object used to cancel the scheduled action
+            (best effort).
+        """
 
         return self.schedule_absolute(self.now, action, state=state)
 
-    def schedule_relative(self, duetime: typing.RelativeTime, action: typing.ScheduledAction,
-                          state: typing.TState = None) -> typing.Disposable:
-        """Schedules an action to be executed after duetime."""
+    def schedule_relative(self,
+                          duetime: typing.RelativeTime,
+                          action: typing.ScheduledAction,
+                          state: Optional[typing.TState] = None
+                          ) -> typing.Disposable:
+        """Schedules an action to be executed after duetime.
+        Args:
+            duetime: Relative time after which to execute the action.
+            action: Action to be executed.
+            state: [Optional] state to be given to the action function.
+        Returns:
+            The disposable object used to cancel the scheduled action
+            (best effort).
+        """
 
         duetime = SchedulerBase.normalize(self.to_timedelta(duetime))
         return self.schedule_absolute(self.now + duetime, action, state)
 
-    def schedule_absolute(self, duetime: typing.AbsoluteTime, action: typing.ScheduledAction,
-                          state: typing.TState = None) -> typing.Disposable:
-        """Schedules an action to be executed at duetime."""
+    def schedule_absolute(self, duetime: typing.AbsoluteTime,
+                          action: typing.ScheduledAction,
+                          state: Optional[typing.TState] = None
+                          ) -> typing.Disposable:
+        """Schedules an action to be executed at duetime.
+
+        Args:
+            duetime: Absolute time after which to execute the action.
+            action: Action to be executed.
+            state: [Optional] state to be given to the action function.
+        """
 
         if self._is_disposed:
             raise DisposedException()
@@ -64,9 +93,23 @@ class EventLoopScheduler(SchedulerBase, typing.Disposable):
 
         return Disposable(si.cancel)
 
-    def schedule_periodic(self, period: typing.RelativeTime, action: typing.ScheduledPeriodicAction, state: Any = None
-                         ) -> typing.Disposable:
-        """Schedule a periodic piece of work."""
+    def schedule_periodic(self,
+                          period: typing.RelativeTime,
+                          action: typing.ScheduledPeriodicAction,
+                          state: Optional[typing.TState] = None
+                          ) -> typing.Disposable:
+        """Schedules a periodic piece of work.
+
+        Args:
+            period: Period in seconds or timedelta for running the
+                work periodically.
+            action: Action to be executed.
+            state: [Optional] Initial state passed to the action upon
+                the first iteration.
+
+        Returns:
+            The disposable object used to cancel the scheduled
+            recurring action (best effort)."""
 
         if self._is_disposed:
             raise DisposedException()

--- a/rx/concurrency/historicalscheduler.py
+++ b/rx/concurrency/historicalscheduler.py
@@ -28,7 +28,7 @@ class HistoricalScheduler(VirtualTimeScheduler):
         """Represents a notion of time for this scheduler. Tasks being scheduled
         on a scheduler will adhere to the time denoted by this property."""
 
-        return self.clock
+        return self._clock
 
     @staticmethod
     def add(absolute, relative):

--- a/rx/concurrency/historicalscheduler.py
+++ b/rx/concurrency/historicalscheduler.py
@@ -6,22 +6,15 @@ class HistoricalScheduler(VirtualTimeScheduler):
     """Provides a virtual time scheduler that uses datetime for absolute time
     and timedelta for relative time."""
 
-    def __init__(self, initial_clock=None, comparer=None):
+    def __init__(self, initial_clock=None):
         """Creates a new historical scheduler with the specified initial clock
         value.
 
         Keyword arguments:
         initial_clock -- {Number} Initial value for the clock.
-        comparer -- {Function} Comparer to determine causality of events based
-            on absolute time."""
+        """
 
-        def compare_datetimes(a, b):
-            return (a > b) - (a < b)
-
-        clock = initial_clock or UTC_ZERO
-        comparer = comparer or compare_datetimes
-
-        super(HistoricalScheduler, self).__init__(clock)
+        super().__init__(initial_clock or UTC_ZERO)
 
     @property
     def now(self):
@@ -41,20 +34,3 @@ class HistoricalScheduler(VirtualTimeScheduler):
         Returns resulting absolute virtual time sum value."""
 
         return absolute + relative
-
-    def to_datetime_offset(self, absolute):
-        """Converts the absolute time value to a datetime value."""
-
-        # datetime -> datetime
-        return absolute
-
-    def to_relative(self, timespan):
-        """Converts the timespan value to a relative virtual time value.
-
-        Keyword arguments:
-        timespan -- {timedelta} Time_span value to convert.
-
-        Returns corresponding relative virtual time value."""
-
-        # timedelta -> timedelta
-        return timespan

--- a/rx/concurrency/historicalscheduler.py
+++ b/rx/concurrency/historicalscheduler.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from .schedulerbase import UTC_ZERO
 from .virtualtimescheduler import VirtualTimeScheduler
 
 
@@ -18,7 +18,7 @@ class HistoricalScheduler(VirtualTimeScheduler):
         def compare_datetimes(a, b):
             return (a > b) - (a < b)
 
-        clock = initial_clock or datetime.utcfromtimestamp(0)
+        clock = initial_clock or UTC_ZERO
         comparer = comparer or compare_datetimes
 
         super(HistoricalScheduler, self).__init__(clock)

--- a/rx/concurrency/immediatescheduler.py
+++ b/rx/concurrency/immediatescheduler.py
@@ -1,8 +1,9 @@
-from datetime import timedelta
 from typing import Any
 
 from rx.core import typing
+from rx.internal.constants import DELTA_ZERO
 from rx.internal.exceptions import WouldBlockException
+
 from .schedulerbase import SchedulerBase
 
 
@@ -17,7 +18,7 @@ class ImmediateScheduler(SchedulerBase):
         """Schedules an action to be executed after duetime."""
 
         duetime = self.to_timedelta(duetime)
-        if duetime > timedelta(0):
+        if duetime > DELTA_ZERO:
             raise WouldBlockException()
 
         return self.invoke_action(action, state)

--- a/rx/concurrency/mainloopscheduler/pygamescheduler.py
+++ b/rx/concurrency/mainloopscheduler/pygamescheduler.py
@@ -1,6 +1,6 @@
 import logging
 from datetime import datetime
-from typing import Any, List
+from typing import Optional
 import threading
 
 from rx.internal import PriorityQueue
@@ -27,20 +27,32 @@ class PyGameScheduler(SchedulerBase):
         self._lock = threading.Lock()
         self._queue: PriorityQueue[ScheduledItem[typing.TState]] = PriorityQueue()
 
-    def schedule(self, action: typing.ScheduledAction, state: Any = None) -> typing.Disposable:
-        """Schedules an action to be executed."""
+    def schedule(self,
+                 action: typing.ScheduledAction,
+                 state: Optional[typing.TState] = None
+                 ) -> typing.Disposable:
+        """Schedules an action to be executed.
+        Args:
+            action: Action to be executed.
+            state: [Optional] state to be given to the action function.
+        Returns:
+            The disposable object used to cancel the scheduled action
+            (best effort).
+        """
 
         log.debug("PyGameScheduler.schedule(state=%s)", state)
         return self.schedule_absolute(self.now, action, state)
 
-    def schedule_relative(self, duetime: typing.RelativeTime, action: typing.ScheduledAction,
-                          state: typing.TState = None) -> typing.Disposable:
+    def schedule_relative(self,
+                          duetime: typing.RelativeTime,
+                          action: typing.ScheduledAction,
+                          state: Optional[typing.TState] = None
+                          ) -> typing.Disposable:
         """Schedules an action to be executed after duetime.
-
         Args:
             duetime: Relative time after which to execute the action.
             action: Action to be executed.
-
+            state: [Optional] state to be given to the action function.
         Returns:
             The disposable object used to cancel the scheduled action
             (best effort).
@@ -49,17 +61,17 @@ class PyGameScheduler(SchedulerBase):
         duetime = SchedulerBase.normalize(self.to_timedelta(duetime))
         return self.schedule_absolute(self.now + duetime, action, state=state)
 
-    def schedule_absolute(self, duetime: typing.AbsoluteTime, action: typing.ScheduledAction,
-                          state: typing.TState = None) -> typing.Disposable:
+    def schedule_absolute(self, duetime: typing.AbsoluteTime,
+                          action: typing.ScheduledAction,
+                          state: Optional[typing.TState] = None
+                          ) -> typing.Disposable:
         """Schedules an action to be executed at duetime.
 
         Args:
             duetime: Absolute time after which to execute the action.
             action: Action to be executed.
-
-        Returns:
-            The disposable object used to cancel the scheduled action
-            (best effort)."""
+            state: [Optional] state to be given to the action function.
+        """
 
         duetime = self.to_datetime(duetime)
         si: ScheduledItem[typing.TState] = ScheduledItem(self, state, action, duetime)

--- a/rx/concurrency/mainloopscheduler/pygamescheduler.py
+++ b/rx/concurrency/mainloopscheduler/pygamescheduler.py
@@ -24,7 +24,7 @@ class PyGameScheduler(SchedulerBase):
         self.timer = None
         self.event_id = event_id or pygame.USEREVENT
 
-        self.queue = PriorityQueue()
+        self.queue: PriorityQueue[ScheduledItem[typing.TState]] = PriorityQueue()
 
     def schedule(self, action: typing.ScheduledAction, state: Any = None) -> typing.Disposable:
         """Schedules an action to be executed."""
@@ -34,7 +34,7 @@ class PyGameScheduler(SchedulerBase):
 
     def run(self) -> None:
         while self.queue:
-            item = self.queue.peek()
+            item: ScheduledItem[typing.TState] = self.queue.peek()
             diff = item.duetime - self.now
 
             if diff > timedelta(0):

--- a/rx/concurrency/mainloopscheduler/pygamescheduler.py
+++ b/rx/concurrency/mainloopscheduler/pygamescheduler.py
@@ -1,9 +1,10 @@
 import logging
-from datetime import timedelta, datetime
+from datetime import datetime
 from typing import Any
 import threading
 
 from rx.internal import PriorityQueue
+from rx.internal.constants import DELTA_ZERO
 from rx.core import typing
 from rx.concurrency import ScheduledItem
 from rx.concurrency.schedulerbase import SchedulerBase
@@ -83,7 +84,7 @@ class PyGameScheduler(SchedulerBase):
                 item: ScheduledItem[typing.TState] = self.queue.peek()
                 diff = item.duetime - self.now
 
-                if diff > timedelta(0):
+                if diff > DELTA_ZERO:
                     break
 
                 item = self.queue.dequeue()

--- a/rx/concurrency/newthreadscheduler.py
+++ b/rx/concurrency/newthreadscheduler.py
@@ -1,6 +1,6 @@
 import time
 import logging
-from typing import List
+from typing import List, Optional
 
 from rx.disposable import Disposable
 from rx.core import typing
@@ -16,7 +16,7 @@ class NewThreadScheduler(SchedulerBase):
     """Creates an object that schedules each unit of work on a separate thread.
     """
 
-    def __init__(self, thread_factory: typing.StartableFactory = None) -> None:
+    def __init__(self, thread_factory: Optional[typing.StartableFactory] = None) -> None:
         super(NewThreadScheduler, self).__init__()
         self.thread_factory = thread_factory or default_thread_factory
 

--- a/rx/concurrency/newthreadscheduler.py
+++ b/rx/concurrency/newthreadscheduler.py
@@ -1,12 +1,13 @@
 import time
 import logging
-import threading
 from typing import List
 
 from rx.disposable import Disposable
 from rx.core import typing
-from .schedulerbase import SchedulerBase
+from rx.internal.concurrency import default_thread_factory
+
 from .eventloopscheduler import EventLoopScheduler
+from .schedulerbase import SchedulerBase
 
 log = logging.getLogger('Rx')
 
@@ -15,15 +16,9 @@ class NewThreadScheduler(SchedulerBase):
     """Creates an object that schedules each unit of work on a separate thread.
     """
 
-    def __init__(self, thread_factory=None) -> None:
+    def __init__(self, thread_factory: typing.StartableFactory = None) -> None:
         super(NewThreadScheduler, self).__init__()
-
-        def default_factory(target, args=None) -> threading.Thread:
-            t = threading.Thread(target=target, args=args or [])
-            t.setDaemon(True)
-            return t
-
-        self.thread_factory = thread_factory or default_factory
+        self.thread_factory = thread_factory or default_thread_factory
 
     def schedule(self, action: typing.ScheduledAction, state: typing.TState = None) -> typing.Disposable:
         """Schedules an action to be executed."""

--- a/rx/concurrency/schedulerbase.py
+++ b/rx/concurrency/schedulerbase.py
@@ -5,7 +5,7 @@ from rx.core import typing
 from rx.core.typing import ScheduledAction, ScheduledPeriodicAction, TState
 from rx.disposable import Disposable, MultipleAssignmentDisposable
 from rx.internal.basic import default_now
-
+from rx.internal.constants import DELTA_ZERO, UTC_ZERO
 
 class SchedulerBase(typing.Scheduler):
     """Provides a set of static properties to access commonly used
@@ -75,7 +75,7 @@ class SchedulerBase(typing.Scheduler):
         """Converts time value to seconds"""
 
         if isinstance(timespan, datetime):
-            timespan = timespan - datetime.utcfromtimestamp(0)
+            timespan = timespan - UTC_ZERO
             timespan = timespan.total_seconds()
         elif isinstance(timespan, timedelta):
             timespan = timespan.total_seconds()
@@ -87,7 +87,7 @@ class SchedulerBase(typing.Scheduler):
         """Converts time value to datetime"""
 
         if isinstance(duetime, timedelta):
-            duetime = datetime.utcfromtimestamp(0) + duetime
+            duetime = UTC_ZERO + duetime
         elif not isinstance(duetime, datetime):
             duetime = datetime.utcfromtimestamp(duetime)
 
@@ -98,7 +98,7 @@ class SchedulerBase(typing.Scheduler):
         """Converts time value to timedelta"""
 
         if isinstance(timespan, datetime):
-            timespan = timespan - datetime.utcfromtimestamp(0)
+            timespan = timespan - UTC_ZERO
         elif not isinstance(timespan, timedelta):
             timespan = timedelta(seconds=timespan)
 
@@ -117,9 +117,8 @@ class SchedulerBase(typing.Scheduler):
         """
 
         if isinstance(timespan, timedelta):
-            nospan = timedelta(0)
-            if not timespan or timespan < nospan:
-                return nospan
+            if not timespan or timespan < DELTA_ZERO:
+                return DELTA_ZERO
 
         elif isinstance(timespan, float):
             if not timespan or timespan < 0.0:

--- a/rx/concurrency/schedulerbase.py
+++ b/rx/concurrency/schedulerbase.py
@@ -2,7 +2,6 @@ from datetime import datetime, timedelta
 from typing import Optional
 
 from rx.core import typing
-from rx.core.typing import ScheduledAction, ScheduledPeriodicAction, TState
 from rx.disposable import Disposable, MultipleAssignmentDisposable
 from rx.internal.basic import default_now
 from rx.internal.constants import DELTA_ZERO, UTC_ZERO
@@ -12,15 +11,21 @@ class SchedulerBase(typing.Scheduler):
     schedulers.
     """
 
-    def invoke_action(self, action: ScheduledAction, state: TState = None) -> typing.Disposable:
+    def invoke_action(self,
+                      action: typing.ScheduledAction,
+                      state: Optional[typing.TState] = None
+                      ) -> typing.Disposable:
         ret = action(self, state)
         if isinstance(ret, typing.Disposable):
             return ret
 
         return Disposable()
 
-    def schedule_periodic(self, period: typing.RelativeTime, action: ScheduledPeriodicAction,
-                          state: TState = None) -> typing.Disposable:
+    def schedule_periodic(self,
+                          period: typing.RelativeTime,
+                          action: typing.ScheduledPeriodicAction,
+                          state: Optional[typing.TState] = None
+                          ) -> typing.Disposable:
         """Schedules a periodic piece of work.
 
         Args:
@@ -32,11 +37,12 @@ class SchedulerBase(typing.Scheduler):
 
         Returns:
             The disposable object used to cancel the scheduled
-            recurring action (best effort)."""
+            recurring action (best effort).
+        """
 
         disp = MultipleAssignmentDisposable()
 
-        def invoke_periodic(scheduler: typing.Scheduler, _: TState) -> Optional[Disposable]:
+        def invoke_periodic(scheduler: typing.Scheduler, _: typing.TState) -> Optional[Disposable]:
             nonlocal state
 
             if disp.is_disposed:

--- a/rx/concurrency/threadpoolscheduler.py
+++ b/rx/concurrency/threadpoolscheduler.py
@@ -1,12 +1,13 @@
 from concurrent.futures import ThreadPoolExecutor
 
+from rx.core.abc import Startable
 from .newthreadscheduler import NewThreadScheduler
 
 
 class ThreadPoolScheduler(NewThreadScheduler):
     """A scheduler that schedules work via the thread pool."""
 
-    class ThreadPoolThread:
+    class ThreadPoolThread(Startable):
         """Wraps a concurrent future as a thread."""
 
         def __init__(self, executor, run):
@@ -23,7 +24,7 @@ class ThreadPoolScheduler(NewThreadScheduler):
     def __init__(self, max_workers=None):
         self.executor = ThreadPoolExecutor(max_workers=max_workers)
 
-        def thread_factory(target, *args):
+        def thread_factory(target):
             return self.ThreadPoolThread(self.executor, target)
 
         super().__init__(thread_factory)

--- a/rx/concurrency/timeoutscheduler.py
+++ b/rx/concurrency/timeoutscheduler.py
@@ -1,10 +1,9 @@
 from threading import Timer
-from datetime import timedelta
 
 from rx.core import typing
 from rx.disposable import SingleAssignmentDisposable, CompositeDisposable, Disposable
 
-from .schedulerbase import SchedulerBase
+from .schedulerbase import SchedulerBase, DELTA_ZERO
 
 
 class TimeoutScheduler(SchedulerBase):
@@ -31,7 +30,7 @@ class TimeoutScheduler(SchedulerBase):
 
         scheduler = self
         timespan = self.to_timedelta(duetime)
-        if timespan == timedelta(0):
+        if timespan == DELTA_ZERO:
             return scheduler.schedule(action, state)
 
         sad = SingleAssignmentDisposable()

--- a/rx/concurrency/virtualtimescheduler.py
+++ b/rx/concurrency/virtualtimescheduler.py
@@ -33,6 +33,12 @@ class VirtualTimeScheduler(SchedulerBase):
 
         super().__init__()
 
+    def _get_clock(self):
+        with self._lock:
+            return self._clock
+
+    clock = property(fget=_get_clock)
+
     @property
     def now(self) -> datetime:
         """Gets the schedulers absolute time clock value as datetime offset."""
@@ -97,7 +103,8 @@ class VirtualTimeScheduler(SchedulerBase):
                 return
             self._is_enabled = True
 
-        spinning = 0
+        spinning: int = 0
+
         while True:
             with self._lock:
                 if not self._is_enabled or not self._queue:

--- a/rx/concurrency/virtualtimescheduler.py
+++ b/rx/concurrency/virtualtimescheduler.py
@@ -28,7 +28,7 @@ class VirtualTimeScheduler(SchedulerBase):
         self.clock = initial_clock
 
         self.is_enabled = False
-        self.queue = PriorityQueue()
+        self.queue: PriorityQueue[ScheduledItem[typing.TState]] = PriorityQueue()
 
         super().__init__()
 
@@ -78,7 +78,7 @@ class VirtualTimeScheduler(SchedulerBase):
 
         spinning = 0
         while self.is_enabled:
-            item = self.get_next()
+            item: ScheduledItem[typing.TState] = self.get_next()
             if not item:
                 break
 
@@ -169,7 +169,7 @@ class VirtualTimeScheduler(SchedulerBase):
         """Returns the next scheduled item to be executed."""
 
         while self.queue:
-            item = self.queue.dequeue()
+            item: ScheduledItem[typing.TState] = self.queue.dequeue()
             if not item.is_cancelled():
                 return item
 

--- a/rx/concurrency/virtualtimescheduler.py
+++ b/rx/concurrency/virtualtimescheduler.py
@@ -1,3 +1,4 @@
+from abc import abstractmethod
 import logging
 from datetime import datetime
 import threading
@@ -119,10 +120,7 @@ class VirtualTimeScheduler(SchedulerBase):
             if self._clock > time:
                 raise ArgumentOutOfRangeException()
 
-            if self._clock == time:
-                return
-
-            if self._is_enabled:
+            if self._clock == time or self._is_enabled:
                 return
 
             self._is_enabled = True
@@ -177,5 +175,6 @@ class VirtualTimeScheduler(SchedulerBase):
             self._clock = dt
 
     @staticmethod
+    @abstractmethod
     def add(absolute, relative):
         raise NotImplementedError

--- a/rx/concurrency/virtualtimescheduler.py
+++ b/rx/concurrency/virtualtimescheduler.py
@@ -28,7 +28,7 @@ class VirtualTimeScheduler(SchedulerBase):
         self.clock = initial_clock
 
         self.is_enabled = False
-        self.queue = PriorityQueue(1024)
+        self.queue = PriorityQueue()
 
         super().__init__()
 

--- a/rx/core/abc/__init__.py
+++ b/rx/core/abc/__init__.py
@@ -2,4 +2,5 @@ from .disposable import Disposable
 from .observable import Observable
 from .observer import Observer
 from .scheduler import Scheduler
+from .startable import Startable
 from .subject import Subject

--- a/rx/core/abc/startable.py
+++ b/rx/core/abc/startable.py
@@ -1,0 +1,10 @@
+from abc import ABC, abstractmethod
+
+
+class Startable(ABC):
+    """Abstract base class for Thread- and Process-like objects."""
+    __slots__ = ()
+
+    @abstractmethod
+    def start(self):
+        raise NotImplementedError

--- a/rx/core/operators/delay.py
+++ b/rx/core/operators/delay.py
@@ -3,6 +3,7 @@ from datetime import datetime, timedelta
 
 from rx import operators as ops
 from rx.core import Observable, typing
+from rx.internal.constants import DELTA_ZERO
 from rx.disposable import CompositeDisposable, SerialDisposable, MultipleAssignmentDisposable
 from rx.concurrency import timeout_scheduler
 
@@ -75,7 +76,7 @@ def observable_delay_timespan(source: Observable, duetime: typing.RelativeTime,
                             if queue:
                                 should_continue = True
                                 diff = queue[0].timestamp - scheduler.now
-                                zero = timedelta(0) if isinstance(diff, timedelta) else 0
+                                zero = DELTA_ZERO if isinstance(diff, timedelta) else 0
                                 recurse_duetime = max(zero, diff)
                             else:
                                 active[0] = False

--- a/rx/core/operators/throttlefirst.py
+++ b/rx/core/operators/throttlefirst.py
@@ -20,7 +20,7 @@ def _throttle_first(window_duration: typing.RelativeTime, scheduler: typing.Sche
         def subscribe(observer, scheduler_=None):
             _scheduler = scheduler or scheduler_ or timeout_scheduler
 
-            duration = _scheduler.to_timedelta(+window_duration or 0.0)
+            duration = _scheduler.to_timedelta(window_duration or 0.0)
             if duration <= _scheduler.to_timedelta(0):
                 raise ValueError('window_duration cannot be less or equal zero.')
             last_on_next = [0]

--- a/rx/core/operators/windowwithtime.py
+++ b/rx/core/operators/windowwithtime.py
@@ -3,6 +3,7 @@ from datetime import timedelta
 
 from rx.core import Observable, typing
 from rx.concurrency import timeout_scheduler
+from rx.internal.constants import DELTA_ZERO
 from rx.internal.utils import add_ref
 from rx.disposable import SingleAssignmentDisposable, CompositeDisposable, RefCountDisposable, SerialDisposable
 from rx.subjects import Subject
@@ -25,7 +26,7 @@ def _window_with_time(timespan: typing.RelativeTime, timeshift: typing.RelativeT
             timer_d = SerialDisposable()
             next_shift = [timeshift]
             next_span = [timespan]
-            total_time = [timedelta(0)]
+            total_time = [DELTA_ZERO]
             q = []
 
             group_disposable = CompositeDisposable(timer_d)

--- a/rx/core/typing.py
+++ b/rx/core/typing.py
@@ -1,6 +1,7 @@
 from abc import abstractmethod
-from typing import Generic, TypeVar, Callable, Any, Union, Optional
+from typing import Any, Callable, Generic, Optional, Tuple, TypeVar, Union
 from datetime import datetime, timedelta
+from threading import Thread
 
 from . import abc
 
@@ -60,6 +61,11 @@ class Scheduler(abc.Scheduler):
     @abstractmethod
     def schedule_absolute(self, duetime: AbsoluteTime, action: ScheduledAction, state: TState = None) -> Disposable:
         return NotImplemented
+
+
+Startable = Union[abc.Startable, Thread]
+StartableTarget = Callable[..., None]
+StartableFactory = Callable[[StartableTarget, Optional[Tuple]], Startable]
 
 
 class Observer(Generic[T_in], abc.Observer):

--- a/rx/internal/__init__.py
+++ b/rx/internal/__init__.py
@@ -2,3 +2,4 @@ from .priorityqueue import PriorityQueue
 from .basic import noop, default_error, default_comparer
 from .exceptions import SequenceContainsNoElementsError, ArgumentOutOfRangeException, DisposedException
 from . import concurrency
+from . import constants

--- a/rx/internal/concurrency.py
+++ b/rx/internal/concurrency.py
@@ -1,3 +1,13 @@
+from threading import Thread
+from typing import Optional, Tuple
+
+from rx.core.typing import StartableTarget
+
+
+def default_thread_factory(target: StartableTarget, args: Optional[Tuple] = None) -> Thread:
+    return Thread(target=target, args=args or (), daemon=True)
+
+
 def synchronized(lock):
     """A decorator for synchronizing access to a given function."""
 

--- a/rx/internal/constants.py
+++ b/rx/internal/constants.py
@@ -1,0 +1,4 @@
+from datetime import datetime, timedelta
+
+DELTA_ZERO = timedelta(0)
+UTC_ZERO = datetime.utcfromtimestamp(0)

--- a/rx/internal/priorityqueue.py
+++ b/rx/internal/priorityqueue.py
@@ -47,3 +47,8 @@ class PriorityQueue(Generic[T1]):
                 return True
 
         return False
+
+    def clear(self):
+        """Remove all items from the queue."""
+        self.items = []
+        self.count = PriorityQueue.MIN_COUNT

--- a/rx/internal/priorityqueue.py
+++ b/rx/internal/priorityqueue.py
@@ -1,18 +1,15 @@
 import heapq
 from typing import Generic, List
-from threading import RLock
 
 from rx.core.typing import T1
 
 
 class PriorityQueue(Generic[T1]):
-    """Priority queue for scheduling"""
+    """Priority queue for scheduling. Note that methods aren't thread-safe."""
 
     def __init__(self) -> None:
         self.items: List[T1] = []
         self.count = 0  # Monotonic increasing for sort stability
-
-        self.lock = RLock()
 
     def __len__(self):
         """Returns length of queue"""
@@ -26,25 +23,21 @@ class PriorityQueue(Generic[T1]):
     def dequeue(self) -> T1:
         """Returns and removes item with lowest priority from queue"""
 
-        with self.lock:
-            item = heapq.heappop(self.items)[0]
-        return item
+        return heapq.heappop(self.items)[0]
 
     def enqueue(self, item: T1) -> None:
         """Adds item to queue"""
 
-        with self.lock:
-            heapq.heappush(self.items, (item, self.count))
-            self.count += 1
+        heapq.heappush(self.items, (item, self.count))
+        self.count += 1
 
     def remove(self, item: T1) -> bool:
         """Remove given item from queue"""
 
-        with self.lock:
-            for index, _item in enumerate(self.items):
-                if _item[0] == item:
-                    self.items.pop(index)
-                    heapq.heapify(self.items)
-                    return True
+        for index, _item in enumerate(self.items):
+            if _item[0] == item:
+                self.items.pop(index)
+                heapq.heapify(self.items)
+                return True
 
         return False

--- a/rx/internal/priorityqueue.py
+++ b/rx/internal/priorityqueue.py
@@ -1,13 +1,15 @@
 import heapq
-from typing import List, Any
+from typing import Generic, List
 from threading import RLock
 
+from rx.core.typing import T1
 
-class PriorityQueue:
+
+class PriorityQueue(Generic[T1]):
     """Priority queue for scheduling"""
 
     def __init__(self) -> None:
-        self.items: List[Any] = []
+        self.items: List[T1] = []
         self.count = 0  # Monotonic increasing for sort stability
 
         self.lock = RLock()
@@ -17,25 +19,25 @@ class PriorityQueue:
 
         return len(self.items)
 
-    def peek(self) -> Any:
+    def peek(self) -> T1:
         """Returns first item in queue without removing it"""
         return self.items[0][0]
 
-    def dequeue(self) -> Any:
+    def dequeue(self) -> T1:
         """Returns and removes item with lowest priority from queue"""
 
         with self.lock:
             item = heapq.heappop(self.items)[0]
         return item
 
-    def enqueue(self, item: Any) -> None:
+    def enqueue(self, item: T1) -> None:
         """Adds item to queue"""
 
         with self.lock:
             heapq.heappush(self.items, (item, self.count))
             self.count += 1
 
-    def remove(self, item: Any) -> bool:
+    def remove(self, item: T1) -> bool:
         """Remove given item from queue"""
 
         with self.lock:

--- a/rx/internal/priorityqueue.py
+++ b/rx/internal/priorityqueue.py
@@ -26,14 +26,6 @@ class PriorityQueue:
         except IndexError:
             raise InvalidOperationException("Queue is empty")
 
-    def remove_at(self, index: int) -> Any:
-        """Removes item at given index"""
-
-        with self.lock:
-            item = self.items.pop(index)[0]
-            heapq.heapify(self.items)
-        return item
-
     def dequeue(self) -> Any:
         """Returns and removes item with lowest priority from queue"""
 

--- a/rx/internal/priorityqueue.py
+++ b/rx/internal/priorityqueue.py
@@ -8,7 +8,7 @@ from rx.internal.exceptions import InvalidOperationException
 class PriorityQueue:
     """Priority queue for scheduling"""
 
-    def __init__(self, capacity=None) -> None:
+    def __init__(self) -> None:
         self.items: List[Any] = []
         self.count = 0  # Monotonic increasing for sort stability
 

--- a/rx/internal/priorityqueue.py
+++ b/rx/internal/priorityqueue.py
@@ -1,4 +1,5 @@
 import heapq
+from sys import maxsize
 from typing import Generic, List
 
 from rx.core.typing import T1
@@ -7,9 +8,11 @@ from rx.core.typing import T1
 class PriorityQueue(Generic[T1]):
     """Priority queue for scheduling. Note that methods aren't thread-safe."""
 
+    MIN_COUNT = ~maxsize
+
     def __init__(self) -> None:
         self.items: List[T1] = []
-        self.count = 0  # Monotonic increasing for sort stability
+        self.count = PriorityQueue.MIN_COUNT  # Monotonic increasing for sort stability
 
     def __len__(self):
         """Returns length of queue"""
@@ -23,7 +26,10 @@ class PriorityQueue(Generic[T1]):
     def dequeue(self) -> T1:
         """Returns and removes item with lowest priority from queue"""
 
-        return heapq.heappop(self.items)[0]
+        item: T1 = heapq.heappop(self.items)[0]
+        if not self.items:
+            self.count = PriorityQueue.MIN_COUNT
+        return item
 
     def enqueue(self, item: T1) -> None:
         """Adds item to queue"""

--- a/rx/internal/priorityqueue.py
+++ b/rx/internal/priorityqueue.py
@@ -2,8 +2,6 @@ import heapq
 from typing import List, Any
 from threading import RLock
 
-from rx.internal.exceptions import InvalidOperationException
-
 
 class PriorityQueue:
     """Priority queue for scheduling"""
@@ -21,10 +19,7 @@ class PriorityQueue:
 
     def peek(self) -> Any:
         """Returns first item in queue without removing it"""
-        try:
-            return self.items[0][0]
-        except IndexError:
-            raise InvalidOperationException("Queue is empty")
+        return self.items[0][0]
 
     def dequeue(self) -> Any:
         """Returns and removes item with lowest priority from queue"""

--- a/rx/testing/coldobservable.py
+++ b/rx/testing/coldobservable.py
@@ -2,21 +2,22 @@ from typing import List
 
 from rx.disposable import Disposable, CompositeDisposable
 from rx.core import Observable, typing
+from rx.concurrency import VirtualTimeScheduler
 
 from .subscription import Subscription
 
 
+
 class ColdObservable(Observable):
-    def __init__(self, scheduler, messages) -> None:
+    def __init__(self, scheduler: VirtualTimeScheduler, messages) -> None:
         super().__init__()
 
-        self.scheduler = scheduler
+        self.scheduler: VirtualTimeScheduler = scheduler
         self.messages = messages
         self.subscriptions: List[Subscription] = []
 
     def _subscribe_core(self, observer=None, scheduler=None) -> typing.Disposable:
-        clock = self.scheduler.to_seconds(self.scheduler.now)
-        self.subscriptions.append(Subscription(clock))
+        self.subscriptions.append(Subscription(self.scheduler._clock))
         index = len(self.subscriptions) - 1
         disp = CompositeDisposable()
 

--- a/rx/testing/coldobservable.py
+++ b/rx/testing/coldobservable.py
@@ -17,7 +17,7 @@ class ColdObservable(Observable):
         self.subscriptions: List[Subscription] = []
 
     def _subscribe_core(self, observer=None, scheduler=None) -> typing.Disposable:
-        self.subscriptions.append(Subscription(self.scheduler._clock))
+        self.subscriptions.append(Subscription(self.scheduler.clock))
         index = len(self.subscriptions) - 1
         disp = CompositeDisposable()
 

--- a/rx/testing/hotobservable.py
+++ b/rx/testing/hotobservable.py
@@ -4,15 +4,15 @@ from rx.disposable import Disposable
 from rx.core import Observable, typing
 from rx.concurrency import VirtualTimeScheduler
 
-from .subscription import Subscription
 from .recorded import Recorded
+from .subscription import Subscription
 
 
 class HotObservable(Observable):
     def __init__(self, scheduler: VirtualTimeScheduler, messages: List[Recorded]) -> None:
         super().__init__()
 
-        self.scheduler = scheduler
+        self.scheduler: VirtualTimeScheduler = scheduler
         self.messages = messages
         self.subscriptions: List[Subscription] = []
         self.observers: List[typing.Observer] = []
@@ -35,13 +35,13 @@ class HotObservable(Observable):
 
     def _subscribe_core(self, observer=None, scheduler=None) -> typing.Disposable:
         self.observers.append(observer)
-        self.subscriptions.append(Subscription(self.scheduler.clock))
+        self.subscriptions.append(Subscription(self.scheduler._clock))
         index = len(self.subscriptions) - 1
 
         def dispose_action():
             self.observers.remove(observer)
             start = self.subscriptions[index].subscribe
-            end = self.scheduler.clock
+            end = self.scheduler._clock
             self.subscriptions[index] = Subscription(start, end)
 
         return Disposable(dispose_action)

--- a/rx/testing/hotobservable.py
+++ b/rx/testing/hotobservable.py
@@ -35,13 +35,13 @@ class HotObservable(Observable):
 
     def _subscribe_core(self, observer=None, scheduler=None) -> typing.Disposable:
         self.observers.append(observer)
-        self.subscriptions.append(Subscription(self.scheduler._clock))
+        self.subscriptions.append(Subscription(self.scheduler.clock))
         index = len(self.subscriptions) - 1
 
         def dispose_action():
             self.observers.remove(observer)
             start = self.subscriptions[index].subscribe
-            end = self.scheduler._clock
+            end = self.scheduler.clock
             self.subscriptions[index] = Subscription(start, end)
 
         return Disposable(dispose_action)

--- a/rx/testing/mockdisposable.py
+++ b/rx/testing/mockdisposable.py
@@ -5,7 +5,7 @@ class MockDisposable:
     def __init__(self, scheduler: VirtualTimeScheduler):
         self.scheduler: VirtualTimeScheduler = scheduler
         self.disposes = []
-        self.disposes.append(self.scheduler._clock)
+        self.disposes.append(self.scheduler.clock)
 
     def dispose(self):
-        self.disposes.append(self.scheduler._clock)
+        self.disposes.append(self.scheduler.clock)

--- a/rx/testing/mockdisposable.py
+++ b/rx/testing/mockdisposable.py
@@ -1,8 +1,11 @@
+from rx.concurrency import VirtualTimeScheduler
+
+
 class MockDisposable:
-    def __init__(self, scheduler):
-        self.scheduler = scheduler
+    def __init__(self, scheduler: VirtualTimeScheduler):
+        self.scheduler: VirtualTimeScheduler = scheduler
         self.disposes = []
-        self.disposes.append(self.scheduler.clock)
+        self.disposes.append(self.scheduler._clock)
 
     def dispose(self):
-        self.disposes.append(self.scheduler.clock)
+        self.disposes.append(self.scheduler._clock)

--- a/rx/testing/mockobserver.py
+++ b/rx/testing/mockobserver.py
@@ -2,21 +2,22 @@ from typing import Any, List
 
 from rx.core.typing import Observer
 from rx.core.notification import OnNext, OnError, OnCompleted
+from rx.concurrency import VirtualTimeScheduler
 
 from .recorded import Recorded
 
 
 class MockObserver(Observer):
 
-    def __init__(self, scheduler) -> None:
-        self.scheduler = scheduler
+    def __init__(self, scheduler: VirtualTimeScheduler) -> None:
+        self.scheduler: VirtualTimeScheduler = scheduler
         self.messages: List[Recorded] = []
 
     def on_next(self, value: Any) -> None:
-        self.messages.append(Recorded(self.scheduler.clock, OnNext(value)))
+        self.messages.append(Recorded(self.scheduler._clock, OnNext(value)))
 
     def on_error(self, error: Exception) -> None:
-        self.messages.append(Recorded(self.scheduler.clock, OnError(error)))
+        self.messages.append(Recorded(self.scheduler._clock, OnError(error)))
 
     def on_completed(self) -> None:
-        self.messages.append(Recorded(self.scheduler.clock, OnCompleted()))
+        self.messages.append(Recorded(self.scheduler._clock, OnCompleted()))

--- a/rx/testing/mockobserver.py
+++ b/rx/testing/mockobserver.py
@@ -14,10 +14,10 @@ class MockObserver(Observer):
         self.messages: List[Recorded] = []
 
     def on_next(self, value: Any) -> None:
-        self.messages.append(Recorded(self.scheduler._clock, OnNext(value)))
+        self.messages.append(Recorded(self.scheduler.clock, OnNext(value)))
 
     def on_error(self, error: Exception) -> None:
-        self.messages.append(Recorded(self.scheduler._clock, OnError(error)))
+        self.messages.append(Recorded(self.scheduler.clock, OnError(error)))
 
     def on_completed(self) -> None:
-        self.messages.append(Recorded(self.scheduler._clock, OnCompleted()))
+        self.messages.append(Recorded(self.scheduler.clock, OnCompleted()))

--- a/tests/test_concurrency/test_currentthreadscheduler.py
+++ b/tests/test_concurrency/test_currentthreadscheduler.py
@@ -31,17 +31,32 @@ class TestCurrentThreadScheduler(unittest.TestCase):
         res = scheduler.now - datetime.utcnow()
         assert res < timedelta(milliseconds=1000)
 
-    def test_currentthread_scheduleaction(self):
+    def test_currentthread_schedule(self):
         scheduler = CurrentThreadScheduler()
-        ran = [False]
+        ran = False
 
         def action(scheduler, state=None):
-            ran[0] = True
+            nonlocal ran
+            ran = True
 
         scheduler.schedule(action)
-        assert ran[0] is True
+        assert ran is True
 
-    def test_currentthread_scheduleactionerror(self):
+    def test_currentthread_schedule_block(self):
+        scheduler = CurrentThreadScheduler()
+        ran = False
+
+        def action(scheduler, state=None):
+            nonlocal ran
+            ran = True
+
+        t = scheduler.now
+        scheduler.schedule_relative(0.2, action)
+        t = scheduler.now - t
+        assert ran is True
+        assert t >= timedelta(seconds=0.2)
+
+    def test_currentthread_schedule_error(self):
         scheduler = CurrentThreadScheduler()
 
         class MyException(Exception):
@@ -50,72 +65,82 @@ class TestCurrentThreadScheduler(unittest.TestCase):
         def action(scheduler, state=None):
             raise MyException()
 
+        exc = None
         try:
-            return scheduler.schedule(action)
-        except MyException:
-            assert True
+            scheduler.schedule(action)
+        except Exception as e:
+            exc = e
+        finally:
+            assert isinstance(exc, MyException)
 
-    def test_currentthread_scheduleactionnested(self):
+    def test_currentthread_schedule_nested(self):
         scheduler = CurrentThreadScheduler()
-        ran = [False]
+        ran = False
 
         def action(scheduler, state=None):
             def inner_action(scheduler, state=None):
-                ran[0] = True
+                nonlocal ran
+                ran = True
 
             return scheduler.schedule(inner_action)
         scheduler.schedule(action)
 
-        assert ran[0] == True
+        assert ran is True
 
     def test_currentthread_ensuretrampoline(self):
         scheduler = CurrentThreadScheduler()
-        ran1, ran2 = [False], [False]
+        ran1, ran2 = False, False
 
         def outer_action(scheduer, state=None):
             def action1(scheduler, state=None):
-                ran1[0] = True
+                nonlocal ran1
+                ran1 = True
 
             scheduler.schedule(action1)
 
             def action2(scheduler, state=None):
-                ran2[0] = True
+                nonlocal ran2
+                ran2 = True
 
             return scheduler.schedule(action2)
 
         scheduler.ensure_trampoline(outer_action)
-        assert ran1[0] == True
-        assert ran2[0] == True
+        assert ran1 is True
+        assert ran2 is True
 
     def test_currentthread_ensuretrampoline_nested(self):
         scheduler = CurrentThreadScheduler()
-        ran1, ran2 = [False], [False]
+        ran1, ran2 = False, False
 
         def outer_action(scheduler, state):
             def inner_action1(scheduler, state):
-                ran1[0] = True
+                nonlocal ran1
+                ran1 = True
 
             scheduler.ensure_trampoline(inner_action1)
 
             def inner_action2(scheduler, state):
-                ran2[0] = True
+                nonlocal ran2
+                ran2 = True
 
             return scheduler.ensure_trampoline(inner_action2)
 
         scheduler.ensure_trampoline(outer_action)
-        assert ran1[0] == True
-        assert ran2[0] == True
+        assert ran1 is True
+        assert ran2 is True
 
     def test_currentthread_ensuretrampoline_and_cancel(self):
         scheduler = CurrentThreadScheduler()
-        ran1, ran2 = [False], [False]
+        ran1, ran2 = False, False
 
         def outer_action(scheduler, state):
             def inner_action1(scheduler, state):
-                ran1[0] = True
+                nonlocal ran1
+                ran1 = True
 
                 def inner_action2(scheduler, state):
-                    ran2[0] = True
+                    nonlocal ran2
+                    ran2 = True
 
                 d = scheduler.schedule(inner_action2)
                 d.dispose()
@@ -123,25 +148,28 @@ class TestCurrentThreadScheduler(unittest.TestCase):
             return scheduler.schedule(inner_action1)
 
         scheduler.ensure_trampoline(outer_action)
-        assert ran1[0] == True
-        assert ran2[0] == False
+        assert ran1 is True
+        assert ran2 is False
 
     def test_currentthread_ensuretrampoline_and_canceltimed(self):
         scheduler = CurrentThreadScheduler()
-        ran1, ran2 = [False], [False]
+        ran1, ran2 = False, False
 
         def outer_action(scheduler, state):
             def inner_action1(scheduler, state):
-                ran1[0] = True
+                nonlocal ran1
+                ran1 = True
 
                 def inner_action2(scheduler, state):
-                    ran2[0] = True
+                    nonlocal ran2
+                    ran2 = True
 
-                d = scheduler.schedule_relative(timedelta(milliseconds=500), inner_action2)
+                t = scheduler.now + timedelta(seconds=0.5)
+                d = scheduler.schedule_absolute(t, inner_action2)
                 d.dispose()
 
             return scheduler.schedule(inner_action1)
 
         scheduler.ensure_trampoline(outer_action)
-        assert ran1[0] == True
-        assert ran2[0] == False
+        assert ran1 is True
+        assert ran2 is False

--- a/tests/test_concurrency/test_currentthreadscheduler.py
+++ b/tests/test_concurrency/test_currentthreadscheduler.py
@@ -1,10 +1,30 @@
 import unittest
 from datetime import datetime, timedelta
+import threading
 
 from rx.concurrency import CurrentThreadScheduler
 
 
 class TestCurrentThreadScheduler(unittest.TestCase):
+
+    def test_currentthread_singleton(self):
+        scheduler = [CurrentThreadScheduler(), CurrentThreadScheduler()]
+        assert scheduler[0] is scheduler[1]
+
+        gate = [threading.Semaphore(0), threading.Semaphore(0)]
+        scheduler = [None, None]
+
+        def run(idx):
+            scheduler[idx] = CurrentThreadScheduler()
+            gate[idx].release()
+
+        for idx in (0, 1):
+            threading.Thread(target=run, args=(idx,)).start()
+            gate[idx].acquire()
+
+        assert scheduler[0] is not None
+        assert scheduler[1] is not None
+        assert scheduler[0] is not scheduler[1]
 
     def test_currentthread_now(self):
         scheduler = CurrentThreadScheduler()

--- a/tests/test_concurrency/test_eventloopscheduler.py
+++ b/tests/test_concurrency/test_eventloopscheduler.py
@@ -2,40 +2,47 @@ import unittest
 
 from datetime import datetime, timedelta
 import threading
+from time import sleep
 from rx.concurrency import EventLoopScheduler
+from rx.internal import DisposedException
 
 
 class TestEventLoopScheduler(unittest.TestCase):
     def test_event_loop_now(self):
         scheduler = EventLoopScheduler()
         res = scheduler.now - datetime.utcnow()
+
         assert res < timedelta(microseconds=1000)
 
     def test_event_loop_schedule_action(self):
         scheduler = EventLoopScheduler(exit_if_empty=True)
-        ran = [False]
+        ran = False
         gate = threading.Semaphore(0)
 
         def action(scheduler, state):
-            ran[0] = True
+            nonlocal ran
+            ran = True
             gate.release()
 
         scheduler.schedule(action)
         gate.acquire()
-        assert (ran[0] is True)
+        assert ran is True
+        assert scheduler._has_thread() is False
 
     def test_event_loop_different_thread(self):
-        thread_id = [None]
+        thread_id = None
         scheduler = EventLoopScheduler(exit_if_empty=True)
         gate = threading.Semaphore(0)
 
         def action(scheduler, state):
-            thread_id[0] = threading.current_thread().ident
+            nonlocal thread_id
+            thread_id = threading.current_thread().ident
             gate.release()
 
         scheduler.schedule(action)
         gate.acquire()
-        assert (thread_id[0] != threading.current_thread().ident)
+        assert thread_id != threading.current_thread().ident
+        assert scheduler._has_thread() is False
 
     def test_event_loop_schedule_ordered_actions(self):
         scheduler = EventLoopScheduler(exit_if_empty=True)
@@ -50,39 +57,174 @@ class TestEventLoopScheduler(unittest.TestCase):
 
         scheduler.schedule(action)
         gate.acquire()
-        assert (result == [1, 2])
+        assert result == [1, 2]
+        assert scheduler._has_thread() is False
 
-    def test_event_loop_schedule_action_due(self):
+    def test_event_loop_schedule_ordered_actions_due(self):
+        scheduler = EventLoopScheduler(exit_if_empty=True)
+        gate = threading.Semaphore(0)
+        result = []
+
+        def action(scheduler, state):
+            result.append(3)
+            gate.release()
+
+        scheduler.schedule_relative(0.10, action)
+        scheduler.schedule_relative(0.05, lambda s, t: result.append(2))
+        scheduler.schedule(lambda s, t: result.append(1))
+
+        gate.acquire()
+        assert result == [1, 2, 3]
+        assert scheduler._has_thread() is False
+
+    def test_event_loop_schedule_ordered_actions_due_mixed(self):
+        scheduler = EventLoopScheduler(exit_if_empty=True)
+        gate = threading.Semaphore(0)
+        result = []
+
+        def action(scheduler, state):
+            result.append(1)
+            scheduler.schedule(action2)
+            scheduler.schedule_relative(0.10, action3)
+            sleep(0.10)
+
+        def action2(scheduler, state):
+            result.append(2)
+
+        def action3(scheduler, state):
+            result.append(3)
+            gate.release()
+
+        scheduler.schedule(action)
+
+        gate.acquire()
+        assert result == [1, 2, 3]
+        assert scheduler._has_thread() is False
+
+    def test_event_loop_schedule_action_relative_due(self):
         scheduler = EventLoopScheduler(exit_if_empty=True)
         gate = threading.Semaphore(0)
         starttime = datetime.utcnow()
-        endtime = [None]
+        endtime = None
 
         def action(scheduler, state):
-            endtime[0] = datetime.utcnow()
+            nonlocal endtime
+            endtime = datetime.utcnow()
             gate.release()
 
         scheduler.schedule_relative(timedelta(milliseconds=200), action)
         gate.acquire()
-        diff = endtime[0]-starttime
-        assert(diff > timedelta(milliseconds=180))
+        diff = endtime - starttime
+        assert diff > timedelta(milliseconds=180)
+        assert scheduler._has_thread() is False
+
+    def test_event_loop_schedule_action_absolute_due(self):
+        scheduler = EventLoopScheduler(exit_if_empty=True)
+        gate = threading.Semaphore(0)
+        starttime = datetime.utcnow()
+        endtime = None
+
+        def action(scheduler, state):
+            nonlocal endtime
+            endtime = datetime.utcnow()
+            gate.release()
+
+        scheduler.schedule_absolute(scheduler.now, action)
+        gate.acquire()
+        diff = endtime - starttime
+        assert diff < timedelta(milliseconds=180)
+        assert scheduler._has_thread() is False
 
     def test_eventloop_schedule_action_periodic(self):
-        scheduler = EventLoopScheduler()
+        scheduler = EventLoopScheduler(exit_if_empty=False)
         gate = threading.Semaphore(0)
-        period = 0.050
-        counter = [3]
+        period = 0.05
+        counter = 3
 
         def action(state):
+            nonlocal counter
             if state:
-                counter[0] -= 1
+                counter -= 1
                 return state - 1
-            if counter[0] == 0:
+            if counter == 0:
                 gate.release()
 
-        scheduler.schedule_periodic(period, action, counter[0])
+        disp = scheduler.schedule_periodic(period, action, counter)
 
-        def done():
-            assert counter[0] == 0
+        def dispose(scheduler, state):
+            disp.dispose()
+            gate.release()
 
         gate.acquire()
+        assert counter == 0
+        assert scheduler._has_thread() is True
+        scheduler.schedule(dispose)
+        gate.acquire()
+        assert scheduler._has_thread() is True
+        sleep(period)
+        scheduler.dispose()
+        sleep(period)
+        assert scheduler._has_thread() is False
+
+    def test_eventloop_schedule_dispose(self):
+        scheduler = EventLoopScheduler(exit_if_empty=False)
+
+        scheduler.dispose()
+
+        ran = False
+
+        def action(scheduler, state):
+            nonlocal ran
+            ran = True
+
+        exc = None
+        try:
+            scheduler.schedule(action)
+        except Exception as e:
+            exc = e
+        finally:
+            assert isinstance(exc, DisposedException)
+            assert ran is False
+            assert scheduler._has_thread() is False
+
+    def test_eventloop_schedule_absolute_dispose(self):
+        scheduler = EventLoopScheduler(exit_if_empty=False)
+
+        scheduler.dispose()
+
+        ran = False
+
+        def action(scheduler, state):
+            nonlocal ran
+            ran = True
+
+        exc = None
+        try:
+            scheduler.schedule_absolute(scheduler.now, action)
+        except Exception as e:
+            exc = e
+        finally:
+            assert isinstance(exc, DisposedException)
+            assert ran is False
+            assert scheduler._has_thread() is False
+
+    def test_eventloop_schedule_periodic_dispose(self):
+        scheduler = EventLoopScheduler(exit_if_empty=False)
+
+        scheduler.dispose()
+
+        ran = False
+
+        def action(scheduler, state):
+            nonlocal ran
+            ran = True
+
+        exc = None
+        try:
+            scheduler.schedule_periodic(0.1, scheduler.now, action)
+        except Exception as e:
+            exc = e
+        finally:
+            assert isinstance(exc, DisposedException)
+            assert ran is False
+            assert scheduler._has_thread() is False

--- a/tests/test_concurrency/test_eventloopscheduler.py
+++ b/tests/test_concurrency/test_eventloopscheduler.py
@@ -1,7 +1,6 @@
 import unittest
 
 from datetime import datetime, timedelta
-from time import sleep
 import threading
 from rx.concurrency import EventLoopScheduler
 
@@ -18,8 +17,8 @@ class TestEventLoopScheduler(unittest.TestCase):
         gate = threading.Semaphore(0)
 
         def action(scheduler, state):
-            gate.release()
             ran[0] = True
+            gate.release()
 
         scheduler.schedule(action)
         gate.acquire()
@@ -31,8 +30,8 @@ class TestEventLoopScheduler(unittest.TestCase):
         gate = threading.Semaphore(0)
 
         def action(scheduler, state):
-            gate.release()
             thread_id[0] = threading.current_thread().ident
+            gate.release()
 
         scheduler.schedule(action)
         gate.acquire()
@@ -46,8 +45,8 @@ class TestEventLoopScheduler(unittest.TestCase):
         scheduler.schedule(lambda s, t: result.append(1))
 
         def action(scheduler, state):
-            gate.release()
             result.append(2)
+            gate.release()
 
         scheduler.schedule(action)
         gate.acquire()
@@ -64,7 +63,6 @@ class TestEventLoopScheduler(unittest.TestCase):
             gate.release()
 
         scheduler.schedule_relative(timedelta(milliseconds=200), action)
-
         gate.acquire()
         diff = endtime[0]-starttime
         assert(diff > timedelta(milliseconds=180))

--- a/tests/test_concurrency/test_historicalscheduler.py
+++ b/tests/test_concurrency/test_historicalscheduler.py
@@ -50,7 +50,7 @@ class TestHistoricalScheduler(unittest.TestCase):
 
     def test_ctor(self):
         s = HistoricalScheduler()
-        self.assertEqual(datetime.utcfromtimestamp(0), s._clock)
+        self.assertEqual(datetime.utcfromtimestamp(0), s.clock)
         self.assertEqual(False, s._is_enabled)
 
     def test_start_stop(self):
@@ -68,22 +68,22 @@ class TestHistoricalScheduler(unittest.TestCase):
         s.start()
 
         self.assertEqual(time(2), s.now)
-        self.assertEqual(time(2), s._clock)
+        self.assertEqual(time(2), s.clock)
 
         s.start()
 
         self.assertEqual(time(4), s.now)
-        self.assertEqual(time(4), s._clock)
+        self.assertEqual(time(4), s.clock)
 
         s.start()
 
         self.assertEqual(time(6), s.now)
-        self.assertEqual(time(6), s._clock)
+        self.assertEqual(time(6), s.clock)
 
         s.start()
 
         self.assertEqual(time(6), s.now)
-        self.assertEqual(time(6), s._clock)
+        self.assertEqual(time(6), s.clock)
 
         assert_equals(list, [
             Timestamped(1, time(0)),
@@ -146,7 +146,7 @@ class TestHistoricalScheduler(unittest.TestCase):
         s.advance_to(time(8))
 
         self.assertEqual(time(8), s.now)
-        self.assertEqual(time(8), s._clock)
+        self.assertEqual(time(8), s.clock)
 
         assert_equals(list, [
             Timestamped(0, time(0)),
@@ -157,7 +157,7 @@ class TestHistoricalScheduler(unittest.TestCase):
         s.advance_to(time(8))
 
         self.assertEqual(time(8), s.now)
-        self.assertEqual(time(8), s._clock)
+        self.assertEqual(time(8), s.clock)
 
         assert_equals(list, [
             Timestamped(0, time(0)),
@@ -169,7 +169,7 @@ class TestHistoricalScheduler(unittest.TestCase):
         s.schedule_absolute(time(8), lambda a, b: list.append(Timestamped(8, s.now)) )
 
         self.assertEqual(time(8), s.now)
-        self.assertEqual(time(8), s._clock)
+        self.assertEqual(time(8), s.clock)
 
         assert_equals(list, [
             Timestamped(0, time(0)),
@@ -180,7 +180,7 @@ class TestHistoricalScheduler(unittest.TestCase):
         s.advance_to(time(10))
 
         self.assertEqual(time(10), s.now)
-        self.assertEqual(time(10), s._clock)
+        self.assertEqual(time(10), s.clock)
 
         assert_equals(list, [
             Timestamped(0, time(0)),
@@ -194,7 +194,7 @@ class TestHistoricalScheduler(unittest.TestCase):
         s.advance_to(time(100))
 
         self.assertEqual(time(100), s.now)
-        self.assertEqual(time(100), s._clock)
+        self.assertEqual(time(100), s.clock)
 
         assert_equals(list, [
             Timestamped(0, time(0)),
@@ -220,7 +220,7 @@ class TestHistoricalScheduler(unittest.TestCase):
         s.advance_by(time(8) - s.now)
 
         self.assertEqual(time(8), s.now)
-        self.assertEqual(time(8), s._clock)
+        self.assertEqual(time(8), s.clock)
 
         assert_equals(list, [
             Timestamped(0, time(0)),
@@ -232,7 +232,7 @@ class TestHistoricalScheduler(unittest.TestCase):
         s.schedule_absolute(time(8), lambda a, b: list.append(Timestamped(8, s.now)))
 
         self.assertEqual(time(8), s.now)
-        self.assertEqual(time(8), s._clock)
+        self.assertEqual(time(8), s.clock)
 
         assert_equals(list, [
             Timestamped(0, time(0)),
@@ -243,7 +243,7 @@ class TestHistoricalScheduler(unittest.TestCase):
         s.advance_by(timedelta(0))
 
         self.assertEqual(time(8), s.now)
-        self.assertEqual(time(8), s._clock)
+        self.assertEqual(time(8), s.clock)
 
         assert_equals(list, [
             Timestamped(0, time(0)),
@@ -254,7 +254,7 @@ class TestHistoricalScheduler(unittest.TestCase):
         s.advance_by(from_days(2))
 
         self.assertEqual(time(10), s.now)
-        self.assertEqual(time(10), s._clock)
+        self.assertEqual(time(10), s.clock)
 
         assert_equals(list, [
             Timestamped(0, time(0)),
@@ -268,7 +268,7 @@ class TestHistoricalScheduler(unittest.TestCase):
         s.advance_by(from_days(90))
 
         self.assertEqual(time(100), s.now)
-        self.assertEqual(time(100), s._clock)
+        self.assertEqual(time(100), s.clock)
 
         assert_equals(list, [
             Timestamped(0, time(0)),
@@ -305,7 +305,7 @@ class TestHistoricalScheduler(unittest.TestCase):
 
         s.sleep(from_days(1))
 
-        self.assertEqual(now + from_days(1), s._clock)
+        self.assertEqual(now + from_days(1), s.clock)
 
     def test_sleep2(self):
         s = HistoricalScheduler()

--- a/tests/test_concurrency/test_historicalscheduler.py
+++ b/tests/test_concurrency/test_historicalscheduler.py
@@ -50,40 +50,40 @@ class TestHistoricalScheduler(unittest.TestCase):
 
     def test_ctor(self):
         s = HistoricalScheduler()
-        self.assertEqual(datetime.utcfromtimestamp(0), s.clock)
-        self.assertEqual(False, s.is_enabled)
+        self.assertEqual(datetime.utcfromtimestamp(0), s._clock)
+        self.assertEqual(False, s._is_enabled)
 
     def test_start_stop(self):
         s = HistoricalScheduler()
         list = []
 
-        s.schedule_absolute(time(0), lambda sc,st: list.append(Timestamped(1, s.now)))
-        s.schedule_absolute(time(1), lambda sc,st: list.append(Timestamped(2, s.now)))
-        s.schedule_absolute(time(2), lambda sc,st: s.stop())
-        s.schedule_absolute(time(3), lambda sc,st: list.append(Timestamped(3, s.now)))
-        s.schedule_absolute(time(4), lambda sc,st: s.stop())
-        s.schedule_absolute(time(5), lambda sc,st: s.start())
-        s.schedule_absolute(time(6), lambda sc,st: list.append(Timestamped(4, s.now)))
+        s.schedule_absolute(time(0), lambda sc, st: list.append(Timestamped(1, s.now)))
+        s.schedule_absolute(time(1), lambda sc, st: list.append(Timestamped(2, s.now)))
+        s.schedule_absolute(time(2), lambda sc, st: s.stop())
+        s.schedule_absolute(time(3), lambda sc, st: list.append(Timestamped(3, s.now)))
+        s.schedule_absolute(time(4), lambda sc, st: s.stop())
+        s.schedule_absolute(time(5), lambda sc, st: s.start())
+        s.schedule_absolute(time(6), lambda sc, st: list.append(Timestamped(4, s.now)))
 
         s.start()
 
         self.assertEqual(time(2), s.now)
-        self.assertEqual(time(2), s.clock)
+        self.assertEqual(time(2), s._clock)
 
         s.start()
 
         self.assertEqual(time(4), s.now)
-        self.assertEqual(time(4), s.clock)
+        self.assertEqual(time(4), s._clock)
 
         s.start()
 
         self.assertEqual(time(6), s.now)
-        self.assertEqual(time(6), s.clock)
+        self.assertEqual(time(6), s._clock)
 
         s.start()
 
         self.assertEqual(time(6), s.now)
-        self.assertEqual(time(6), s.clock)
+        self.assertEqual(time(6), s._clock)
 
         assert_equals(list, [
             Timestamped(1, time(0)),
@@ -146,7 +146,7 @@ class TestHistoricalScheduler(unittest.TestCase):
         s.advance_to(time(8))
 
         self.assertEqual(time(8), s.now)
-        self.assertEqual(time(8), s.clock)
+        self.assertEqual(time(8), s._clock)
 
         assert_equals(list, [
             Timestamped(0, time(0)),
@@ -157,7 +157,7 @@ class TestHistoricalScheduler(unittest.TestCase):
         s.advance_to(time(8))
 
         self.assertEqual(time(8), s.now)
-        self.assertEqual(time(8), s.clock)
+        self.assertEqual(time(8), s._clock)
 
         assert_equals(list, [
             Timestamped(0, time(0)),
@@ -169,7 +169,7 @@ class TestHistoricalScheduler(unittest.TestCase):
         s.schedule_absolute(time(8), lambda a, b: list.append(Timestamped(8, s.now)) )
 
         self.assertEqual(time(8), s.now)
-        self.assertEqual(time(8), s.clock)
+        self.assertEqual(time(8), s._clock)
 
         assert_equals(list, [
             Timestamped(0, time(0)),
@@ -180,7 +180,7 @@ class TestHistoricalScheduler(unittest.TestCase):
         s.advance_to(time(10))
 
         self.assertEqual(time(10), s.now)
-        self.assertEqual(time(10), s.clock)
+        self.assertEqual(time(10), s._clock)
 
         assert_equals(list, [
             Timestamped(0, time(0)),
@@ -194,7 +194,7 @@ class TestHistoricalScheduler(unittest.TestCase):
         s.advance_to(time(100))
 
         self.assertEqual(time(100), s.now)
-        self.assertEqual(time(100), s.clock)
+        self.assertEqual(time(100), s._clock)
 
         assert_equals(list, [
             Timestamped(0, time(0)),
@@ -220,7 +220,7 @@ class TestHistoricalScheduler(unittest.TestCase):
         s.advance_by(time(8) - s.now)
 
         self.assertEqual(time(8), s.now)
-        self.assertEqual(time(8), s.clock)
+        self.assertEqual(time(8), s._clock)
 
         assert_equals(list, [
             Timestamped(0, time(0)),
@@ -232,7 +232,7 @@ class TestHistoricalScheduler(unittest.TestCase):
         s.schedule_absolute(time(8), lambda a, b: list.append(Timestamped(8, s.now)))
 
         self.assertEqual(time(8), s.now)
-        self.assertEqual(time(8), s.clock)
+        self.assertEqual(time(8), s._clock)
 
         assert_equals(list, [
             Timestamped(0, time(0)),
@@ -243,7 +243,7 @@ class TestHistoricalScheduler(unittest.TestCase):
         s.advance_by(timedelta(0))
 
         self.assertEqual(time(8), s.now)
-        self.assertEqual(time(8), s.clock)
+        self.assertEqual(time(8), s._clock)
 
         assert_equals(list, [
             Timestamped(0, time(0)),
@@ -254,7 +254,7 @@ class TestHistoricalScheduler(unittest.TestCase):
         s.advance_by(from_days(2))
 
         self.assertEqual(time(10), s.now)
-        self.assertEqual(time(10), s.clock)
+        self.assertEqual(time(10), s._clock)
 
         assert_equals(list, [
             Timestamped(0, time(0)),
@@ -268,7 +268,7 @@ class TestHistoricalScheduler(unittest.TestCase):
         s.advance_by(from_days(90))
 
         self.assertEqual(time(100), s.now)
-        self.assertEqual(time(100), s.clock)
+        self.assertEqual(time(100), s._clock)
 
         assert_equals(list, [
             Timestamped(0, time(0)),
@@ -283,20 +283,20 @@ class TestHistoricalScheduler(unittest.TestCase):
     def test_is_enabled(self):
         s = HistoricalScheduler()
 
-        self.assertEqual(False, s.is_enabled)
+        self.assertEqual(False, s._is_enabled)
 
         def action(scheduler, state):
-            self.assertEqual(True, s.is_enabled)
+            self.assertEqual(True, s._is_enabled)
             s.stop()
-            self.assertEqual(False, s.is_enabled)
+            self.assertEqual(False, s._is_enabled)
 
         s.schedule(action)
 
-        self.assertEqual(False, s.is_enabled)
+        self.assertEqual(False, s._is_enabled)
 
         s.start()
 
-        self.assertEqual(False, s.is_enabled)
+        self.assertEqual(False, s._is_enabled)
 
     def test_sleep1(self):
         now = datetime(year=1983, month=2, day=11, hour=12)
@@ -305,7 +305,7 @@ class TestHistoricalScheduler(unittest.TestCase):
 
         s.sleep(from_days(1))
 
-        self.assertEqual(now + from_days(1), s.clock)
+        self.assertEqual(now + from_days(1), s._clock)
 
     def test_sleep2(self):
         s = HistoricalScheduler()

--- a/tests/test_concurrency/test_mainloopscheduler/test_pygamescheduler.py
+++ b/tests/test_concurrency/test_mainloopscheduler/test_pygamescheduler.py
@@ -1,0 +1,88 @@
+import unittest
+from datetime import datetime, timedelta
+from time import sleep
+import pytest
+
+pygame = pytest.importorskip("pygame")
+from rx.concurrency.mainloopscheduler import PyGameScheduler
+
+
+class TestPyGameScheduler(unittest.TestCase):
+
+    def test_pygame_schedule_now(self):
+        scheduler = PyGameScheduler()
+        res = scheduler.now - datetime.utcnow()
+        assert res < timedelta(seconds=1)
+
+    def test_pygame_schedule_action(self):
+        scheduler = PyGameScheduler()
+        ran = False
+
+        def action(scheduler, state):
+            nonlocal ran
+            ran = True
+
+        scheduler.schedule(action)
+        scheduler.run()
+
+        assert ran is True
+
+    def test_pygame_schedule_action_due_relative(self):
+        scheduler = PyGameScheduler()
+        starttime = datetime.utcnow()
+        endtime = None
+
+        def action(scheduler, state):
+            nonlocal endtime
+            endtime = datetime.utcnow()
+
+        scheduler.schedule_relative(0.1, action)
+
+        scheduler.run()
+
+        assert endtime is None
+
+        sleep(0.2)
+        scheduler.run()
+
+        assert endtime is not None
+        diff = endtime - starttime
+        assert diff > timedelta(milliseconds=180)
+
+    def test_pygame_schedule_action_due_absolute(self):
+        scheduler = PyGameScheduler()
+        starttime = datetime.utcnow()
+        endtime = None
+
+        def action(scheduler, state):
+            nonlocal endtime
+            endtime = datetime.utcnow()
+
+        scheduler.schedule_absolute(starttime + timedelta(seconds=0.1), action)
+
+        scheduler.run()
+
+        assert endtime is None
+
+        sleep(0.2)
+        scheduler.run()
+
+        assert endtime is not None
+        diff = endtime - starttime
+        assert diff > timedelta(milliseconds=180)
+
+    def test_pygame_schedule_action_cancel(self):
+        scheduler = PyGameScheduler()
+        ran = False
+
+        def action(scheduler, state):
+            nonlocal ran
+            ran = True
+
+        d = scheduler.schedule_relative(0.1, action)
+        d.dispose()
+
+        sleep(0.2)
+        scheduler.run()
+
+        assert ran is False

--- a/tests/test_concurrency/test_virtualtimescheduler.py
+++ b/tests/test_concurrency/test_virtualtimescheduler.py
@@ -1,33 +1,15 @@
 import unittest
 from datetime import datetime, timedelta
 from rx.concurrency import VirtualTimeScheduler
+from rx.internal import ArgumentOutOfRangeException
 
 
 class VirtualSchedulerTestScheduler(VirtualTimeScheduler):
     def __init__(self):
-        super(VirtualSchedulerTestScheduler, self).__init__()
-
-    @staticmethod
-    def comparer(a, b):
-        if a > b:
-            return 1
-
-        if a < b:
-            return -1
-
-        return 0
+        super().__init__()
 
     def add(self, absolute, relative):
-        if not absolute:
-            absolute = ''
-
         return absolute + relative
-
-    def to_datetime_offset(self, absolute):
-        if not absolute:
-            absolute = ''
-
-        return datetime.utcfromtimestamp(len(absolute))
 
 
 class TestVirtualTimeScheduler(unittest.TestCase):
@@ -59,3 +41,16 @@ class TestVirtualTimeScheduler(unittest.TestCase):
             assert(False)
         except Exception as e:
             self.assertEqual(str(e), ex)
+
+    def test_virtual_schedule_advance_clock_error(self):
+        scheduler = VirtualSchedulerTestScheduler()
+
+        try:
+            scheduler.sleep(-1)
+        except Exception as e:
+            assert isinstance(e, ArgumentOutOfRangeException)
+
+        try:
+            scheduler.advance_to(scheduler._clock - 1)
+        except Exception as e:
+            assert isinstance(e, ArgumentOutOfRangeException)

--- a/tests/test_core/test_priorityqueue.py
+++ b/tests/test_core/test_priorityqueue.py
@@ -131,19 +131,3 @@ class TestPriorityQueue(unittest.TestCase):
         assert p.peek() == 41
         p.enqueue(43)
         assert p.peek() == 41
-
-    def test_priorityqueue_remove_at(self):
-        """Remove item at index"""
-
-        p = PriorityQueue()
-
-        self.assertRaises(IndexError, p.remove_at, 42)
-        p.enqueue(42)
-        p.enqueue(41)
-        p.enqueue(43)
-
-        assert p.remove_at(2) == 43
-        assert p.remove_at(1) == 42
-        assert p.remove_at(0) == 41
-
-        self.assertRaises(IndexError, p.remove_at, 0)

--- a/tests/test_core/test_priorityqueue.py
+++ b/tests/test_core/test_priorityqueue.py
@@ -1,7 +1,6 @@
 import unittest
 
 from rx.internal import PriorityQueue
-from rx.internal.exceptions import InvalidOperationException
 
 
 class TestItem():
@@ -124,7 +123,7 @@ class TestPriorityQueue(unittest.TestCase):
 
         p = PriorityQueue()
 
-        self.assertRaises(InvalidOperationException, p.peek)
+        self.assertRaises(IndexError, p.peek)
         p.enqueue(42)
         assert p.peek() == 42
         p.enqueue(41)

--- a/tests/test_core/test_priorityqueue.py
+++ b/tests/test_core/test_priorityqueue.py
@@ -33,6 +33,10 @@ class TestItem():
 
 
 class TestPriorityQueue(unittest.TestCase):
+
+    def test_priorityqueue_count(self):
+        assert PriorityQueue.MIN_COUNT < 0
+
     def test_priorityqueue_empty(self):
         """Must be empty on construction"""
 

--- a/tests/test_observable/test_defer.py
+++ b/tests/test_observable/test_defer.py
@@ -31,7 +31,7 @@ class TestDefer(unittest.TestCase):
             def defer(scheduler):
                 invoked[0] += 1
                 xs[0] = scheduler.create_cold_observable(
-                    on_next(100, scheduler._clock),
+                    on_next(100, scheduler.clock),
                     on_completed(200)
                 )
                 return xs[0]
@@ -52,7 +52,7 @@ class TestDefer(unittest.TestCase):
             def defer(scheduler):
                 invoked[0] += 1
                 xs[0] = scheduler.create_cold_observable(
-                        on_next(100, scheduler._clock), on_error(200, ex))
+                        on_next(100, scheduler.clock), on_error(200, ex))
                 return xs[0]
             return rx.defer(defer)
 
@@ -71,7 +71,7 @@ class TestDefer(unittest.TestCase):
             def defer(scheduler):
                 invoked[0] += 1
                 xs[0] = scheduler.create_cold_observable(
-                    on_next(100, scheduler._clock),
+                    on_next(100, scheduler.clock),
                     on_next(200, invoked[0]),
                     on_next(1100, 1000))
                 return xs[0]

--- a/tests/test_observable/test_defer.py
+++ b/tests/test_observable/test_defer.py
@@ -31,7 +31,7 @@ class TestDefer(unittest.TestCase):
             def defer(scheduler):
                 invoked[0] += 1
                 xs[0] = scheduler.create_cold_observable(
-                    on_next(100, scheduler.clock),
+                    on_next(100, scheduler._clock),
                     on_completed(200)
                 )
                 return xs[0]
@@ -52,7 +52,7 @@ class TestDefer(unittest.TestCase):
             def defer(scheduler):
                 invoked[0] += 1
                 xs[0] = scheduler.create_cold_observable(
-                        on_next(100, scheduler.clock), on_error(200, ex))
+                        on_next(100, scheduler._clock), on_error(200, ex))
                 return xs[0]
             return rx.defer(defer)
 
@@ -71,7 +71,7 @@ class TestDefer(unittest.TestCase):
             def defer(scheduler):
                 invoked[0] += 1
                 xs[0] = scheduler.create_cold_observable(
-                    on_next(100, scheduler.clock),
+                    on_next(100, scheduler._clock),
                     on_next(200, invoked[0]),
                     on_next(1100, 1000))
                 return xs[0]

--- a/tests/test_observable/test_map.py
+++ b/tests/test_observable/test_map.py
@@ -62,7 +62,7 @@ class TestSelect(unittest.TestCase):
         def projection(x, *args, **kw):
             invoked[0] += 1
 
-            if scheduler._clock > 400:
+            if scheduler.clock > 400:
                 d.dispose()
             return x
 
@@ -251,7 +251,7 @@ class TestSelect(unittest.TestCase):
 
         def projection(x, index):
             invoked[0] += 1
-            if scheduler._clock > 400:
+            if scheduler.clock > 400:
                 d.dispose()
 
             return x + index * 10

--- a/tests/test_observable/test_map.py
+++ b/tests/test_observable/test_map.py
@@ -62,7 +62,7 @@ class TestSelect(unittest.TestCase):
         def projection(x, *args, **kw):
             invoked[0] += 1
 
-            if scheduler.clock > 400:
+            if scheduler._clock > 400:
                 d.dispose()
             return x
 
@@ -251,7 +251,7 @@ class TestSelect(unittest.TestCase):
 
         def projection(x, index):
             invoked[0] += 1
-            if scheduler.clock > 400:
+            if scheduler._clock > 400:
                 d.dispose()
 
             return x + index * 10

--- a/tests/test_observable/test_starmap.py
+++ b/tests/test_observable/test_starmap.py
@@ -109,7 +109,7 @@ class TestSelect(unittest.TestCase):
 
         def mapper(x, y):
             invoked[0] += 1
-            if scheduler.clock > 250:
+            if scheduler._clock > 250:
                 d.dispose()
             return x + y
 

--- a/tests/test_observable/test_using.py
+++ b/tests/test_observable/test_using.py
@@ -41,7 +41,7 @@ class TestUsing(unittest.TestCase):
                 _d[0] = d
                 create_invoked[0] += 1
                 xs[0] = scheduler.create_cold_observable(
-                        on_next(100, scheduler._clock), on_completed(200))
+                        on_next(100, scheduler.clock), on_completed(200))
                 return xs[0]
             return rx.using(create_resources, create_observable)
 
@@ -72,7 +72,7 @@ class TestUsing(unittest.TestCase):
                 _d[0] = d
                 create_invoked[0] += 1
                 xs[0] = scheduler.create_cold_observable(
-                        on_next(100, scheduler._clock), on_completed(200))
+                        on_next(100, scheduler.clock), on_completed(200))
                 return xs[0]
             return rx.using(create_resource, create_observable)
 
@@ -104,7 +104,7 @@ class TestUsing(unittest.TestCase):
                 _d[0] = d
                 create_invoked[0] += 1
                 xs[0] = scheduler.create_cold_observable(
-                        on_next(100, scheduler._clock), on_error(200, ex))
+                        on_next(100, scheduler.clock), on_error(200, ex))
                 return xs[0]
             return rx.using(create_resource, create_observable)
         results = scheduler.start(create)
@@ -134,8 +134,8 @@ class TestUsing(unittest.TestCase):
                 _d[0] = d
                 create_invoked[0] += 1
                 xs[0] = scheduler.create_cold_observable(
-                        on_next(100, scheduler._clock),
-                        on_next(1000, scheduler._clock + 1))
+                        on_next(100, scheduler.clock),
+                        on_next(1000, scheduler.clock + 1))
                 return xs[0]
             return rx.using(create_resource, create_observable)
         results = scheduler.start(create)

--- a/tests/test_observable/test_using.py
+++ b/tests/test_observable/test_using.py
@@ -41,7 +41,7 @@ class TestUsing(unittest.TestCase):
                 _d[0] = d
                 create_invoked[0] += 1
                 xs[0] = scheduler.create_cold_observable(
-                        on_next(100, scheduler.clock), on_completed(200))
+                        on_next(100, scheduler._clock), on_completed(200))
                 return xs[0]
             return rx.using(create_resources, create_observable)
 
@@ -72,7 +72,7 @@ class TestUsing(unittest.TestCase):
                 _d[0] = d
                 create_invoked[0] += 1
                 xs[0] = scheduler.create_cold_observable(
-                        on_next(100, scheduler.clock), on_completed(200))
+                        on_next(100, scheduler._clock), on_completed(200))
                 return xs[0]
             return rx.using(create_resource, create_observable)
 
@@ -104,7 +104,7 @@ class TestUsing(unittest.TestCase):
                 _d[0] = d
                 create_invoked[0] += 1
                 xs[0] = scheduler.create_cold_observable(
-                        on_next(100, scheduler.clock), on_error(200, ex))
+                        on_next(100, scheduler._clock), on_error(200, ex))
                 return xs[0]
             return rx.using(create_resource, create_observable)
         results = scheduler.start(create)
@@ -134,8 +134,8 @@ class TestUsing(unittest.TestCase):
                 _d[0] = d
                 create_invoked[0] += 1
                 xs[0] = scheduler.create_cold_observable(
-                        on_next(100, scheduler.clock),
-                        on_next(1000, scheduler.clock + 1))
+                        on_next(100, scheduler._clock),
+                        on_next(1000, scheduler._clock + 1))
                 return xs[0]
             return rx.using(create_resource, create_observable)
         results = scheduler.start(create)


### PR DESCRIPTION
This supercedes https://github.com/ReactiveX/RxPY/pull/324 -- I've re-considered and decided to put in a little extra effort to submit a somewhat more topical PR.

In particular, I've left out some cosmetic changes which were not directly linked to the PriorityQueue or its related schedulers. They are entirely trivial changes, but polluted the already too large diff because they touch many files.

If we can reach agreement on this PR (I'd be happy to amend in response to suggestions or complaints, of course) I will submit the remaining polish commits at some later time.

As before, I've run every commit separately through Travis, you can see that all of them pass [here](https://github.com/erikkemperman/RxPY/commits/priorityqueue). I believe that the least annoying way to review this is one commit at a time -- nevertheless, I apologize that the PR is still pretty unwieldy...

I also figured I ought to be more verbose in motivating these changes... All links in the following refer to the current master branch, at [b3334408](https://github.com/ReactiveX/RxPY/tree/b333440871ad5e74dbdf5365fe99643f22f92c25):

- I noticed that the PriorityScheduler has some minor, superficial, quirks:
  - It declares a [`capacity`](https://github.com/ReactiveX/RxPY/blob/b333440871ad5e74dbdf5365fe99643f22f92c25/rx/internal/priorityqueue.py#L11) constructor arg, but it is not enforced. I prefer to err on the side of simplicity, so for the moment I propose removing the argument.
  - It declares a [`remove_at`](https://github.com/ReactiveX/RxPY/blob/b333440871ad5e74dbdf5365fe99643f22f92c25/rx/internal/priorityqueue.py#L29) method, but addressing the queue by index isn't a well-defined operation (note that while sorting the list maintains the heap invariant, but conversely a valid heap does not necessarily correspond to a sorted list).
  - The [`peek`](https://github.com/ReactiveX/RxPY/blob/b333440871ad5e74dbdf5365fe99643f22f92c25/rx/internal/priorityqueue.py#L27) method raises a custom InvalidOperationException when the queue is empty, but other methods don't and simply raise IndexError in the same circumstance.
  - It ought to be Generic, in the type of items in the queue.

- The methods of PriorityQueue are synchronized "coarsely", but I notice there is room to be a little more precise with locking the queues, if we define the queue itself to be unsynchronized and shift the burden to the classes that use it:
  - The CurrentThreadScheduler, it seems to me, should not need any explicit locks at all -- its own semantics ought to guarantee safety. But currently it is imposing a [second layer](https://github.com/ReactiveX/RxPY/blob/b333440871ad5e74dbdf5365fe99643f22f92c25/rx/concurrency/currentthreadscheduler.py#L46) of synchronization, on top of the queue's own lock.
  - Also, the CurrentThreadScheduler uses a [dict](https://github.com/ReactiveX/RxPY/blob/b333440871ad5e74dbdf5365fe99643f22f92c25/rx/concurrency/currentthreadscheduler.py#L45) to make sure that each invoking thread is mapped to its own queue. But that is just what `threading.local` does, no need to implement it manually (and leaking keys in the dict, as threads disappear).
  - Refactoring to address the above, we find that there is no longer a need for re-entrant locks and we can use the cheaper regular lock.

- Similar to the preceding arguments, more or less straightforward changes can be made to the other usages of the PriorityQueue, namely the EventLoopScheduler, VirtualTimeScheduler and PyGameScheduler.
  - The EventLoopScheduler, moreover, currently uses a separate [`Timer`](https://github.com/ReactiveX/RxPY/blob/b333440871ad5e74dbdf5365fe99643f22f92c25/rx/concurrency/eventloopscheduler.py#L145) which is unnecessary. Since threads are costly on some platforms, I propose avoiding them when it is easy to do so.
   - When using regular (non re-rentrant) locks, we have to be careful to call the `invoke` methods of scheduled items outside of the synchronized / critical sections -- otherwise recursive scheduling would go amiss. Fortunately the changes needed to achieve this for the affected schedulers aren't too complicated.

By the way, I'm not sure I understand the PyGameScheduler properly: I've made sure that I maintain the semantics that were before, but it seems odd to me that this scheduler doesn't actually rely on any pygame primitives?

Finally, I did include some polishing, but only on the files that were affected already.

Also, to get an idea of the impact on coverage, it might be nice to quickly try what I suggested in issue [#316](https://github.com/ReactiveX/RxPY/issues/316) -- it should take a couple of minutes, and there's no harm in trying since coverage reporting is currently not working?
 
Again, I apologize profusely for the inconvenience of such a large PR -- I hope that you agree there might be some benefit to these changes.