### PR TITLE
fix from_iterable: add scheduler parameter in public API

### DIFF
--- a/rx/__init__.py
+++ b/rx/__init__.py
@@ -245,7 +245,7 @@ def from_future(future: _Future) -> Observable:
     return _from_future(future)
 
 
-def from_iterable(iterable: Iterable) -> Observable:
+def from_iterable(iterable: Iterable, scheduler: typing.Scheduler = None) -> Observable:
     """Converts an iterable to an observable sequence.
 
     Example:
@@ -260,7 +260,7 @@ def from_iterable(iterable: Iterable) -> Observable:
         given iterable sequence.
     """
     from .core.observable.fromiterable import from_iterable as from_iterable_
-    return from_iterable_(iterable)
+    return from_iterable_(iterable, scheduler)
 
 
 from_ = from_iterable


### PR DESCRIPTION
The *scheduler* parameter is missing for the `from_iterable` operator in the public API.

I assume this is an oversight because *scheduler* parameter is declared in the implementation file:
https://github.com/ReactiveX/RxPY/blob/9752a0018bac74b88fd153e308bc55e09ec16a9d/rx/core/observable/fromiterable.py#L8-L10

I've tried to add some tests but I didn't find an easy way to test the scheduler selection mechanism. 