### PR TITLE
fix: range operator drops scheduler argument

### DIFF
--- a/rx/__init__.py
+++ b/rx/__init__.py
@@ -561,7 +561,7 @@ def range(start: int, stop: int = None, step: int = None, scheduler: typing.Sche
         integral numbers.
     """
     from .core.observable.range import _range
-    return _range(start, stop, step)
+    return _range(start, stop, step, scheduler)
 
 
 def return_value(value: Any, scheduler: typing.Scheduler = None) -> Observable:


### PR DESCRIPTION
`range` operator actually drops the scheduler when specified thru the public API.