### PR TITLE
Scheduler coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,6 @@ TestResults/Rx.TE.Tests_log.ldf
 .vscode/
 .noseids
 _build
+
+# Mac OS
+.DS_Store

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ matrix:
     - os: linux
       dist: xenial
       language: python
-      python: 3.6
+      python: '3.6'
       # Coverage for the baseline 3.6 build: include some optional packages
       before_script:
         # install some packages to ensure all of the optional tests are covered
@@ -22,21 +22,21 @@ matrix:
     - os: linux
       dist: xenial
       language: python
-      python: 3.7
+      python: '3.7'
 
     - os: linux
       dist: xenial
       language: python
-      python: 3.8-dev
+      python: '3.8-dev'
 
     - os: osx
       osx_image: xcode10.1
       language: sh
-      python: 3.7
+      python: '3.7'
 
     - os: windows
       language: sh
-      python: 3.7
+      python: '3.7'
       before_install:
         - choco install python3
         - ln -s "/c/Python37/python.exe" "/c/Python37/python3.exe"

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,8 @@ matrix:
       python: 3.6
       # Coverage for the baseline 3.6 build: include some optional packages
       before_script:
-        - pip3 install eventlet gevent pygame tornado twisted
+        # install some packages to ensure all of the optional tests are covered
+        - pip3 install eventlet gevent pygame pyqt5 pyside2 tornado twisted
         # pycairo / pygobject need native libraries
         - sudo apt-get install -y libgirepository1.0-dev gir1.2-gtk-3.0
         - pip3 install pycairo pygobject

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,11 @@ matrix:
         # pycairo / pygobject need native libraries
         - sudo apt-get install -y libgirepository1.0-dev gir1.2-gtk-3.0
         - pip3 install pycairo pygobject
+        # wxpython needs native libraries
+        - sudo apt-get install -y freeglut3 freeglut3-dev libgtk-3-dev
+          libgstreamer-plugins-base1.0-0 libgstreamer-plugins-base1.0-dev
+          libgstreamer1.0-0 libgstreamer1.0-dev libsdl2-dev
+        - pip3 install -U -f https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-16.04 wxPython
       script:
         - coverage run --source=rx setup.py test && coveralls
 

--- a/README.rst
+++ b/README.rst
@@ -91,8 +91,8 @@ Differences from .NET and RxJS
 
 RxPY is a fairly complete implementation of
 `Rx <http://reactivex.io/>`_ with more than
-`134 query operators <http://reactivex.io/documentation/operators.html>`_, and
-over `1100 passing unit-tests <https://coveralls.io/github/dbrattli/RxPY>`_. RxPY
+`120 operators <https://rxpy.readthedocs.io/en/latest/operators.html>`_, and
+over `1300 passing unit-tests <https://coveralls.io/github/ReactiveX/RxPY>`_. RxPY
 is mostly a direct port of RxJS, but also borrows a bit from RxNET and RxJava in
 terms of threading and blocking operators.
 

--- a/examples/timeflies/timeflies_qt.py
+++ b/examples/timeflies/timeflies_qt.py
@@ -13,8 +13,7 @@ except ImportError:
         from PySide2 import QtCore
         from PySide2.QtWidgets import QApplication, QLabel, QWidget
     except ImportError:
-        from PyQt4 import QtCore
-        from PyQt4.QtGui import QWidget, QLabel, QApplication
+        raise ImportError('Please ensure either PyQT5 or PySide2 is available!')
 
 
 class Window(QWidget):

--- a/rx/concurrency/catchscheduler.py
+++ b/rx/concurrency/catchscheduler.py
@@ -123,16 +123,15 @@ class CatchScheduler(SchedulerBase):
 
         def periodic_action(periodic_state) -> Optional[typing.TState]:
             nonlocal failed
-            if failed:
-                return None
-            try:
-                return action(periodic_state)
-            except Exception as ex:
-                failed = True
-                if not self._handler(ex):
-                    raise Exception(ex)
-                d.dispose()
-                return None
+            if not failed:
+                try:
+                    return action(periodic_state)
+                except Exception as ex:
+                    failed = True
+                    if not self._handler(ex):
+                        raise
+                    d.dispose()
+                    return None
 
         d.disposable = self._scheduler.schedule_periodic(period, periodic_action, state=state)
         return d
@@ -150,7 +149,7 @@ class CatchScheduler(SchedulerBase):
                 return action(parent._get_recursive_wrapper(self), state)
             except Exception as ex:
                 if not parent._handler(ex):
-                    raise Exception(ex)
+                    raise
                 return Disposable()
 
         return wrapped_action

--- a/rx/concurrency/mainloopscheduler/wxscheduler.py
+++ b/rx/concurrency/mainloopscheduler/wxscheduler.py
@@ -21,7 +21,7 @@ class WxScheduler(SchedulerBase):
         class Timer(wx.Timer):
 
             def __init__(self, callback) -> None:
-                super(Timer, self).__init__()
+                super().__init__()
                 self.callback = callback
 
             def Notify(self):
@@ -56,10 +56,8 @@ class WxScheduler(SchedulerBase):
                 sad.disposable = action(scheduler, state)
 
         msecs = int(self.to_seconds(time) * 1000.0)
-        if msecs == 0:
-            msecs = 1  # wx.Timer doesn't support zero.
 
-        log.debug("timeout: %s", msecs)
+        log.debug("timeout wx: %s", msecs)
 
         timer = self._timer_class(interval)
         timer.Start(
@@ -127,7 +125,7 @@ class WxScheduler(SchedulerBase):
         """
 
         duetime = self.to_datetime(duetime)
-        return self._wxtimer_schedule(duetime, action, state=state)
+        return self._wxtimer_schedule(duetime - self.now, action, state=state)
 
     def schedule_periodic(self,
                           period: typing.RelativeTime,

--- a/rx/concurrency/scheduleditem.py
+++ b/rx/concurrency/scheduleditem.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from typing import Generic, Optional
 
 from rx.core import typing
@@ -12,12 +13,12 @@ class ScheduledItem(Generic[typing.TState]):  # pylint: disable=unsubscriptable-
                  scheduler: SchedulerBase,
                  state: Optional[typing.TState],
                  action: typing.ScheduledAction,
-                 duetime: typing.AbsoluteTime
+                 duetime: datetime
                  ) -> None:
         self.scheduler: SchedulerBase = scheduler
         self.state: Optional[typing.TState] = state
         self.action: typing.ScheduledAction = action
-        self.duetime: typing.AbsoluteTime = duetime
+        self.duetime: datetime = duetime
         self.disposable: SingleAssignmentDisposable = SingleAssignmentDisposable()
 
     def invoke(self) -> None:

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
         'Topic :: Software Development :: Libraries :: Python Modules'
     ],
     setup_requires=['pytest-runner'],
-    tests_require=['pytest', "pytest-asyncio"],
+    tests_require=['pytest', 'pytest-asyncio', 'coverage'],
 
     packages=['rx', 'rx.internal', 'rx.core', 'rx.core.abc',
               'rx.core.operators', 'rx.core.observable',

--- a/tests/test_concurrency/test_catchscheduler.py
+++ b/tests/test_concurrency/test_catchscheduler.py
@@ -1,0 +1,324 @@
+import unittest
+from datetime import timedelta
+
+from rx.concurrency import CatchScheduler, VirtualTimeScheduler
+
+
+class MyException(Exception):
+    pass
+
+
+class CatchSchedulerTestScheduler(VirtualTimeScheduler):
+
+    def __init__(self, initial_clock=0.0):
+        super().__init__(initial_clock)
+        self.exc = None
+
+    def add(self, absolute, relative):
+        return absolute + relative
+
+    def _wrap(self, action):
+        def _action(scheduler, state=None):
+            ret = None
+            try:
+                ret = action(scheduler, state)
+            except MyException as e:
+                self.exc = e
+            finally:
+                return ret
+        return _action
+
+    def schedule_absolute(self, duetime, action, state=None):
+        action = self._wrap(action)
+        return super().schedule_absolute(duetime, action, state=state)
+
+
+class TestCatchScheduler(unittest.TestCase):
+
+    def test_catch_now(self):
+        wrapped = CatchSchedulerTestScheduler()
+        scheduler = CatchScheduler(wrapped, lambda ex: True)
+        diff = scheduler.now - wrapped.now
+        assert abs(diff) < timedelta(milliseconds=1)
+
+    def test_catch_now_units(self):
+        wrapped = CatchSchedulerTestScheduler()
+        scheduler = CatchScheduler(wrapped, lambda ex: True)
+        diff = scheduler.now
+        wrapped.sleep(0.1)
+        diff = scheduler.now - diff
+        assert timedelta(milliseconds=80) < diff < timedelta(milliseconds=180)
+
+    def test_catch_schedule(self):
+        ran = False
+        handled = False
+
+        def action(scheduler, state):
+            nonlocal ran
+            ran = True
+
+        def handler(_):
+            nonlocal handled
+            handled = True
+            return True
+
+        wrapped = CatchSchedulerTestScheduler()
+        scheduler = CatchScheduler(wrapped, handler)
+
+        scheduler.schedule(action)
+        wrapped.start()
+        assert ran is True
+        assert handled is False
+        assert wrapped.exc is None
+
+    def test_catch_schedule_relative(self):
+        ran = False
+        handled = False
+
+        def action(scheduler, state):
+            nonlocal ran
+            ran = True
+
+        def handler(_):
+            nonlocal handled
+            handled = True
+            return True
+
+        wrapped = CatchSchedulerTestScheduler()
+        scheduler = CatchScheduler(wrapped, handler)
+
+        scheduler.schedule_relative(0.1, action)
+        wrapped.start()
+        assert ran is True
+        assert handled is False
+        assert wrapped.exc is None
+
+    def test_catch_schedule_absolute(self):
+        ran = False
+        handled = False
+
+        def action(scheduler, state):
+            nonlocal ran
+            ran = True
+
+        def handler(_):
+            nonlocal handled
+            handled = True
+            return True
+
+        wrapped = CatchSchedulerTestScheduler()
+        scheduler = CatchScheduler(wrapped, handler)
+
+        scheduler.schedule_absolute(0.1, action)
+        wrapped.start()
+        assert ran is True
+        assert handled is False
+        assert wrapped.exc is None
+
+    def test_catch_schedule_error_handled(self):
+        ran = False
+        handled = False
+
+        def action(scheduler, state):
+            nonlocal ran
+            ran = True
+            raise MyException()
+
+        def handler(_):
+            nonlocal handled
+            handled = True
+            return True
+
+        wrapped = CatchSchedulerTestScheduler()
+        scheduler = CatchScheduler(wrapped, handler)
+
+        scheduler.schedule(action)
+        wrapped.start()
+        assert ran is True
+        assert handled is True
+        assert wrapped.exc is None
+
+    def test_catch_schedule_error_unhandled(self):
+        ran = False
+        handled = False
+
+        def action(scheduler, state):
+            nonlocal ran
+            ran = True
+            raise MyException()
+
+        def handler(_):
+            nonlocal handled
+            handled = True
+            return False
+
+        wrapped = CatchSchedulerTestScheduler()
+        scheduler = CatchScheduler(wrapped, handler)
+
+        scheduler.schedule(action)
+        wrapped.start()
+        assert ran is True
+        assert handled is True
+        assert isinstance(wrapped.exc, MyException)
+
+    def test_catch_schedule_nested(self):
+        ran = False
+        handled = False
+
+        def inner(scheduler, state):
+            nonlocal ran
+            ran = True
+
+        def outer(scheduler, state):
+            scheduler.schedule(inner)
+
+        def handler(_):
+            nonlocal handled
+            handled = True
+            return True
+
+        wrapped = CatchSchedulerTestScheduler()
+        scheduler = CatchScheduler(wrapped, handler)
+
+        scheduler.schedule(outer)
+        wrapped.start()
+
+        assert ran is True
+        assert handled is False
+        assert wrapped.exc is None
+
+    def test_catch_schedule_nested_error_handled(self):
+        ran = False
+        handled = False
+
+        def inner(scheduler, state):
+            nonlocal ran
+            ran = True
+            raise MyException()
+
+        def outer(scheduler, state):
+            scheduler.schedule(inner)
+
+        def handler(_):
+            nonlocal handled
+            handled = True
+            return True
+
+        wrapped = CatchSchedulerTestScheduler()
+        scheduler = CatchScheduler(wrapped, handler)
+
+        scheduler.schedule(outer)
+        wrapped.start()
+        assert ran is True
+        assert handled is True
+        assert wrapped.exc is None
+
+    def test_catch_schedule_nested_error_unhandled(self):
+        ran = False
+        handled = False
+
+        def inner(scheduler, state):
+            nonlocal ran
+            ran = True
+            raise MyException()
+
+        def outer(scheduler, state):
+            scheduler.schedule(inner)
+
+        def handler(_):
+            nonlocal handled
+            handled = True
+            return False
+
+        wrapped = CatchSchedulerTestScheduler()
+        scheduler = CatchScheduler(wrapped, handler)
+
+        scheduler.schedule(outer)
+        wrapped.start()
+        assert ran is True
+        assert handled is True
+        assert isinstance(wrapped.exc, MyException)
+
+    def test_catch_schedule_periodic(self):
+        period = 0.05
+        counter = 3
+        handled = False
+
+        def action(state):
+            nonlocal counter
+            if state:
+                counter -= 1
+                return state - 1
+            if counter == 0:
+                disp.dispose()
+
+        def handler(_):
+            nonlocal handled
+            handled = True
+            return True
+
+        wrapped = CatchSchedulerTestScheduler()
+        scheduler = CatchScheduler(wrapped, handler)
+
+        disp = scheduler.schedule_periodic(period, action, counter)
+        wrapped.start()
+        assert counter == 0
+        assert handled is False
+        assert wrapped.exc is None
+
+    def test_catch_schedule_periodic_error_handled(self):
+        period = 0.05
+        counter = 3
+        handled = False
+
+        def action(state):
+            nonlocal counter
+            if state:
+                counter -= 1
+                return state - 1
+            if counter == 0:
+                raise MyException()
+
+        def handler(_):
+            nonlocal handled
+            handled = True
+            disp.dispose()
+            return True
+
+        wrapped = CatchSchedulerTestScheduler()
+        scheduler = CatchScheduler(wrapped, handler)
+
+        disp = scheduler.schedule_periodic(period, action, counter)
+        wrapped.start()
+        assert counter == 0
+        assert handled is True
+        assert wrapped.exc is None
+
+    def test_catch_schedule_periodic_error_unhandled(self):
+        period = 0.05
+        counter = 3
+        handled = False
+
+        def action(state):
+            nonlocal counter
+            if state:
+                counter -= 1
+                return state - 1
+            if counter == 0:
+                raise MyException()
+
+        def handler(_):
+            nonlocal handled
+            handled = True
+            disp.dispose()
+            return False
+
+        wrapped = CatchSchedulerTestScheduler()
+        scheduler = CatchScheduler(wrapped, handler)
+
+        disp = scheduler.schedule_periodic(period, action, counter)
+        wrapped.start()
+        assert counter == 0
+        assert handled is True
+        assert isinstance(wrapped.exc, MyException)
+

--- a/tests/test_concurrency/test_eventloopscheduler.py
+++ b/tests/test_concurrency/test_eventloopscheduler.py
@@ -79,8 +79,8 @@ class TestEventLoopScheduler(unittest.TestCase):
             result.append(3)
             gate.release()
 
-        scheduler.schedule_relative(0.2, action)
-        scheduler.schedule_relative(0.1, lambda s, t: result.append(2))
+        scheduler.schedule_relative(0.4, action)
+        scheduler.schedule_relative(0.2, lambda s, t: result.append(2))
         scheduler.schedule(lambda s, t: result.append(1))
 
         gate.acquire()
@@ -94,8 +94,8 @@ class TestEventLoopScheduler(unittest.TestCase):
 
         def action(scheduler, state):
             result.append(1)
+            scheduler.schedule_relative(0.2, action3)
             scheduler.schedule(action2)
-            scheduler.schedule_relative(0.10, action3)
 
         def action2(scheduler, state):
             result.append(2)
@@ -210,7 +210,7 @@ class TestEventLoopScheduler(unittest.TestCase):
         assert ran is False
         assert scheduler._has_thread() is False
 
-    def test_eventloop_schedule_periodic_dispose(self):
+    def test_eventloop_schedule_periodic_dispose_error(self):
         scheduler = EventLoopScheduler(exit_if_empty=False)
 
         scheduler.dispose()
@@ -222,7 +222,7 @@ class TestEventLoopScheduler(unittest.TestCase):
             ran = True
 
         with pytest.raises(DisposedException):
-            scheduler.schedule_periodic(0.1, scheduler.now, action)
+            scheduler.schedule_periodic(0.1, action)
 
         assert ran is False
         assert scheduler._has_thread() is False

--- a/tests/test_concurrency/test_mainloopscheduler/test_qtscheduler.py
+++ b/tests/test_concurrency/test_mainloopscheduler/test_qtscheduler.py
@@ -15,11 +15,7 @@ except ImportError:
         from PySide2 import QtCore
         from PySide2.QtGui import QGuiApplication as QApplication
     except ImportError:
-        try:
-            from PyQt4 import QtCore
-            from PyQt4.QtGui import QApplication
-        except ImportError:
-            skip = True
+        skip = True
 
 if not skip:
     from rx.concurrency.mainloopscheduler import QtScheduler

--- a/tests/test_concurrency/test_mainloopscheduler/test_qtscheduler.py
+++ b/tests/test_concurrency/test_mainloopscheduler/test_qtscheduler.py
@@ -9,11 +9,9 @@ from time import sleep
 skip = False
 try:
     from PyQt5 import QtCore
-    from PyQt5.QtWidgets import QApplication
 except ImportError:
     try:
         from PySide2 import QtCore
-        from PySide2.QtGui import QGuiApplication as QApplication
     except ImportError:
         skip = True
 
@@ -27,9 +25,9 @@ app = None  # Prevent garbage collection
 
 def make_app():
     global app
-    app = QApplication.instance()
+    app = QtCore.QCoreApplication.instance()
     if app is None:
-        app = QApplication([])
+        app = QtCore.QCoreApplication([])
     return app
 
 

--- a/tests/test_concurrency/test_mainloopscheduler/test_qtscheduler_qt5.py
+++ b/tests/test_concurrency/test_mainloopscheduler/test_qtscheduler_qt5.py
@@ -1,0 +1,200 @@
+import unittest
+import threading
+from datetime import timedelta
+from time import sleep
+import pytest
+
+
+skip = False
+try:
+    from PyQt5 import QtCore
+    from PyQt5.QtWidgets import QApplication
+except ImportError:
+    skip = True
+
+if not skip:
+    from rx.concurrency.mainloopscheduler import QtScheduler
+    from rx.internal.basic import default_now
+
+
+app = None  # Prevent garbage collection
+
+
+def make_app():
+    global app
+    app = QApplication.instance()
+    if app is None:
+        app = QApplication([])
+    return app
+
+
+@pytest.mark.skipif("skip == True")
+class TestQtSchedulerQt5(unittest.TestCase):
+
+    def test_qt5_schedule_now(self):
+        scheduler = QtScheduler(QtCore)
+        diff = scheduler.now - default_now()
+        assert abs(diff) < timedelta(milliseconds=1)
+
+    def test_qt5_schedule_now_units(self):
+        scheduler = QtScheduler(QtCore)
+        diff = scheduler.now
+        sleep(0.1)
+        diff = scheduler.now - diff
+        assert timedelta(milliseconds=80) < diff < timedelta(milliseconds=180)
+
+    def test_qt5_schedule_action(self):
+        app = make_app()
+
+        scheduler = QtScheduler(QtCore)
+        gate = threading.Semaphore(0)
+        ran = False
+
+        def action(scheduler, state):
+            nonlocal ran
+            ran = True
+
+        scheduler.schedule(action)
+
+        def done():
+            app.quit()
+            gate.release()
+
+        QtCore.QTimer.singleShot(50, done)
+        app.exec_()
+
+        gate.acquire()
+        assert ran is True
+
+    def test_qt5_schedule_action_due_relative(self):
+        app = make_app()
+
+        scheduler = QtScheduler(QtCore)
+        gate = threading.Semaphore(0)
+        starttime = default_now()
+        endtime = None
+
+        def action(scheduler, state):
+            nonlocal endtime
+            endtime = default_now()
+
+        scheduler.schedule_relative(0.2, action)
+
+        def done():
+            app.quit()
+            gate.release()
+
+        QtCore.QTimer.singleShot(300, done)
+        app.exec_()
+
+        gate.acquire()
+        assert endtime is not None
+        diff = endtime - starttime
+        assert diff > timedelta(milliseconds=180)
+
+    def test_qt5_schedule_action_due_absolute(self):
+        app = make_app()
+
+        scheduler = QtScheduler(QtCore)
+        gate = threading.Semaphore(0)
+        starttime = default_now()
+        endtime = None
+
+        def action(scheduler, state):
+            nonlocal endtime
+            endtime = default_now()
+
+        scheduler.schedule_absolute(starttime + timedelta(seconds=0.2), action)
+
+        def done():
+            app.quit()
+            gate.release()
+
+        QtCore.QTimer.singleShot(300, done)
+        app.exec_()
+
+        gate.acquire()
+        assert endtime is not None
+        diff = endtime - starttime
+        assert diff > timedelta(milliseconds=180)
+
+    def test_qt5_schedule_action_cancel(self):
+        app = make_app()
+
+        ran = False
+        scheduler = QtScheduler(QtCore)
+        gate = threading.Semaphore(0)
+
+        def action(scheduler, state):
+            nonlocal ran
+            ran = True
+
+        d = scheduler.schedule_relative(0.1, action)
+        d.dispose()
+
+        def done():
+            app.quit()
+            gate.release()
+
+        QtCore.QTimer.singleShot(300, done)
+        app.exec_()
+
+        gate.acquire()
+        assert ran is False
+
+    def test_qt5_schedule_action_periodic(self):
+        app = make_app()
+
+        scheduler = QtScheduler(QtCore)
+        gate = threading.Semaphore(0)
+        period = 0.050
+        counter = 3
+
+        def action(state):
+            nonlocal counter
+            if state:
+                counter -= 1
+                return state - 1
+
+        scheduler.schedule_periodic(period, action, counter)
+
+        def done():
+            app.quit()
+            gate.release()
+
+        QtCore.QTimer.singleShot(300, done)
+        app.exec_()
+
+        gate.acquire()
+        assert counter == 0
+
+    def test_qt5_schedule_periodic_cancel(self):
+        app = make_app()
+
+        scheduler = QtScheduler(QtCore)
+        gate = threading.Semaphore(0)
+        period = 0.05
+        counter = 3
+
+        def action(state):
+            nonlocal counter
+            if state:
+                counter -= 1
+                return state - 1
+
+        disp = scheduler.schedule_periodic(period, action, counter)
+
+        def dispose():
+            disp.dispose()
+
+        QtCore.QTimer.singleShot(100, dispose)
+
+        def done():
+            app.quit()
+            gate.release()
+
+        QtCore.QTimer.singleShot(300, done)
+        app.exec_()
+
+        gate.acquire()
+        assert 0 < counter < 3

--- a/tests/test_concurrency/test_mainloopscheduler/test_wxscheduler.py
+++ b/tests/test_concurrency/test_mainloopscheduler/test_wxscheduler.py
@@ -1,0 +1,131 @@
+from datetime import timedelta
+from time import sleep
+import unittest
+import pytest
+
+from rx.concurrency.mainloopscheduler import WxScheduler
+from rx.internal.basic import default_now
+from rx.internal.constants import DELTA_ZERO
+
+wx = pytest.importorskip('wx')
+
+
+class AppExit(wx.Timer):
+
+    def __init__(self, app) -> None:
+        super().__init__()
+        self.app = app
+
+    def Notify(self):
+        self.app.ExitMainLoop()
+
+
+class TestWxScheduler(unittest.TestCase):
+
+    def test_wx_schedule_now(self):
+        scheduler = WxScheduler(wx)
+        diff = scheduler.now - default_now()
+        assert abs(diff) < timedelta(milliseconds=1)
+
+    def test_wx_schedule_now_units(self):
+        scheduler = WxScheduler(wx)
+        diff = scheduler.now
+        sleep(0.1)
+        diff = scheduler.now - diff
+        assert timedelta(milliseconds=80) < diff < timedelta(milliseconds=180)
+
+    def test_wx_schedule_action(self):
+        app = wx.AppConsole()
+        exit = AppExit(app)
+        scheduler = WxScheduler(wx)
+        ran = False
+
+        def action(scheduler, state):
+            nonlocal ran
+            ran = True
+
+        scheduler.schedule(action)
+        exit.Start(100, wx.TIMER_ONE_SHOT)
+        app.MainLoop()
+        scheduler.cancel_all()
+
+        assert ran is True
+
+    def test_wx_schedule_action_relative(self):
+        app = wx.AppConsole()
+        exit = AppExit(app)
+        scheduler = WxScheduler(wx)
+        starttime = default_now()
+        endtime = None
+
+        def action(scheduler, state):
+            nonlocal endtime
+            endtime = default_now()
+
+        scheduler.schedule_relative(0.1, action)
+        exit.Start(200, wx.TIMER_ONE_SHOT)
+        app.MainLoop()
+        scheduler.cancel_all()
+
+        assert endtime is not None
+        diff = endtime - starttime
+        assert timedelta(milliseconds=80) < diff < timedelta(milliseconds=180)
+
+    def test_wx_schedule_action_absolute(self):
+        app = wx.AppConsole()
+        exit = AppExit(app)
+        scheduler = WxScheduler(wx)
+        starttime = default_now()
+        endtime = None
+
+        def action(scheduler, state):
+            nonlocal endtime
+            endtime = default_now()
+
+        due = scheduler.now + timedelta(milliseconds=100)
+        scheduler.schedule_absolute(due, action)
+        exit.Start(200, wx.TIMER_ONE_SHOT)
+        app.MainLoop()
+        scheduler.cancel_all()
+
+        assert endtime is not None
+        diff = endtime - starttime
+        assert timedelta(milliseconds=80) < diff < timedelta(milliseconds=180)
+
+    def test_wx_schedule_action_cancel(self):
+        app = wx.AppConsole()
+        exit = AppExit(app)
+        scheduler = WxScheduler(wx)
+        ran = False
+
+        def action(scheduler, state):
+            nonlocal ran
+            ran = True
+
+        d = scheduler.schedule_relative(0.1, action)
+        d.dispose()
+        exit.Start(200, wx.TIMER_ONE_SHOT)
+        app.MainLoop()
+        scheduler.cancel_all()
+
+        assert ran is False
+
+    def test_wx_schedule_action_periodic(self):
+        app = wx.AppConsole()
+        exit = AppExit(app)
+        scheduler = WxScheduler(wx)
+        period = 0.05
+        counter = 3
+
+        def action(state):
+            nonlocal counter
+            if state:
+                counter -= 1
+                return state - 1
+
+        scheduler.schedule_periodic(period, action, counter)
+        exit.Start(500, wx.TIMER_ONE_SHOT)
+        app.MainLoop()
+        scheduler.cancel_all()
+
+        assert counter == 0

--- a/tests/test_concurrency/test_scheduleditem.py
+++ b/tests/test_concurrency/test_scheduleditem.py
@@ -1,0 +1,81 @@
+import unittest
+from datetime import timedelta
+from typing import Optional
+
+from rx.core import typing
+from rx.disposable import Disposable
+from rx.internal.basic import default_now
+from rx.concurrency.schedulerbase import SchedulerBase
+from rx.concurrency.scheduleditem import ScheduledItem
+
+
+class ScheduledItemTestScheduler(SchedulerBase):
+
+    def __init__(self):
+        super()
+        self.action = None
+        self.state = None
+        self.disposable = None
+
+    def invoke_action(self, action, state):
+        self.action = action
+        self.state = state
+        self.disposable = super().invoke_action(action, state)
+        return self.disposable
+
+    def schedule(self, action, state):
+        pass
+
+    def schedule_relative(self, duetime, action, state):
+        pass
+
+    def schedule_absolute(self, duetime, action, state):
+        pass
+
+
+class TestScheduledItem(unittest.TestCase):
+
+    def test_scheduleditem_invoke(self):
+        scheduler = ScheduledItemTestScheduler()
+        disposable = Disposable()
+        state = 42
+        ran = False
+
+        def action(scheduler, state):
+            nonlocal ran
+            ran = True
+            return disposable
+
+        item = ScheduledItem(scheduler, state, action, default_now())
+
+        item.invoke()
+
+        assert ran is True
+        assert item.disposable.disposable is disposable
+        assert scheduler.disposable is disposable
+        assert scheduler.state is state
+        assert scheduler.action is action
+
+    def test_scheduleditem_cancel(self):
+        scheduler = ScheduledItemTestScheduler()
+
+        item = ScheduledItem(scheduler, None, lambda s, t: None, default_now())
+
+        item.cancel()
+
+        assert item.disposable.is_disposed
+        assert item.is_cancelled()
+
+    def test_scheduleditem_compare(self):
+        scheduler = ScheduledItemTestScheduler()
+
+        duetime1 = default_now()
+        duetime2 = duetime1 + timedelta(seconds=1)
+
+        item1 = ScheduledItem(scheduler, None, lambda s, t: None, duetime1)
+        item2 = ScheduledItem(scheduler, None, lambda s, t: None, duetime2)
+        item3 = ScheduledItem(scheduler, None, lambda s, t: None, duetime1)
+
+        assert item1 < item2
+        assert item2 > item3
+        assert item1 == item3


### PR DESCRIPTION
Now that most of my effort to polish the concurrency package is merged, I am rebasing some of the other stuff I was playing around with.

In this PR, I added some tests for previously untested schedulers (`CatchScheduler` and `WxScheduler`) and I finally figured out how to get the `QtScheduler` tests working on Travis (the trick is to use the headless API, d'oh!)

Also, I split the unit tests for qt5 and pyside2 -- even though they are the same tests, and of course these are *supposed* to be more or less equivalent dependencies... Still I thought it might be good to test both variants separately.

Finally, I figured it might be time to remove Qt4, but let me know if there are objections to this...