### PR TITLE
Fix silent on_error when observer throws

### DIFF
--- a/rx/core/observer/autodetachobserver.py
+++ b/rx/core/observer/autodetachobserver.py
@@ -23,12 +23,7 @@ class AutoDetachObserver(typing.Observer):
     def on_next(self, value: Any) -> None:
         if self.is_stopped:
             return
-
-        try:
-            self._on_next(value)
-        except Exception:
-            self.dispose()
-            raise
+        self._on_next(value)
 
     def on_error(self, error) -> None:
         if self.is_stopped:

--- a/tests/test_observable/test_fromiterable.py
+++ b/tests/test_observable/test_fromiterable.py
@@ -58,6 +58,10 @@ class TestFromIterable(unittest.TestCase):
         results = scheduler.start(lambda: rx.concat(obs, obs))
 
         assert results.messages == [
-                on_next(200, 1), on_next(200, 2), on_next(200, 3),
-                on_next(200, 1), on_next(200, 2), on_next(200, 3),
-                on_completed(200)]
+            on_next(200, 1), on_next(200, 2), on_next(200, 3),
+            on_next(200, 1), on_next(200, 2), on_next(200, 3),
+            on_completed(200)]
+
+    def test_observer_throws(self):
+        with self.assertRaises(RxException):
+            rx.from_iterable([1, 2, 3]).subscribe(lambda x: _raise('ex'))


### PR DESCRIPTION
Let exeptions bubble up and mute when on_error/on_completed on the way down.