### PR TITLE
Fix wrong operator type annotations 

### DIFF
--- a/rx/core/operators/ignoreelements.py
+++ b/rx/core/operators/ignoreelements.py
@@ -1,8 +1,10 @@
+from typing import Callable
+
 from rx.core import Observable
 from rx.internal import noop
 
 
-def _ignore_elements() -> Observable:
+def _ignore_elements() -> Callable[[Observable], Observable]:
     """Ignores all elements in an observable sequence leaving only the
     termination messages.
 

--- a/rx/core/operators/publish.py
+++ b/rx/core/operators/publish.py
@@ -5,7 +5,7 @@ from rx.core import Observable, ConnectableObservable, pipe
 from rx.subjects import Subject
 
 
-def _publish(mapper=None) -> ConnectableObservable:
+def _publish(mapper=None) -> Callable[[Observable], ConnectableObservable]:
     """Returns an observable sequence that is the result of invoking the
     mapper on a connectable observable sequence that shares a single
     subscription to the underlying sequence. This operator is a

--- a/rx/core/operators/publish.py
+++ b/rx/core/operators/publish.py
@@ -1,11 +1,12 @@
-from typing import Callable
+from typing import Callable, Optional
 
 from rx import operators as ops
 from rx.core import Observable, ConnectableObservable, pipe
+from rx.core.typing import Mapper
 from rx.subjects import Subject
 
 
-def _publish(mapper=None) -> Callable[[Observable], ConnectableObservable]:
+def _publish(mapper: Optional[Mapper] = None) -> Callable[[Observable], ConnectableObservable]:
     """Returns an observable sequence that is the result of invoking the
     mapper on a connectable observable sequence that shares a single
     subscription to the underlying sequence. This operator is a

--- a/rx/core/operators/singleordefault.py
+++ b/rx/core/operators/singleordefault.py
@@ -31,7 +31,7 @@ def _single_or_default_async(has_default: bool = False, default_value: Any = Non
     return single_or_default_async
 
 
-def _single_or_default(predicate: Optional[Predicate] = None, default_value: Any = None) -> Observable:
+def _single_or_default(predicate: Optional[Predicate] = None, default_value: Any = None) -> Callable[[Observable], Observable]:
     """Returns the only element of an observable sequence that matches
     the predicate, or a default value if no such element exists this
     method reports an exception if there is more than one element in the

--- a/rx/core/operators/singleordefault.py
+++ b/rx/core/operators/singleordefault.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Optional, Callable
 
 from rx import operators as ops
 from rx.core import Observable, pipe
@@ -6,7 +6,7 @@ from rx.core.typing import Predicate, Any
 from rx.internal.exceptions import SequenceContainsNoElementsError
 
 
-def _single_or_default_async(has_default: bool = False, default_value: Any = None):
+def _single_or_default_async(has_default: bool = False, default_value: Any = None) -> Callable[[Observable], Observable]:
     def single_or_default_async(source: Observable) -> Observable:
         def subscribe(observer, scheduler=None):
             value = [default_value]

--- a/rx/core/operators/zip.py
+++ b/rx/core/operators/zip.py
@@ -24,7 +24,7 @@ def _zip(*args: Observable) -> Callable[[Observable], Observable]:
         return rx.zip(source, *args)
     return zip
 
-def _zip_with_iterable(seq: Iterable):
+def _zip_with_iterable(seq: Iterable) -> Callable[[Observable], Observable]:
     def zip_with_iterable(source: Observable) -> Observable:
         """Merges the specified observable sequence and list into one
         observable sequence by creating a tuple whenever all of

--- a/rx/operators/__init__.py
+++ b/rx/operators/__init__.py
@@ -1781,7 +1781,7 @@ def pluck_attr(prop: str) -> Callable[[Observable], Observable]:
     return _pluck_attr(prop)
 
 
-def publish(mapper=None) -> Callable[[Observable], ConnectableObservable]:
+def publish(mapper: Optional[Mapper] = None) -> Callable[[Observable], ConnectableObservable]:
     """The `publish` operator.
 
     Returns an observable sequence that is the result of invoking the

--- a/rx/operators/__init__.py
+++ b/rx/operators/__init__.py
@@ -1781,7 +1781,7 @@ def pluck_attr(prop: str) -> Callable[[Observable], Observable]:
     return _pluck_attr(prop)
 
 
-def publish(mapper=None) -> ConnectableObservable:
+def publish(mapper=None) -> Callable[[Observable], ConnectableObservable]:
     """The `publish` operator.
 
     Returns an observable sequence that is the result of invoking the

--- a/rx/operators/__init__.py
+++ b/rx/operators/__init__.py
@@ -2158,7 +2158,7 @@ def single_or_default(predicate: Optional[Predicate] = None, default_value: Any 
     return _single_or_default(predicate, default_value)
 
 
-def single_or_default_async(has_default: bool = False, default_value: Any = None):
+def single_or_default_async(has_default: bool = False, default_value: Any = None) -> Callable[[Observable], Observable]:
     from rx.core.operators.singleordefault import _single_or_default_async
     return _single_or_default_async(has_default, default_value)
 

--- a/rx/operators/__init__.py
+++ b/rx/operators/__init__.py
@@ -2123,7 +2123,7 @@ def single(predicate: Predicate = None) -> Callable[[Observable], Observable]:
     return _single(predicate)
 
 
-def single_or_default(predicate: Optional[Predicate] = None, default_value: Any = None) -> Observable:
+def single_or_default(predicate: Optional[Predicate] = None, default_value: Any = None) -> Callable[[Observable], Observable]:
     """Returns the only element of an observable sequence that matches
     the predicate, or a default value if no such element exists this
     method reports an exception if there is more than one element in

--- a/rx/operators/__init__.py
+++ b/rx/operators/__init__.py
@@ -1206,7 +1206,7 @@ def group_join(right, left_duration_mapper, right_duration_mapper,
     return _group_join(right, left_duration_mapper, right_duration_mapper)
 
 
-def ignore_elements() -> Observable:
+def ignore_elements() -> Callable[[Observable], Observable]:
     """Ignores all elements in an observable sequence leaving only the
     termination messages.
 

--- a/rx/operators/__init__.py
+++ b/rx/operators/__init__.py
@@ -2190,7 +2190,7 @@ def skip(count: int) -> Callable[[Observable], Observable]:
     return _skip(count)
 
 
-def skip_last(count: int) -> Observable:
+def skip_last(count: int) -> Callable[[Observable], Observable]:
     """The skip_last operator.
 
     .. marble::

--- a/rx/operators/__init__.py
+++ b/rx/operators/__init__.py
@@ -3260,7 +3260,7 @@ def zip(*args: Observable) -> Callable[[Observable], Observable]:
     return _zip(*args)
 
 
-def zip_with_iterable(second):
+def zip_with_iterable(second: Iterable) -> Callable[[Observable], Observable]:
     """Merges the specified observable sequence and list into one
     observable sequence by creating a tuple whenever all of
     the observable sequences have produced an element at a


### PR DESCRIPTION
This PR fixes wrong return type for operators:

- ignore_elements
- publish 
- single_or_default_async
- single_or_default
- skip_last 
- zip_with_iterable

This should also fix #377.
