### PR TITLE
Slightly relaxed timings in eventloop test, fixes #337

### DIFF
--- a/tests/test_concurrency/test_eventloopscheduler.py
+++ b/tests/test_concurrency/test_eventloopscheduler.py
@@ -69,8 +69,8 @@ class TestEventLoopScheduler(unittest.TestCase):
             result.append(3)
             gate.release()
 
-        scheduler.schedule_relative(0.10, action)
-        scheduler.schedule_relative(0.05, lambda s, t: result.append(2))
+        scheduler.schedule_relative(0.2, action)
+        scheduler.schedule_relative(0.1, lambda s, t: result.append(2))
         scheduler.schedule(lambda s, t: result.append(1))
 
         gate.acquire()


### PR DESCRIPTION
I just ran the eventloop tests 500 times on my (pretty fast) desktop, zero errors. So I think the timings were just slightly too aggressive for the (pretty slow) VMs that Travis spins up to run the tests -- causing the first scheduled action to run, and release the semaphore, before the second was even scheduled.