### PR TITLE
Simplify coveralls configuration (zero); fixes #316

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,2 +1,0 @@
-service_name: travis-pro
-repo_token: XXYpw6bql9Q6dtYESB2iMIUkeudK3Kiyy

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ matrix:
       python: 3.6
       # Coverage for the baseline 3.6 build: include some optional packages
       before_script:
-        - pip3 install eventlet gevent pyyaml tornado twisted
+        - pip3 install eventlet gevent tornado twisted
         # pycairo / pygobject need native libraries
         - sudo apt-get install -y libgirepository1.0-dev gir1.2-gtk-3.0
         - pip3 install pycairo pygobject

--- a/README.rst
+++ b/README.rst
@@ -5,8 +5,8 @@ The Reactive Extensions for Python (RxPY)
 .. image:: https://img.shields.io/travis/ReactiveX/RxPY.svg
         :target: https://travis-ci.org/ReactiveX/RxPY
 
-.. image:: https://img.shields.io/coveralls/dbrattli/RxPY.svg
-        :target: https://coveralls.io/r/dbrattli/RxPY
+.. image:: https://img.shields.io/coveralls/ReactiveX/RxPY.svg
+        :target: https://coveralls.io/github/ReactiveX/RxPY
 
 .. image:: https://img.shields.io/pypi/v/rx.svg
         :target: https://pypi.python.org/pypi/Rx


### PR DESCRIPTION
I was wondering if just removing custom Coveralls configuration and instead relying on automatic / defaults would fix #316. Looks like it does?

(Worked hard at the PQ stuff, would love to see a report with a little coverage bump :-) Comparing branches locally is tedious).