### PR TITLE
Doc: fixed docstrings and typing

### DIFF
--- a/doc/reference_scheduler.rst
+++ b/doc/reference_scheduler.rst
@@ -6,8 +6,10 @@ Schedulers
 .. automodule:: rx.concurrency
     :members: ImmediateScheduler, CurrentThreadScheduler, VirtualTimeScheduler,
                 TimeoutScheduler, NewThreadScheduler, ThreadPoolScheduler,
-                EventLoopScheduler, HistoricalScheduler, CatchScheduler,
-                AsyncIOScheduler, IOLoopScheduler, GEventScheduler,
+                EventLoopScheduler, HistoricalScheduler, CatchScheduler
+
+.. automodule:: rx.concurrency.mainloopscheduler
+    :members: AsyncIOScheduler, IOLoopScheduler, GEventScheduler,
                 GtkScheduler, TwistedScheduler, TkinterScheduler,
                 PyGameScheduler, QtScheduler, WxScheduler,
                 EventLetEventScheduler

--- a/rx/__init__.py
+++ b/rx/__init__.py
@@ -625,6 +625,7 @@ def start(func, scheduler=None) -> Observable:
         The function is called immediately, not during the subscription
         of the resulting sequence. Multiple subscriptions to the
         resulting sequence can observe the function's result.
+
     Returns:
         An observable sequence exposing the function's result value,
         or an exception.

--- a/rx/core/typing.py
+++ b/rx/core/typing.py
@@ -37,7 +37,7 @@ class Disposable(abc.Disposable):
         raise NotImplementedError
 
 
-ScheduledAction = Callable[['Scheduler', TState], Optional[Disposable]]
+ScheduledAction = Callable[[Scheduler, TState], Optional[Disposable]]
 ScheduledPeriodicAction = Callable[[TState], TState]
 
 

--- a/rx/operators/__init__.py
+++ b/rx/operators/__init__.py
@@ -1643,12 +1643,14 @@ def on_error_resume_next(second: Observable) -> Callable[[Observable], Observabl
         -1--2--3--4-a--b-|
 
     Keyword arguments:
-    second -- Second observable sequence used to produce results
-        after the first sequence terminates.
+        second: Second observable sequence used to produce results
+            after the first sequence terminates.
 
-    Returns an observable sequence that concatenates the first and
-    second sequence, even if the first sequence terminates
-    exceptionally.
+
+    Returns:
+        An observable sequence that concatenates the first and
+        second sequence, even if the first sequence terminates
+        exceptionally.
     """
 
     from rx.core.operators.onerrorresumenext import _on_error_resume_next
@@ -2082,7 +2084,7 @@ def share() -> Callable[[Observable], Observable]:
 
 
 def single(predicate: Predicate = None) -> Callable[[Observable], Observable]:
-    """The `single`operator.
+    """The single operator.
 
     Returns the only element of an observable sequence that satisfies
     the condition in the optional predicate, and reports an exception
@@ -2385,7 +2387,7 @@ def skip_with_time(duration: typing.RelativeTime, scheduler: typing.Scheduler = 
     result sequence, even if the error occurs before the duration.
 
     Args:
-    duration: Duration for skipping elements from the start of the
+        duration: Duration for skipping elements from the start of the
         sequence.
 
     Returns:


### PR DESCRIPTION
This PR fixes doc strings comments that generate warnings in sphinx.
I also changed the typing of *ScheduledAction* in *rx/core/typing.py*. I suppose that this was a typo ? 