### PR TITLE
Align docs with current example code

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -19,7 +19,7 @@ The Reactive Extensions for Python (RxPY)
 *A library for composing asynchronous and event-based programs using observable collections and
 query operator functions in Python*
 
-RxPY v3.0 Alpha
+RxPY v3.0 Beta
 ----------------
 
 **This branch is work-in-progress.**
@@ -45,15 +45,16 @@ parameterize concurrency in data/event streams using Schedulers.
 
 .. code:: python
 
-    from rx import of, operators as op
+    import rx
+    from rx import operators as ops
 
-    source = of("Alpha", "Beta", "Gamma", "Delta", "Epsilon")
+    source = rx.of("Alpha", "Beta", "Gamma", "Delta", "Epsilon")
 
     composed = source.pipe(
-        op.map(lambda s: len(s)),
-        op.filter(lambda i: i >= 5)
+        ops.map(lambda s: len(s)),
+        ops.filter(lambda i: i >= 5)
     )
-    composed.subscribe_(lambda value: print("Received {0}".format(value)))
+    composed.subscribe(lambda value: print("Received {0}".format(value)))
 
 
 Learning RxPY
@@ -111,7 +112,7 @@ need to be written with an `_` in Python:
 
 .. code:: python
 
-    group = source.group_by(lambda i: i % 3)
+    group = source.pipe(ops.group_by(lambda i: i % 3))
 
 With RxPY you should use `named keyword arguments
 <https://docs.python.org/3/glossary.html>`_ instead of positional arguments when

--- a/docs/get_started.rst
+++ b/docs/get_started.rst
@@ -52,7 +52,7 @@ Let's consider the following example:
 An Observable is created with create. On subscription, the *push_five_strings*
 function is called. This function emits five items. The three callbacks provided
 to the *subscribe* function simply print the received items and completion
-states. Note that the use of lambdas simplify the code in this basic example. 
+states. Note that the use of lambdas simplify the code in this basic example.
 
 Output:
 
@@ -93,7 +93,7 @@ and error are ignored:
 
     source = of("Alpha", "Beta", "Gamma", "Delta", "Epsilon")
 
-    source.subscribe_(lambda value: print("Received {0}".format(value)))
+    source.subscribe(lambda value: print("Received {0}".format(value)))
 
 Output:
 
@@ -125,7 +125,7 @@ yield two separate Observables built off each other.
         op.map(lambda s: len(s)),
         op.filter(lambda i: i >= 5)
     )
-    composed.subscribe_(lambda value: print("Received {0}".format(value)))
+    composed.subscribe(lambda value: print("Received {0}".format(value)))
 
 Output:
 
@@ -148,7 +148,7 @@ operations. That way your code is readable and tells a story much more easily.
     of("Alpha", "Beta", "Gamma", "Delta", "Epsilon").pipe(
         op.map(lambda s: len(s)),
         op.filter(lambda i: i >= 5)
-    ).subscribe_(lambda value: print("Received {0}".format(value)))
+    ).subscribe(lambda value: print("Received {0}".format(value)))
 
 Custom operator
 ---------------
@@ -161,17 +161,18 @@ other operators, then the implementation is straightforward, thanks to the
 
 .. code:: python
 
-    from rx import of, pipe, operators as op
+    import rx
+    from rx import operators as ops
 
     def length_more_than_5():
         return pipe(
-            op.map(lambda s: len(s)),
-            op.filter(lambda i: i >= 5),
+            ops.map(lambda s: len(s)),
+            ops.filter(lambda i: i >= 5),
         )
 
-    of("Alpha", "Beta", "Gamma", "Delta", "Epsilon").pipe(
+    rx.of("Alpha", "Beta", "Gamma", "Delta", "Epsilon").pipe(
         length_more_than_5()
-    ).subscribe_(lambda value: print("Received {0}".format(value)))
+    ).subscribe(lambda value: print("Received {0}".format(value)))
 
 In this example, the *pipe* and *filter* operators are grouped in a new
 *length_more_then_5* operator.
@@ -182,7 +183,7 @@ emissions:
 
  .. code:: python
 
-    from rx import of, pipe, create
+    import rx
 
     def lowercase():
         def _lowercase(source):
@@ -191,16 +192,16 @@ emissions:
                     observer.on_next(value.lower())
 
                 return source.subscribe(
-                    on_next, 
-                    observer.on_error, 
-                    observer.on_completed, 
+                    on_next,
+                    observer.on_error,
+                    observer.on_completed,
                     scheduler)
-            return create(subscribe)
+            return rx.create(subscribe)
         return _lowercase
 
-    of("Alpha", "Beta", "Gamma", "Delta", "Epsilon").pipe(
+    rx.of("Alpha", "Beta", "Gamma", "Delta", "Epsilon").pipe(
             lowercase()
-        ).subscribe_(lambda value: print("Received {0}".format(value)))
+         ).subscribe(lambda value: print("Received {0}".format(value)))
 
 In this example, the *lowsercase* operator converts all received items to
 lowercase. The structure of the *_lowercase* function is a very common way to
@@ -282,7 +283,7 @@ using :func:`subscribe_on() <rx.operators.subscribe_on>` as well as an
     Observable.of("Alpha", "Beta", "Gamma", "Delta", "Epsilon") \
         .map(lambda s: intense_calculation(s)) \
         .subscribe_on(pool_scheduler) \
-        .subscribe_(on_next=lambda s: print("PROCESS 1: {0} {1}".format(current_thread().name, s)),
+        .subscribe(on_next=lambda s: print("PROCESS 1: {0} {1}".format(current_thread().name, s)),
                     on_error=lambda e: print(e),
                     on_completed=lambda: print("PROCESS 1 done!"))
 
@@ -290,7 +291,7 @@ using :func:`subscribe_on() <rx.operators.subscribe_on>` as well as an
     Observable.range(1, 10) \
         .map(lambda s: intense_calculation(s)) \
         .subscribe_on(pool_scheduler) \
-        .subscribe_(on_next=lambda i: print("PROCESS 2: {0} {1}".format(current_thread().name, i)),
+        .subscribe(on_next=lambda i: print("PROCESS 2: {0} {1}".format(current_thread().name, i)),
                     on_error=lambda e: print(e), on_completed=lambda: print("PROCESS 2 done!"))
 
     # Create Process 3, which is infinite
@@ -298,7 +299,7 @@ using :func:`subscribe_on() <rx.operators.subscribe_on>` as well as an
         .map(lambda i: i * 100) \
         .observe_on(pool_scheduler) \
         .map(lambda s: intense_calculation(s)) \
-        .subscribe_(on_next=lambda i: print("PROCESS 3: {0} {1}".format(current_thread().name, i)),
+        .subscribe(on_next=lambda i: print("PROCESS 3: {0} {1}".format(current_thread().name, i)),
                     on_error=lambda e: print(e))
 
     input("Press any key to exit\n")

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -7,7 +7,7 @@ RxPY v3.x runs on `Python <http://www.python.org/>`__ 3. To install RxPY:
 
 .. code:: python
 
-    pip3 install rx
+    pip3 install --pre rx
 
 For Python 2.x you need to use version 1.6
 

--- a/docs/migration.rst
+++ b/docs/migration.rst
@@ -33,18 +33,19 @@ implemented as functions:
 
 .. code:: python
 
-    from rx import of, operators as op
+    import rx
+    from rx import operators as ops
 
-    of("Alpha", "Beta", "Gamma", "Delta", "Epsilon").pipe(
-            op.map(lambda s: len(s)),
-            op.filter(lambda i: i >= 5)
-        ).subscribe_(lambda value: print("Received {0}".format(value)))
+    rx.of("Alpha", "Beta", "Gamma", "Delta", "Epsilon").pipe(
+        ops.map(lambda s: len(s)),
+        ops.filter(lambda i: i >= 5)
+    ).subscribe(lambda value: print("Received {0}".format(value)))
 
 The fact that operators are functions means that adding new operators is now
 very easy. Instead of wrapping custom operators with the *let* operator, they can
 be directly used in a pipe chain.
 
-Removal Of The Result Mapper 
+Removal Of The Result Mapper
 -----------------------------
 
 The mapper function is removed in operators that combine the values of several
@@ -69,15 +70,16 @@ the source Observables:
 
 .. code:: python
 
-    from rx import of, operators as op
+    import rx
+    from rx import operators as ops
     import operator
 
-    a = of(1, 2, 3, 4)
-    b = of(2, 2, 4, 4)
+    a = rx.of(1, 2, 3, 4)
+    b = rx.of(2, 2, 4, 4)
 
     a.pipe(
-        op.zip(b), # returns a tuple with the items of a and b
-        op.map(lambda z: operator.mul(z[0], z[1]))
+        ops.zip(b), # returns a tuple with the items of a and b
+        ops.map(lambda z: operator.mul(z[0], z[1]))
     ).subscribe(print)
 
 Dealing with the tuple unpacking is made easier with the starmap operator that
@@ -85,15 +87,16 @@ unpacks the tuple to args:
 
 .. code:: python
 
-    from rx import of, operators as op
+    import rx
+    from rx import operators as ops
     import operator
 
-    a = of(1, 2, 3, 4)
-    b = of(2, 2, 4, 4)
+    a = rx.of(1, 2, 3, 4)
+    b = rx.of(2, 2, 4, 4)
 
     a.pipe(
-        op.zip(b),
-        op.starmap(operator.mul)
+        ops.zip(b),
+        ops.starmap(operator.mul)
     ).subscribe(print)
 
 
@@ -146,7 +149,8 @@ unpacked:
 
 .. code:: python
 
-    import rx, operator as op
+    import rx
+    from rx import operators as ops
 
     obs1 = rx.from_([1, 2, 3, 4])
     obs2 = rx.from_([5, 6, 7, 8])
@@ -184,8 +188,8 @@ The *run* operator returns only the last value emitted by the source Observable.
 It is possible to use the previous blocking operators by using the standard
 operators before *run*. For example:
 
-* Get first item: obs.first().run()
-* Get all items: obs.to_list().run()
+* Get first item: obs.pipe(ops.first()).run()
+* Get all items: obs.pipe(ops.to_list()).run()
 
 
 BackPressure
@@ -205,10 +209,10 @@ of milliseconds. This RxPY v1 example:
 
 .. code:: python
 
-    obs.debounce(500)
+    ops.debounce(500)
 
 is now written as:
 
 .. code:: python
 
-    obs.debounce(0.5)
+    ops.debounce(0.5)


### PR DESCRIPTION
Aligning the docs with the current example code. We can discuss how things should be but we should try to have a consistent style in both docs and examples. 