### PR TITLE
Don't instantiate new CurrentThreadScheduler._Local with each scheduler instance

### DIFF
--- a/rx/concurrency/currentthreadscheduler.py
+++ b/rx/concurrency/currentthreadscheduler.py
@@ -47,6 +47,7 @@ class CurrentThreadScheduler(SchedulerBase):
     that will block the current thread while waiting.
     """
 
+    _local = _Local()
     _global: MutableMapping[threading.Thread, 'CurrentThreadScheduler'] = WeakKeyDictionary()
 
     def __new__(cls) -> 'CurrentThreadScheduler':
@@ -62,9 +63,7 @@ class CurrentThreadScheduler(SchedulerBase):
     def __init__(self) -> None:
         """Creates a scheduler that schedules work as soon as possible
         on the current thread."""
-
         super().__init__()
-        self._local = _Local()
 
     def schedule(self,
                  action: typing.ScheduledAction,
@@ -127,7 +126,7 @@ class CurrentThreadScheduler(SchedulerBase):
 
         si: ScheduledItem[typing.TState] = ScheduledItem(self, state, action, duetime)
 
-        local: _Local = self._local
+        local: _Local = CurrentThreadScheduler._local
         local.queue.enqueue(si)
         if local.idle:
             local.idle = False
@@ -147,7 +146,7 @@ class CurrentThreadScheduler(SchedulerBase):
         False; otherwise, if the trampoline is not active, then it
         returns True.
         """
-        return self._local.idle
+        return CurrentThreadScheduler._local.idle
 
     def ensure_trampoline(self, action):
         """Method for testing the CurrentThreadScheduler."""

--- a/rx/concurrency/currentthreadscheduler.py
+++ b/rx/concurrency/currentthreadscheduler.py
@@ -45,6 +45,15 @@ class CurrentThreadScheduler(SchedulerBase):
     """Represents an object that schedules units of work on the current thread.
     You never want to schedule timeouts using the CurrentThreadScheduler since
     that will block the current thread while waiting.
+
+    Please note, there will be at most a single instance per thread -- calls to
+    the constructor will just return the same instance if one already exists.
+
+    Conversely, if you pass an instance to another thread, it will effectively
+    behave as a separate scheduler, with its own queue. In particular, this
+    implies that you can't make assumptions about the execution order of items
+    that were scheduled by different threads -- even if they were submitted to
+    what superficially appears to be a single scheduler instance.
     """
 
     _local = _Local()


### PR DESCRIPTION
This fixes the problem pointed out by @MichaelSchneeberger in https://github.com/ReactiveX/RxPY/issues/358.