### PR TITLE
Fix type hints for pipe using overloads. Fixes #355, #285

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -7,5 +7,6 @@ exclude_lines =
     pragma: no cover
     return NotImplemented
     raise NotImplementedError
+    ...
 [xml]
 output = coverage.xml

--- a/.coveragerc
+++ b/.coveragerc
@@ -7,6 +7,6 @@ exclude_lines =
     pragma: no cover
     return NotImplemented
     raise NotImplementedError
-    ...
+    \.\.\.
 [xml]
 output = coverage.xml

--- a/rx/core/observable/observable.py
+++ b/rx/core/observable/observable.py
@@ -216,7 +216,25 @@ class Observable(typing.Observable):
         return Disposable(auto_detach_observer.dispose)
 
     @overload
-    def pipe(self) -> 'Observable':  # pylint: disable=no-self-use
+    def pipe(self, *operators: Callable[['Observable'], 'Observable']) -> 'Observable':  # pylint: disable=no-self-use
+        """Compose multiple operators left to right.
+
+        Composes zero or more operators into a functional composition.
+        The operators are composed to right. A composition of zero
+        operators gives back the original source.
+
+        source.pipe() == source
+        source.pipe(f) == f(source)
+        source.pipe(g, f) == f(g(source))
+        source.pipe(h, g, f) == f(g(h(source)))
+        ...
+
+        Returns the composed observable.
+        """
+        ...
+
+    @overload
+    def pipe(self) -> 'Observable':  # pylint: disable=function-redefined, no-self-use
         ...  # pylint: disable=pointless-statement
 
     @overload
@@ -264,7 +282,7 @@ class Observable(typing.Observable):
         ...  # pylint: disable=pointless-statement
 
     @overload
-    def pipe(self,  # pylint: disable=function-redefined,too-many-arguments,no-self-use
+    def pipe(self,  # pylint: disable=function-redefined, no-self-use, too-many-arguments
              op1: Callable[['Observable'], A],
              op2: Callable[[A], B],
              op3: Callable[[B], C],
@@ -275,7 +293,7 @@ class Observable(typing.Observable):
         ...  # pylint: disable=pointless-statement
 
     # pylint: disable=function-redefined
-    def pipe(self, *operators: Callable[['Observable'], Any]) -> Any:  # type: ignore
+    def pipe(self, *operators: Callable[['Observable'], Any]) -> Any:
         """Compose multiple operators left to right.
 
         Composes zero or more operators into a functional composition.

--- a/rx/core/observable/observable.py
+++ b/rx/core/observable/observable.py
@@ -217,61 +217,61 @@ class Observable(typing.Observable):
 
     @overload
     def pipe(self) -> 'Observable':  # pylint: disable=no-self-use
-        ... # pylint: disable=pointless-statement
-
-    @overload
-    def pipe(self, op1: Callable[['Observable'], A]) -> A:  # pylint: disable=function-redefined, no-self-use
-        ... # pylint: disable=pointless-statement
-
-    @overload
-    def pipe(self,
-             op1: Callable[['Observable'], A],
-             op2: Callable[[A], B]) -> B:  # pylint: disable=function-redefined, no-self-use
-        ... # pylint: disable=pointless-statement
-
-    @overload
-    def pipe(self,
-             op1: Callable[['Observable'], A],
-             op2: Callable[[A], B],
-             op3: Callable[[B], C]) -> C:  # pylint: disable=function-redefined, no-self-use
-        ... # pylint: disable=pointless-statement
-
-    @overload
-    def pipe(self,
-             op1: Callable[['Observable'], A],
-             op2: Callable[[A], B],
-             op3: Callable[[B], C],
-             op4: Callable[[C], D]) -> D:  # pylint: disable=function-redefined, no-self-use
         ...  # pylint: disable=pointless-statement
 
     @overload
-    def pipe(self,
+    def pipe(self, op1: Callable[['Observable'], A]) -> A:  # pylint: disable=function-redefined, no-self-use
+        ...  # pylint: disable=pointless-statement
+
+    @overload
+    def pipe(self,  # pylint: disable=function-redefined, no-self-use
+             op1: Callable[['Observable'], A],
+             op2: Callable[[A], B]) -> B:
+        ...  # pylint: disable=pointless-statement
+
+    @overload
+    def pipe(self,  # pylint: disable=function-redefined, no-self-use
+             op1: Callable[['Observable'], A],
+             op2: Callable[[A], B],
+             op3: Callable[[B], C]) -> C:
+        ...  # pylint: disable=pointless-statement
+
+    @overload
+    def pipe(self,  # pylint: disable=function-redefined, no-self-use
+             op1: Callable[['Observable'], A],
+             op2: Callable[[A], B],
+             op3: Callable[[B], C],
+             op4: Callable[[C], D]) -> D:
+        ...  # pylint: disable=pointless-statement
+
+    @overload
+    def pipe(self,  # pylint: disable=function-redefined, no-self-use, too-many-arguments
              op1: Callable[['Observable'], A],
              op2: Callable[[A], B],
              op3: Callable[[B], C],
              op4: Callable[[C], D],
-             op5: Callable[[D], E]) -> E:  # pylint: disable=function-redefined, no-self-use
+             op5: Callable[[D], E]) -> E:
         ...  # pylint: disable=pointless-statement
 
     @overload
-    def pipe(self,
+    def pipe(self,  # pylint: disable=function-redefined, no-self-use, too-many-arguments
              op1: Callable[['Observable'], A],
              op2: Callable[[A], B],
              op3: Callable[[B], C],
              op4: Callable[[C], D],
              op5: Callable[[D], E],
-             op6: Callable[[E], F]) -> F:  # pylint: disable=function-redefined, no-self-use
+             op6: Callable[[E], F]) -> F:
         ...  # pylint: disable=pointless-statement
 
     @overload
-    def pipe(self,
+    def pipe(self,  # pylint: disable=function-redefined,too-many-arguments,no-self-use
              op1: Callable[['Observable'], A],
              op2: Callable[[A], B],
              op3: Callable[[B], C],
              op4: Callable[[C], D],
              op5: Callable[[D], E],
              op6: Callable[[E], F],
-             op7: Callable[[F], G]) -> G:  # pylint: disable=function-redefined, no-self-use
+             op7: Callable[[F], G]) -> G:
         ...  # pylint: disable=pointless-statement
 
     # pylint: disable=function-redefined

--- a/rx/core/observable/observable.py
+++ b/rx/core/observable/observable.py
@@ -1,12 +1,20 @@
 # By design, pylint: disable=C0302
 import threading
-from typing import Any, Callable, Optional, Union, cast
+from typing import Any, Callable, Optional, Union, TypeVar, cast, overload
 
 from rx.disposable import Disposable
 from rx.concurrency import current_thread_scheduler
 
 from ..observer import AutoDetachObserver
 from .. import typing, abc
+
+A = TypeVar('A')
+B = TypeVar('B')
+C = TypeVar('C')
+D = TypeVar('D')
+E = TypeVar('E')
+F = TypeVar('F')
+G = TypeVar('G')
 
 
 class Observable(typing.Observable):
@@ -145,7 +153,6 @@ class Observable(typing.Observable):
 
         return self.subscribe_(on_next, on_error, on_completed, scheduler)
 
-
     def subscribe_(self,
                    on_next: typing.OnNext = None,
                    on_error: typing.OnError = None,
@@ -208,8 +215,67 @@ class Observable(typing.Observable):
         # Hide the identity of the auto detach observer
         return Disposable(auto_detach_observer.dispose)
 
+    @overload
+    def pipe(self) -> 'Observable':  # pylint: disable=no-self-use
+        ... # pylint: disable=pointless-statement
 
-    def pipe(self, *operators: Callable[['Observable'], 'Observable']) -> 'Observable':
+    @overload
+    def pipe(self, op1: Callable[['Observable'], A]) -> A:  # pylint: disable=function-redefined, no-self-use
+        ... # pylint: disable=pointless-statement
+
+    @overload
+    def pipe(self,
+             op1: Callable[['Observable'], A],
+             op2: Callable[[A], B]) -> B:  # pylint: disable=function-redefined, no-self-use
+        ... # pylint: disable=pointless-statement
+
+    @overload
+    def pipe(self,
+             op1: Callable[['Observable'], A],
+             op2: Callable[[A], B],
+             op3: Callable[[B], C]) -> C:  # pylint: disable=function-redefined, no-self-use
+        ... # pylint: disable=pointless-statement
+
+    @overload
+    def pipe(self,
+             op1: Callable[['Observable'], A],
+             op2: Callable[[A], B],
+             op3: Callable[[B], C],
+             op4: Callable[[C], D]) -> D:  # pylint: disable=function-redefined, no-self-use
+        ...  # pylint: disable=pointless-statement
+
+    @overload
+    def pipe(self,
+             op1: Callable[['Observable'], A],
+             op2: Callable[[A], B],
+             op3: Callable[[B], C],
+             op4: Callable[[C], D],
+             op5: Callable[[D], E]) -> E:  # pylint: disable=function-redefined, no-self-use
+        ...  # pylint: disable=pointless-statement
+
+    @overload
+    def pipe(self,
+             op1: Callable[['Observable'], A],
+             op2: Callable[[A], B],
+             op3: Callable[[B], C],
+             op4: Callable[[C], D],
+             op5: Callable[[D], E],
+             op6: Callable[[E], F]) -> F:  # pylint: disable=function-redefined, no-self-use
+        ...  # pylint: disable=pointless-statement
+
+    @overload
+    def pipe(self,
+             op1: Callable[['Observable'], A],
+             op2: Callable[[A], B],
+             op3: Callable[[B], C],
+             op4: Callable[[C], D],
+             op5: Callable[[D], E],
+             op6: Callable[[E], F],
+             op7: Callable[[E], G]) -> G:  # pylint: disable=function-redefined, no-self-use
+        ...  # pylint: disable=pointless-statement
+
+    # pylint: disable=function-redefined
+    def pipe(self, *operators: Callable[['Observable'], Any]) -> Any:  # type: ignore
         """Compose multiple operators left to right.
 
         Composes zero or more operators into a functional composition.
@@ -227,13 +293,12 @@ class Observable(typing.Observable):
         from ..pipe import pipe
         return pipe(*operators)(self)
 
-
     def run(self) -> Any:
         """Run source synchronously.
 
         Subscribes to the observable source. Then blocks and waits for the
         observable source to either complete or error. Returns the
-        last value emitted, or thows exception if any error occured.
+        last value emitted, or throws exception if any error occurred.
 
         Examples:
             >>> result = run(source)
@@ -241,7 +306,7 @@ class Observable(typing.Observable):
         Raises:
             SequenceContainsNoElementsError: if observable completes
                 (on_completed) without any values being emitted.
-            Exception: raises exception if any error (on_error) occured.
+            Exception: raises exception if any error (on_error) occurred.
 
         Returns:
             The last element emitted from the observable.

--- a/rx/core/observable/observable.py
+++ b/rx/core/observable/observable.py
@@ -271,7 +271,7 @@ class Observable(typing.Observable):
              op4: Callable[[C], D],
              op5: Callable[[D], E],
              op6: Callable[[E], F],
-             op7: Callable[[E], G]) -> G:  # pylint: disable=function-redefined, no-self-use
+             op7: Callable[[F], G]) -> G:  # pylint: disable=function-redefined, no-self-use
         ...  # pylint: disable=pointless-statement
 
     # pylint: disable=function-redefined

--- a/rx/core/pipe.py
+++ b/rx/core/pipe.py
@@ -1,9 +1,70 @@
-from typing import Callable
+from typing import Callable, Any, TypeVar, overload
 from functools import reduce
-from .observable import Observable
+
+A = TypeVar('A')
+B = TypeVar('B')
+C = TypeVar('C')
+D = TypeVar('D')
+E = TypeVar('E')
+F = TypeVar('F')
+G = TypeVar('G')
 
 
-def pipe(*operators: Callable[[Observable], Observable]) -> Callable[[Observable], Observable]:
+@overload
+def pipe() -> Callable[[A], A]:
+    ...  # pylint: disable=pointless-statement
+
+
+@overload
+def pipe(op1: Callable[[A], B]) -> Callable[[A], B]:  # pylint: disable=function-redefined
+    ...  # pylint: disable=pointless-statement
+
+
+@overload
+def pipe(op1: Callable[[A], B], op2: Callable[[B], C]) -> Callable[[A], C]:  # pylint: disable=function-redefined
+    ...  # pylint: disable=pointless-statement
+
+
+@overload
+def pipe(op1: Callable[[A], B],
+         op2: Callable[[B], C],
+         op3: Callable[[C], D]
+         ) -> Callable[[A], D]:  # pylint: disable=function-redefined
+    ...  # pylint: disable=pointless-statement
+
+
+@overload
+def pipe(op1: Callable[[A], B],
+         op2: Callable[[B], C],
+         op3: Callable[[C], D],
+         op4: Callable[[D], E]
+         ) -> Callable[[A], E]:  # pylint: disable=function-redefined
+    ...  # pylint: disable=pointless-statement
+
+
+@overload
+def pipe(op1: Callable[[A], B],
+         op2: Callable[[B], C],
+         op3: Callable[[C], D],
+         op4: Callable[[D], E],
+         op5: Callable[[E], F]
+         ) -> Callable[[A], F]:  # pylint: disable=function-redefined
+    ...  # pylint: disable=pointless-statement
+
+
+@overload
+def pipe(op1: Callable[[A], B],
+         op2: Callable[[B], C],
+         op3: Callable[[C], D],
+         op4: Callable[[D], E],
+         op5: Callable[[E], F],
+         op6: Callable[[F], G]
+         ) -> Callable[[A], G]:  # pylint: disable=function-redefined
+    ...  # pylint: disable=pointless-statement
+
+
+# pylint: disable=function-redefined
+def pipe(*operators: Callable[[Any], Any]) -> Callable[[Any], Any]:  # type: ignore
     """Compose multiple operators left to right.
 
     Composes zero or more operators into a functional composition. The
@@ -21,6 +82,6 @@ def pipe(*operators: Callable[[Observable], Observable]) -> Callable[[Observable
         The composed observable.
     """
 
-    def compose(source: Observable) -> Observable:
+    def compose(source: Any) -> Any:
         return reduce(lambda obs, op: op(obs), operators, source)
     return compose

--- a/rx/core/pipe.py
+++ b/rx/core/pipe.py
@@ -11,7 +11,27 @@ G = TypeVar('G')
 
 
 @overload
-def pipe() -> Callable[[A], A]:
+def pipe(*operators: Callable[['Observable'], 'Observable']) -> Callable[['Observable'], 'Observable']:  # type: ignore
+    """Compose multiple operators left to right.
+
+    Composes zero or more operators into a functional composition. The
+    operators are composed to left to right. A composition of zero
+    operators gives back the source.
+
+    Examples:
+        >>> pipe()(source) == source
+        >>> pipe(f)(source) == f(source)
+        >>> pipe(f, g)(source) == g(f(source))
+        >>> pipe(f, g, h)(source) == h(g(f(source)))
+        ...
+
+    Returns:
+        The composed observable.
+    """
+    ...
+
+@overload
+def pipe() -> Callable[[A], A]:  # pylint: disable=function-redefined
     ...  # pylint: disable=pointless-statement
 
 
@@ -64,7 +84,7 @@ def pipe(op1: Callable[[A], B],  # pylint: disable=function-redefined,too-many-a
 
 
 # pylint: disable=function-redefined
-def pipe(*operators: Callable[[Any], Any]) -> Callable[[Any], Any]:  # type: ignore
+def pipe(*operators: Callable[[Any], Any]) -> Callable[[Any], Any]:
     """Compose multiple operators left to right.
 
     Composes zero or more operators into a functional composition. The

--- a/rx/core/pipe.py
+++ b/rx/core/pipe.py
@@ -26,40 +26,40 @@ def pipe(op1: Callable[[A], B], op2: Callable[[B], C]) -> Callable[[A], C]:  # p
 
 
 @overload
-def pipe(op1: Callable[[A], B],
+def pipe(op1: Callable[[A], B],  # pylint: disable=function-redefined
          op2: Callable[[B], C],
          op3: Callable[[C], D]
-         ) -> Callable[[A], D]:  # pylint: disable=function-redefined
+         ) -> Callable[[A], D]:
     ...  # pylint: disable=pointless-statement
 
 
 @overload
-def pipe(op1: Callable[[A], B],
+def pipe(op1: Callable[[A], B],  # pylint: disable=function-redefined
          op2: Callable[[B], C],
          op3: Callable[[C], D],
          op4: Callable[[D], E]
-         ) -> Callable[[A], E]:  # pylint: disable=function-redefined
+         ) -> Callable[[A], E]:
     ...  # pylint: disable=pointless-statement
 
 
 @overload
-def pipe(op1: Callable[[A], B],
+def pipe(op1: Callable[[A], B],  # pylint: disable=function-redefined
          op2: Callable[[B], C],
          op3: Callable[[C], D],
          op4: Callable[[D], E],
          op5: Callable[[E], F]
-         ) -> Callable[[A], F]:  # pylint: disable=function-redefined
+         ) -> Callable[[A], F]:
     ...  # pylint: disable=pointless-statement
 
 
 @overload
-def pipe(op1: Callable[[A], B],
+def pipe(op1: Callable[[A], B],  # pylint: disable=function-redefined,too-many-arguments
          op2: Callable[[B], C],
          op3: Callable[[C], D],
          op4: Callable[[D], E],
          op5: Callable[[E], F],
          op6: Callable[[F], G]
-         ) -> Callable[[A], G]:  # pylint: disable=function-redefined
+         ) -> Callable[[A], G]:
     ...  # pylint: disable=pointless-statement
 
 


### PR DESCRIPTION
This PR fixes the typing issues with the `pipe` operator using typing overloads. The downside is that pylint does not support this yet and only sees the first overload (https://github.com/PyCQA/pylint/issues/2239). The good thing is that PyCharm does the right thing and see all the overloads and correctly infers the last type.

<img width="930" alt="Skjermbilde 2019-05-10 kl  17 40 30" src="https://user-images.githubusercontent.com/849479/57539485-e0ee5280-734a-11e9-9a94-b8177ef19e05.png">

Thus I would rather do it the right way since PyCharm already supports this, and let pylint problems be pylint problems. This is similary to how the typing were fixed with typescript in RxJS (https://github.com/ReactiveX/rxjs/blob/master/src/internal/Observable.ts). Hopefully pylint will eventually be fixed.