### PR TITLE
Fix GtkScheduler and its tests

### DIFF
--- a/rx/concurrency/mainloopscheduler/gtkscheduler.py
+++ b/rx/concurrency/mainloopscheduler/gtkscheduler.py
@@ -57,7 +57,7 @@ class GtkScheduler(SchedulerBase):
             The disposable object used to cancel the scheduled action
             (best effort).
         """
-        return self._gtk_schedule(duetime, action, state)
+        return self._gtk_schedule(duetime, action, state=state)
 
     def schedule_absolute(self, duetime: typing.AbsoluteTime, action: typing.ScheduledAction,
                           state: typing.TState = None) -> typing.Disposable:
@@ -73,7 +73,7 @@ class GtkScheduler(SchedulerBase):
         """
 
         duetime = self.to_datetime(duetime)
-        return self._gtk_schedule(duetime, action, state)
+        return self._gtk_schedule(duetime - self.now, action, state=state)
 
     def schedule_periodic(self, period: typing.RelativeTime, action: typing.ScheduledPeriodicAction,
                           state: typing.TState = None):


### PR DESCRIPTION
I fixed an error in the GtkScheduler, but at first I did not understand why this was not caught by the unittests earlier...

A little bit weird: it might be dangerous to do assertions from within callbacks -- at least in this case of the GtkScheduler, it seems that the thread which invokes the callbacks eats exceptions, so they never actually cause the unit tests to fail...

I think some of the other tests might have to be visited to check for this phenomenon as well, hopefully I might find some time to do that the next couple of days.