### PR TITLE
Correct HistoricalScheduler.add() for both timedelta and float inputs.

### DIFF
--- a/rx/concurrency/historicalscheduler.py
+++ b/rx/concurrency/historicalscheduler.py
@@ -45,4 +45,4 @@ class HistoricalScheduler(VirtualTimeScheduler):
             The resulting absolute virtual time sum value.
         """
 
-        return absolute + relative
+        return absolute + HistoricalScheduler.to_timedelta(relative)

--- a/tests/test_concurrency/test_historicalscheduler.py
+++ b/tests/test_concurrency/test_historicalscheduler.py
@@ -324,3 +324,39 @@ class TestHistoricalScheduler(unittest.TestCase):
         s.advance_to(s.now + timedelta(5 * 6000))
 
         self.assertEqual(2, n[0])
+    
+    def test_schedule_relative_with_timedelta(self):
+        s = HistoricalScheduler()
+        n = 0
+
+        def action(scheduler, state):
+            nonlocal n
+            n += 1
+        
+        s.schedule_relative(timedelta(2), action)
+
+        s.advance_by(timedelta(1))
+
+        self.assertEqual(n, 0)
+
+        s.advance_by(timedelta(1))
+
+        self.assertEqual(n, 1)
+
+    def test_schedule_relative_with_float(self):
+        s = HistoricalScheduler()
+        n = 0
+
+        def action(scheduler, state):
+            nonlocal n
+            n += 1
+        
+        s.schedule_relative(1.0, action)
+
+        s.advance_by(0.5)
+
+        self.assertEqual(n, 0)
+
+        s.advance_by(0.5)
+
+        self.assertEqual(n, 1)


### PR DESCRIPTION
`HistoricalScheduler.add()` now better conforms to it’s declared type signature. Previously it assumed that the relative value was a `datetime.timedelta` instance. Due to the way `VirtualTimeScheduler.schedule_relative()` is implemented, a `TypeError` was always raised.