### PR TITLE
Sphinx

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,7 +68,6 @@ TestResults/Rx.TE.Tests_log.ldf
 
 .ipynb_checkpoints
 .cache/
-.mypy_cache/
 .vscode/
 .noseids
 _build

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -11,23 +11,36 @@
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
-#
+
 import os
+import re
 import sys
 import guzzle_sphinx_theme
-sys.path.insert(0, os.path.abspath('../'))
+from configparser import ConfigParser
+
+root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+sys.path.insert(0, root)
 
 
 # -- Project information -----------------------------------------------------
 
-project = 'RxPY'
-copyright = '2018, Dag Brattli'
-author = 'Dag Brattli'
+# General project metadata is stored in project.cfg
+with open(os.path.join(root, 'project.cfg')) as project_file:
+    config = ConfigParser()
+    config.read_file(project_file)
+    project_meta = dict(config.items('project'))
 
-# The short X.Y version
-version = '3.0'
+project = project_meta['project']
+author = project_meta['author']
+copyright = project_meta['copyright']
+description = project_meta['description']
+url = project_meta['url']
+title = project + ' Documentation'
+
 # The full version, including alpha/beta/rc tags
-release = '3.0.0-alpha1'
+release = project_meta['version']
+# The short X.Y.Z version
+version = re.sub('[^0-9.].*$', '', release)
 
 
 # -- General configuration ---------------------------------------------------
@@ -82,8 +95,8 @@ pygments_style = 'sphinx'
 html_translator_class = 'guzzle_sphinx_theme.HTMLTranslator'
 html_theme_path = guzzle_sphinx_theme.html_theme_path()
 html_theme = 'guzzle_sphinx_theme'
-html_title = "RxPY Documentation"
-html_short_title = "RxPY 3.0"
+html_title = title
+html_short_title = project + ' ' + version
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
@@ -91,7 +104,7 @@ html_short_title = "RxPY 3.0"
 #
 # html_theme_options = {}
 html_theme_options = {
-    "projectlink": "https://github.com/ReactiveX/RxPY",
+    'projectlink': url,
 }
 
 # Add any paths that contain custom static files (such as style sheets) here,
@@ -116,7 +129,7 @@ html_sidebars = {
 # -- Options for HTMLHelp output ---------------------------------------------
 
 # Output file base name for HTML help builder.
-htmlhelp_basename = 'RxPYdoc'
+htmlhelp_basename = project + 'doc'
 
 
 # -- Options for LaTeX output ------------------------------------------------
@@ -143,8 +156,7 @@ latex_elements = {
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-    (master_doc, 'RxPY.tex', 'RxPY Documentation',
-     'Dag Brattli', 'manual'),
+    (master_doc, project + '.tex', title, author, 'manual')
 ]
 
 
@@ -153,8 +165,7 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    (master_doc, 'rxpy', 'RxPY Documentation',
-     [author], 1)
+    (master_doc, project.lower(), title, [author], 1)
 ]
 
 
@@ -164,9 +175,7 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-    (master_doc, 'RxPY', 'RxPY Documentation',
-     author, 'RxPY', 'One line description of project.',
-     'Miscellaneous'),
+    (master_doc, project, title, author, project, description, 'Miscellaneous')
 ]
 
 

--- a/project.cfg
+++ b/project.cfg
@@ -1,0 +1,11 @@
+[project]
+name = Rx
+project = RxPY
+version = 3.0.0-alpha2
+description = Reactive Extensions (Rx) for Python
+author = Dag Brattli
+author_email = dag@brattli.net
+copyright = 2018-2019, Dag Bratlli
+license = Apache License v2.0
+url = http://reactivex.io
+download_url = https://github.com/ReactiveX/RxPY

--- a/rx/core/typing.py
+++ b/rx/core/typing.py
@@ -38,10 +38,6 @@ class Disposable(abc.Disposable):
         raise NotImplementedError
 
 
-ScheduledAction = Callable[['Scheduler', TState], Optional[Disposable]]
-ScheduledPeriodicAction = Callable[[TState], TState]
-
-
 class Scheduler(abc.Scheduler):
     __slots__ = ()
 
@@ -51,17 +47,21 @@ class Scheduler(abc.Scheduler):
         return NotImplemented
 
     @abstractmethod
-    def schedule(self, action: ScheduledAction, state: TState = None) -> Disposable:
+    def schedule(self, action: 'ScheduledAction', state: TState = None) -> Disposable:
         return NotImplemented
 
     @abstractmethod
-    def schedule_relative(self, duetime: RelativeTime, action: ScheduledAction, state: TState = None) -> Disposable:
+    def schedule_relative(self, duetime: RelativeTime, action: 'ScheduledAction', state: TState = None) -> Disposable:
         return NotImplemented
 
     @abstractmethod
-    def schedule_absolute(self, duetime: AbsoluteTime, action: ScheduledAction, state: TState = None) -> Disposable:
+    def schedule_absolute(self, duetime: AbsoluteTime, action: 'ScheduledAction', state: TState = None) -> Disposable:
         return NotImplemented
 
+
+ScheduledAction = Callable[[Scheduler, Optional[TState]], Optional[Disposable]]
+ScheduledPeriodicAction = Callable[[Optional[TState]], TState]
+ScheduledSingleOrPeriodicAction = Union[ScheduledAction, ScheduledPeriodicAction]
 
 Startable = Union[abc.Startable, Thread]
 StartableTarget = Callable[..., None]

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@
 #tag_svn_revision = 1
 
 [aliases]
-test=pytest
+test = pytest
 
 [tool:pytest]
 testpaths = tests

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 try:
     from setuptools import setup
 except ImportError:
@@ -5,19 +7,34 @@ except ImportError:
     use_setuptools()
     from setuptools import setup
 
+from configparser import ConfigParser
+
+
+# General project metadata is stored in project.cfg
+with open('project.cfg') as project_file:
+    config = ConfigParser()
+    config.read_file(project_file)
+    project_meta = dict(config.items('project'))
+
+
+# Populate the long_description field from README.rst
 with open('README.rst') as readme_file:
-    readme = readme_file.read()
+    project_meta['long_description'] = readme_file.read()
+
 
 setup(
-    name='Rx',
-    version='3.0.0-alpha2',
-    description='Reactive Extensions (Rx) for Python',
-    long_description=readme,
-    author='Dag Brattli',
-    author_email='dag@brattli.net',
-    license='Apache License',
-    url='http://reactivex.io',
-    download_url='https://github.com/ReactiveX/RxPY',
+    **{key: project_meta[key] for key in (
+        'name',
+        'version',
+        'description',
+        'long_description',
+        'author',
+        'author_email',
+        'license',
+        'url',
+        'download_url'
+    )},
+
     zip_safe=True,
     python_requires='>=3.6.0',
 
@@ -29,9 +46,10 @@ setup(
         'License :: OSI Approved :: Apache Software License',
         'Operating System :: OS Independent',
         'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: Implementation :: CPython',
-        'Topic :: Software Development :: Libraries :: Python Modules',
+        'Topic :: Software Development :: Libraries :: Python Modules'
     ],
     setup_requires=['pytest-runner'],
     tests_require=['pytest', "pytest-asyncio"],
@@ -43,5 +61,5 @@ setup(
               'rx.operators', 'rx.disposable', 'rx.subjects',
               'rx.testing'],
     package_dir={'rx': 'rx'},
-    include_package_data=True,
+    include_package_data=True
 )


### PR DESCRIPTION
I thought it might make sense to consolidate some project metadata in a single file, and to reference that from `setup.py` as well as `doc/conf.py`.

This PR also gets rid of a bunch of warnings when running sphinx-build (specifically, it seems sphinx can't handle forward type references within square brackets, but it does understand them in function arg annotations.)

Finally, I would like to propose having the generated documentation hosted on readthedocs.org -- it seems trivial to set up, and subsequently there will be automatic doc builds whenever the default branch or a tag is pushed to github.

Does that sound like a good idea, or worth a try at least? If so, I guess @dbrattli would have the permissions to do so; perhaps you could check https://readthedocs.org (signing up / singing in through github should allow you to import the project with a few clicks). We can always throw it away if it doesn't work well.
