### PR TITLE
add missing type annotations (operators)

### DIFF
--- a/rx/core/operators/buffer.py
+++ b/rx/core/operators/buffer.py
@@ -1,4 +1,4 @@
-from typing import Callable
+from typing import Callable, Optional
 
 from rx import operators as ops
 from rx.core import Observable, pipe
@@ -27,7 +27,7 @@ def _buffer(buffer_openings=None, buffer_closing_mapper=None) -> Callable[[Obser
     )
 
 
-def _buffer_with_count(count: int, skip: int = None) -> Callable[[Observable], Observable]:
+def _buffer_with_count(count: int, skip: Optional[int] = None) -> Callable[[Observable], Observable]:
     """Projects each element of an observable sequence into zero or more
     buffers which are produced based on element count information.
 

--- a/rx/core/operators/reduce.py
+++ b/rx/core/operators/reduce.py
@@ -3,9 +3,9 @@ from typing import Any, Callable
 from rx import operators as ops
 from rx.internal.utils import NotSet
 from rx.core import Observable, pipe
+from rx.core.typing import Accumulator
 
-
-def _reduce(accumulator: Callable[[Any, Any], Any], seed: Any = NotSet) -> Callable[[Observable], Observable]:
+def _reduce(accumulator: Accumulator, seed: Any = NotSet) -> Callable[[Observable], Observable]:
     """Applies an accumulator function over an observable sequence,
     returning the result of the aggregation as a single element in the
     result sequence. The specified seed value is used as the initial

--- a/rx/core/operators/replay.py
+++ b/rx/core/operators/replay.py
@@ -34,6 +34,7 @@ def _replay(mapper: Optional[Mapper] = None,
         buffer_size: [Optional] Maximum element count of the replay
             buffer.
         window: [Optional] Maximum time length of the replay buffer.
+        scheduler: [Optional] Scheduler the observers are invoked on.
 
     Returns:
         An observable sequence that contains the elements of a

--- a/rx/core/operators/sample.py
+++ b/rx/core/operators/sample.py
@@ -5,7 +5,7 @@ from rx.core import Observable, typing
 from rx.disposable import CompositeDisposable
 
 
-def sample_observable(source, sampler):
+def sample_observable(source: Observable, sampler: Observable) -> Observable:
     def subscribe(observer, scheduler=None):
         at_end = [None]
         has_value = [None]
@@ -33,7 +33,11 @@ def sample_observable(source, sampler):
     return Observable(subscribe)
 
 
-def _sample(interval=None, sampler=None, scheduler: Optional[typing.Scheduler] = None) -> Callable[[Observable], Observable]:
+def _sample(interval: Optional[typing.RelativeTime] = None,
+            sampler: Optional[Observable] = None,
+            scheduler: Optional[typing.Scheduler] = None
+            ) -> Callable[[Observable], Observable]:
+
     def sample(source: Observable) -> Observable:
         """Samples the observable sequence at each interval.
 

--- a/rx/core/operators/scan.py
+++ b/rx/core/operators/scan.py
@@ -3,9 +3,9 @@ from typing import Any, Callable
 from rx import defer, operators as ops
 from rx.internal.utils import NotSet
 from rx.core import Observable
+from rx.core.typing import Accumulator
 
-
-def _scan(accumulator: Callable[[Any, Any], Any], seed: Any = NotSet) -> Callable[[Observable], Observable]:
+def _scan(accumulator: Accumulator, seed: Any = NotSet) -> Callable[[Observable], Observable]:
     has_seed = seed is not NotSet
 
     def scan(source: Observable) -> Observable:
@@ -25,19 +25,20 @@ def _scan(accumulator: Callable[[Any, Any], Any], seed: Any = NotSet) -> Callabl
         """
 
         def factory(scheduler):
-            nonlocal source
-
-            has_accumulation = [False]
-            accumulation = [None]
+            has_accumulation = False
+            accumulation = None
 
             def projection(x):
-                if has_accumulation[0]:
-                    accumulation[0] = accumulator(accumulation[0], x)
-                else:
-                    accumulation[0] = accumulator(seed, x) if has_seed else x
-                    has_accumulation[0] = True
+                nonlocal has_accumulation
+                nonlocal accumulation
 
-                return accumulation[0]
+                if has_accumulation:
+                    accumulation = accumulator(accumulation, x)
+                else:
+                    accumulation = accumulator(seed, x) if has_seed else x
+                    has_accumulation = True
+
+                return accumulation
             return source.pipe(ops.map(projection))
         return defer(factory)
     return scan

--- a/rx/core/operators/sequenceequal.py
+++ b/rx/core/operators/sequenceequal.py
@@ -1,13 +1,14 @@
-from typing import Any, Callable
+from typing import Any, Callable, Optional
 import collections
 
 import rx
 from rx.core import Observable
+from rx.core.typing import Comparer
 from rx.disposable import CompositeDisposable
 from rx.internal import default_comparer
 
 
-def _sequence_equal(second: Observable, comparer: Callable[[Any, Any], bool] = None
+def _sequence_equal(second: Observable, comparer: Optional[Comparer] = None
                     ) -> Callable[[Observable], Observable]:
     comparer = comparer or default_comparer
     if isinstance(second, collections.abc.Iterable):

--- a/rx/core/operators/some.py
+++ b/rx/core/operators/some.py
@@ -1,10 +1,10 @@
-from typing import Callable
+from typing import Callable, Optional
 
 from rx import operators as ops
 from rx.core import Observable
+from rx.core.typing import Predicate
 
-
-def _some(predicate=None) -> Callable[[Observable], Observable]:
+def _some(predicate: Optional[Predicate] = None) -> Callable[[Observable], Observable]:
     def some(source: Observable) -> Observable:
         """Partially applied operator.
 

--- a/rx/core/operators/takewhile.py
+++ b/rx/core/operators/takewhile.py
@@ -1,9 +1,9 @@
 from typing import Any, Callable
 
 from rx.core import Observable
+from rx.core.typing import Predicate, PredicateIndexed
 
-
-def _take_while(predicate: Callable[[Any], Any]) -> Callable[[Observable], Observable]:
+def _take_while(predicate: Predicate) -> Callable[[Observable], Observable]:
     def take_while(source: Observable) -> Observable:
         """Returns elements from an observable sequence as long as a
         specified condition is true. The element's index is used in the
@@ -47,7 +47,7 @@ def _take_while(predicate: Callable[[Any], Any]) -> Callable[[Observable], Obser
     return take_while
 
 
-def _take_while_indexed(predicate: Callable[[Any, int], Any]) -> Callable[[Observable], Observable]:
+def _take_while_indexed(predicate: PredicateIndexed) -> Callable[[Observable], Observable]:
     def take_while_indexed(source: Observable) -> Observable:
         """Returns elements from an observable sequence as long as a
         specified condition is true. The element's index is used in the

--- a/rx/core/operators/timeout.py
+++ b/rx/core/operators/timeout.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import Union, Callable, Optional
+from typing import Callable, Optional
 
 from rx import from_future, throw
 from rx.core import Observable, typing

--- a/rx/core/operators/timeoutwithmapper.py
+++ b/rx/core/operators/timeoutwithmapper.py
@@ -1,11 +1,13 @@
-from typing import Callable
+from typing import Callable, Optional, Any
 
 import rx
 from rx.core import Observable
 from rx.disposable import CompositeDisposable, SingleAssignmentDisposable, SerialDisposable
 
 
-def _timeout_with_mapper(first_timeout=None, timeout_duration_mapper=None, other=None
+def _timeout_with_mapper(first_timeout: Optional[Observable] = None,
+                         timeout_duration_mapper: Optional[Callable[[Any], Observable]] = None,
+                         other: Optional[Observable] = None
                          ) -> Callable[[Observable], Observable]:
     """Returns the source observable sequence, switching to the other
     observable sequence if a timeout is signaled.
@@ -43,7 +45,7 @@ def _timeout_with_mapper(first_timeout=None, timeout_duration_mapper=None, other
             switched = False
             _id = [0]
 
-            def set_timer(timeout):
+            def set_timer(timeout: Observable) -> None:
                 my_id = _id[0]
 
                 def timer_wins():

--- a/rx/core/operators/todict.py
+++ b/rx/core/operators/todict.py
@@ -1,11 +1,11 @@
 from typing import Callable, Any, Optional
 
-from rx.core import typing
-from rx.core import Observable
+from rx.core import typing, Observable
+from rx.core.typing import Mapper
 
 
-def _to_dict(key_mapper: Callable[[Any], Any],
-             element_mapper: Optional[Callable[[Any], Any]] = None
+def _to_dict(key_mapper: Mapper,
+             element_mapper: Optional[Mapper] = None
              ) -> Callable[[Observable], Observable]:
     def to_dict(source: Observable) -> Observable:
         """Converts the observable sequence to a Map if it exists.

--- a/rx/core/operators/tofuture.py
+++ b/rx/core/operators/tofuture.py
@@ -1,11 +1,11 @@
-from typing import Callable
+from typing import Callable, Optional
 from asyncio import Future
 
 from rx.core import Observable
 from rx.internal.exceptions import SequenceContainsNoElementsError
 
 
-def _to_future(future_ctor: Callable[[], Future] = None) -> Callable[[Observable], Future]:
+def _to_future(future_ctor: Optional[Callable[[], Future]] = None) -> Callable[[Observable], Future]:
     future_ctor = future_ctor or Future
     future = future_ctor()
 

--- a/rx/core/operators/tomarbles.py
+++ b/rx/core/operators/tomarbles.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Optional
 
 from rx.core import Observable
 from rx.core.typing import Scheduler, RelativeTime
@@ -7,7 +7,7 @@ from rx.concurrency import NewThreadScheduler
 new_thread_scheduler = NewThreadScheduler()
 
 
-def _to_marbles(scheduler: Scheduler = None, timespan: RelativeTime = 0.1):
+def _to_marbles(scheduler: Optional[Scheduler] = None, timespan: RelativeTime = 0.1):
 
     def to_marbles(source: Observable) -> Observable:
         """Convert an observable sequence into a marble diagram string.

--- a/rx/core/operators/whiledo.py
+++ b/rx/core/operators/whiledo.py
@@ -3,11 +3,11 @@ import itertools
 
 import rx
 from rx.core import Observable
-
+from rx.core.typing import Predicate
 from rx.internal.utils import is_future, infinite
 
 
-def _while_do(condition: Callable[[Any], bool]) -> Callable[[Observable], Observable]:
+def _while_do(condition: Predicate) -> Callable[[Observable], Observable]:
     def while_do(source: Observable) -> Observable:
         """Repeats source as long as condition holds emulating a while
         loop.

--- a/rx/operators/__init__.py
+++ b/rx/operators/__init__.py
@@ -2069,7 +2069,7 @@ def scan(accumulator: Accumulator, seed: Any = NotSet) -> Callable[[Observable],
     return _scan(accumulator, seed)
 
 
-def sequence_equal(second: Observable, comparer: Callable[[Any, Any], bool] = None
+def sequence_equal(second: Observable, comparer: Optional[Comparer] = None
                    ) -> Callable[[Observable], Observable]:
     """Determines whether two sequences are equal by comparing the
     elements pairwise using a specified equality comparer.

--- a/rx/operators/__init__.py
+++ b/rx/operators/__init__.py
@@ -2306,7 +2306,8 @@ def skip_until(other: Observable) -> Callable[[Observable], Observable]:
     return _skip_until(other)
 
 
-def skip_until_with_time(start_time: typing.AbsoluteOrRelativeTime, scheduler: typing.Scheduler = None
+def skip_until_with_time(start_time: typing.AbsoluteOrRelativeTime,
+                         scheduler: Optional[typing.Scheduler] = None
                         ) -> Callable[[Observable], Observable]:
     """Skips elements from the observable source sequence until the
     specified start time.

--- a/rx/operators/__init__.py
+++ b/rx/operators/__init__.py
@@ -2586,7 +2586,7 @@ def subscribe_on(scheduler: typing.Scheduler) -> Callable[[Observable], Observab
     return _subscribe_on(scheduler)
 
 
-def sum(key_mapper: Mapper = None) -> Callable[[Observable], Observable]:
+def sum(key_mapper: Optional[Mapper] = None) -> Callable[[Observable], Observable]:
     """Computes the sum of a sequence of values that are obtained by
     invoking an optional transform function on each element of the
     input sequence, else if not specified computes the sum on each item

--- a/rx/operators/__init__.py
+++ b/rx/operators/__init__.py
@@ -3231,14 +3231,17 @@ def window_with_count(count: int, skip: Optional[int] = None) -> Callable[[Obser
     return _window_with_count(count, skip)
 
 
-def window_with_time(timespan: typing.RelativeTime, timeshift: Optional[typing.RelativeTime] = None,
-                     scheduler: Optional[typing.Scheduler] = None) -> Callable[[Observable], Observable]:
+def window_with_time(timespan: typing.RelativeTime,
+                     timeshift: Optional[typing.RelativeTime] = None,
+                     scheduler: Optional[typing.Scheduler] = None
+                     ) -> Callable[[Observable], Observable]:
     from rx.core.operators.windowwithtime import _window_with_time
     return _window_with_time(timespan, timeshift, scheduler)
 
 
 def window_with_time_or_count(timespan: typing.RelativeTime, count: int,
-                              scheduler: Optional[typing.Scheduler] = None) -> Callable[[Observable], Observable]:
+                              scheduler: Optional[typing.Scheduler] = None
+                              ) -> Callable[[Observable], Observable]:
     from rx.core.operators.windowwithtimeorcount import _window_with_time_or_count
     return _window_with_time_or_count(timespan, count, scheduler)
 

--- a/rx/operators/__init__.py
+++ b/rx/operators/__init__.py
@@ -6,7 +6,7 @@ from datetime import timedelta, datetime
 
 from rx.internal.utils import NotSet
 from rx.core import Observable, ConnectableObservable, GroupedObservable, typing, pipe
-from rx.core.typing import Mapper, MapperIndexed, Predicate, PredicateIndexed, Comparer
+from rx.core.typing import Mapper, MapperIndexed, Predicate, PredicateIndexed, Comparer, Accumulator
 from rx.subjects import Subject
 
 
@@ -1872,7 +1872,7 @@ def publish_value(initial_value: Any, mapper: Optional[Mapper] = None) -> Callab
     return _publish_value(initial_value, mapper)
 
 
-def reduce(accumulator: Callable[[Any, Any], Any], seed: Any = NotSet) -> Callable[[Observable], Observable]:
+def reduce(accumulator: Accumulator, seed: Any = NotSet) -> Callable[[Observable], Observable]:
     """The reduce operator.
 
     Applies an accumulator function over an observable sequence,

--- a/rx/operators/__init__.py
+++ b/rx/operators/__init__.py
@@ -159,8 +159,10 @@ def buffer_with_count(count: int, skip: Optional[int] = None) -> Callable[[Obser
     return _buffer_with_count(count, skip)
 
 
-def buffer_with_time(timespan: typing.RelativeTime, timeshift: Optional[typing.RelativeTime] = None,
-                     scheduler: Optional[typing.Scheduler] = None) -> Callable[[Observable], Observable]:
+def buffer_with_time(timespan: typing.RelativeTime,
+                     timeshift: Optional[typing.RelativeTime] = None,
+                     scheduler: Optional[typing.Scheduler] = None
+                     ) -> Callable[[Observable], Observable]:
     """Projects each element of an observable sequence into zero or more
     buffers which are produced based on timing information.
 
@@ -227,7 +229,8 @@ def buffer_with_time_or_count(timespan, count, scheduler=None) -> Callable[[Obse
     return _buffer_with_time_or_count(timespan, count, scheduler)
 
 
-def catch(second: Observable = None, handler: Callable[[Exception, Observable], Observable] = None
+def catch(second: Observable = None,
+          handler: Callable[[Exception, Observable], Observable] = None
           ) -> Callable[[Observable], Observable]:
     """Continues an observable sequence that is terminated by an
     exception with the next observable sequence.
@@ -433,7 +436,8 @@ def default_if_empty(default_value: Any = None) -> Callable[[Observable], Observ
     return _default_if_empty(default_value)
 
 
-def delay_subscription(duetime: typing.AbsoluteOrRelativeTime, scheduler: Optional[typing.Scheduler] = None
+def delay_subscription(duetime: typing.AbsoluteOrRelativeTime,
+                       scheduler: Optional[typing.Scheduler] = None
                       ) -> Callable[[Observable], Observable]:
     """Time shifts the observable sequence by delaying the
     subscription.
@@ -461,7 +465,9 @@ def delay_subscription(duetime: typing.AbsoluteOrRelativeTime, scheduler: Option
     return _delay_subscription(duetime, scheduler=scheduler)
 
 
-def delay_with_mapper(subscription_delay=None, delay_duration_mapper=None) -> Callable[[Observable], Observable]:
+def delay_with_mapper(subscription_delay=None,
+                      delay_duration_mapper=None
+                      ) -> Callable[[Observable], Observable]:
     """Time shifts the observable sequence based on a subscription
     delay and a delay mapper function for each element.
 
@@ -678,7 +684,7 @@ def do_action(on_next: Optional[typing.OnNext] = None,
     return _do_action(on_next, on_error, on_completed)
 
 
-def do_while(condition: Callable[[Any], bool]) -> Callable[[Observable], Observable]:
+def do_while(condition: Predicate) -> Callable[[Observable], Observable]:
     """Repeats source as long as condition holds emulating a do while
     loop.
 
@@ -2154,7 +2160,9 @@ def single(predicate: Optional[Predicate] = None) -> Callable[[Observable], Obse
     return _single(predicate)
 
 
-def single_or_default(predicate: Optional[Predicate] = None, default_value: Any = None) -> Callable[[Observable], Observable]:
+def single_or_default(predicate: Optional[Predicate] = None,
+                      default_value: Any = None
+                      ) -> Callable[[Observable], Observable]:
     """Returns the only element of an observable sequence that matches
     the predicate, or a default value if no such element exists this
     method reports an exception if there is more than one element in
@@ -2189,7 +2197,9 @@ def single_or_default(predicate: Optional[Predicate] = None, default_value: Any 
     return _single_or_default(predicate, default_value)
 
 
-def single_or_default_async(has_default: bool = False, default_value: Any = None) -> Callable[[Observable], Observable]:
+def single_or_default_async(has_default: bool = False,
+                            default_value: Any = None
+                            ) -> Callable[[Observable], Observable]:
     from rx.core.operators.singleordefault import _single_or_default_async
     return _single_or_default_async(has_default, default_value)
 
@@ -2439,7 +2449,10 @@ def skip_with_time(duration: typing.RelativeTime, scheduler: Optional[typing.Sch
     return _skip_with_time(duration, scheduler=scheduler)
 
 
-def slice(start: Optional[int] = None, stop: Optional[int] = None, step: int = 1) -> Callable[[Observable], Observable]:
+def slice(start: Optional[int] = None,
+          stop: Optional[int] = None,
+          step: int = 1
+          ) -> Callable[[Observable], Observable]:
     """The slice operator.
 
     Slices the given observable. It is basically a wrapper around the

--- a/rx/operators/__init__.py
+++ b/rx/operators/__init__.py
@@ -2923,7 +2923,8 @@ def take_with_time(duration: typing.RelativeTime, scheduler: Optional[typing.Sch
     return _take_with_time(duration, scheduler=scheduler)
 
 
-def throttle_first(window_duration: typing.RelativeTime, scheduler: typing.Scheduler = None
+def throttle_first(window_duration: typing.RelativeTime,
+                   scheduler: Optional[typing.Scheduler] = None
                   ) -> Callable[[Observable], Observable]:
     """Returns an Observable that emits only the first item emitted by
     the source Observable during sequential time windows of a specified
@@ -2963,7 +2964,7 @@ def throttle_with_mapper(throttle_duration_mapper: Callable[[Any], Observable]) 
     return _throttle_with_mapper(throttle_duration_mapper)
 
 
-def timestamp(scheduler: typing.Scheduler = None) -> Callable[[Observable], Observable]:
+def timestamp(scheduler: Optional[typing.Scheduler] = None) -> Callable[[Observable], Observable]:
     """The timestamp operator.
 
     Records the timestamp for each value in an observable sequence.

--- a/rx/operators/__init__.py
+++ b/rx/operators/__init__.py
@@ -2502,7 +2502,7 @@ def some(predicate: Optional[Predicate] = None) -> Callable[[Observable], Observ
 
 
 
-def starmap(mapper: Mapper = None) -> Callable[[Observable], Observable]:
+def starmap(mapper: Optional[Mapper] = None) -> Callable[[Observable], Observable]:
     """The starmap operator.
 
     Unpack arguments grouped as tuple elements of an observable

--- a/rx/operators/__init__.py
+++ b/rx/operators/__init__.py
@@ -3052,7 +3052,7 @@ def timeout_with_mapper(first_timeout: Optional[Observable] = None,
     return _timeout_with_mapper(first_timeout, timeout_duration_mapper, other)
 
 
-def time_interval(scheduler: typing.Scheduler = None) -> Callable[[Observable], Observable]:
+def time_interval(scheduler: Optional[typing.Scheduler] = None) -> Callable[[Observable], Observable]:
     """Records the time interval between consecutive values in an
     observable sequence.
 

--- a/rx/operators/__init__.py
+++ b/rx/operators/__init__.py
@@ -1838,7 +1838,7 @@ def publish(mapper: Optional[Mapper] = None) -> Callable[[Observable], Connectab
     return _publish(mapper)
 
 
-def publish_value(initial_value: Any, mapper: Mapper = None) -> Callable[[Observable], Observable]:
+def publish_value(initial_value: Any, mapper: Optional[Mapper] = None) -> Callable[[Observable], Observable]:
     """Returns an observable sequence that is the result of invoking
     the mapper on a connectable observable sequence that shares a
     single subscription to the underlying sequence and starts with

--- a/rx/operators/__init__.py
+++ b/rx/operators/__init__.py
@@ -2700,7 +2700,7 @@ def take_last(count: int) -> Callable[[Observable], Observable]:
     return _take_last(count)
 
 
-def take_last_buffer(count) -> Callable[[Observable], Observable]:
+def take_last_buffer(count: int) -> Callable[[Observable], Observable]:
     """The `take_last_buffer` operator.
 
     Returns an array with the specified number of contiguous elements

--- a/rx/operators/__init__.py
+++ b/rx/operators/__init__.py
@@ -3021,8 +3021,10 @@ def timeout(duetime: typing.AbsoluteTime,
     return _timeout(duetime, other, scheduler)
 
 
-def timeout_with_mapper(first_timeout=None, timeout_duration_mapper=None, other=None
-                       ) -> Callable[[Observable], Observable]:
+def timeout_with_mapper(first_timeout: Optional[Observable] = None,
+                        timeout_duration_mapper: Optional[Callable[[Any], Observable]] = None,
+                        other: Optional[Observable] = None
+                        ) -> Callable[[Observable], Observable]:
     """Returns the source observable sequence, switching to the other
     observable sequence if a timeout is signaled.
 

--- a/rx/operators/__init__.py
+++ b/rx/operators/__init__.py
@@ -2469,7 +2469,7 @@ def slice(start: Optional[int] = None, stop: Optional[int] = None, step: int = 1
     return _slice(start, stop, step)
 
 
-def some(predicate=None) -> Callable[[Observable], Observable]:
+def some(predicate: Optional[Predicate] = None) -> Callable[[Observable], Observable]:
     """The some operator.
 
     Determines whether some element of an observable sequence

--- a/rx/operators/__init__.py
+++ b/rx/operators/__init__.py
@@ -1946,8 +1946,11 @@ def repeat(repeat_count: Optional[int] = None) -> Callable[[Observable], Observa
     return _repeat(repeat_count)
 
 
-def replay(mapper: Mapper = None, buffer_size: int = None, window: typing.RelativeTime = None,
-           scheduler: typing.Scheduler = None) -> Callable[[Observable], Union[Observable, ConnectableObservable]]:
+def replay(mapper: Optional[Mapper] = None,
+           buffer_size: Optional[int] = None,
+           window: Optional[typing.RelativeTime] = None,
+           scheduler: Optional[typing.Scheduler] = None
+           ) -> Callable[[Observable], Union[Observable, ConnectableObservable]]:
     """The `replay` operator.
 
     Returns an observable sequence that is the result of invoking the
@@ -1974,6 +1977,7 @@ def replay(mapper: Mapper = None, buffer_size: int = None, window: typing.Relati
         buffer_size: [Optional] Maximum element count of the replay
             buffer.
         window: [Optional] Maximum time length of the replay buffer.
+        scheduler: [Optional] Scheduler the observers are invoked on.
 
     Returns:
         An operator function that takes an observable source and

--- a/rx/operators/__init__.py
+++ b/rx/operators/__init__.py
@@ -2439,7 +2439,7 @@ def skip_with_time(duration: typing.RelativeTime, scheduler: Optional[typing.Sch
     return _skip_with_time(duration, scheduler=scheduler)
 
 
-def slice(start: int = None, stop: int = None, step: int = 1) -> Callable[[Observable], Observable]:
+def slice(start: Optional[int] = None, stop: Optional[int] = None, step: int = 1) -> Callable[[Observable], Observable]:
     """The slice operator.
 
     Slices the given observable. It is basically a wrapper around the

--- a/rx/operators/__init__.py
+++ b/rx/operators/__init__.py
@@ -1989,7 +1989,7 @@ def replay(mapper: Optional[Mapper] = None,
     return _replay(mapper, buffer_size, window, scheduler=scheduler)
 
 
-def retry(retry_count: int = None) -> Callable[[Observable], Observable]:
+def retry(retry_count: Optional[int] = None) -> Callable[[Observable], Observable]:
     """Repeats the source observable sequence the specified number of
     times or until it successfully terminates. If the retry count is
     not specified, it retries indefinitely.

--- a/rx/operators/__init__.py
+++ b/rx/operators/__init__.py
@@ -2735,7 +2735,9 @@ def take_last_buffer(count: int) -> Callable[[Observable], Observable]:
     return _take_last_buffer(count)
 
 
-def take_last_with_time(duration: typing.RelativeTime, scheduler: typing.Scheduler = None) -> Callable[[Observable], Observable]:
+def take_last_with_time(duration: typing.RelativeTime,
+                        scheduler: Optional[typing.Scheduler] = None
+                        ) -> Callable[[Observable], Observable]:
     """Returns elements within the specified duration from the end of
     the observable source sequence.
 

--- a/rx/operators/__init__.py
+++ b/rx/operators/__init__.py
@@ -2402,7 +2402,7 @@ def skip_while_indexed(predicate: typing.PredicateIndexed) -> Callable[[Observab
     return _skip_while_indexed(predicate)
 
 
-def skip_with_time(duration: typing.RelativeTime, scheduler: typing.Scheduler = None
+def skip_with_time(duration: typing.RelativeTime, scheduler: Optional[typing.Scheduler] = None
                   ) -> Callable[[Observable], Observable]:
     """Skips elements for the specified duration from the start of the
     observable source sequence.

--- a/rx/operators/__init__.py
+++ b/rx/operators/__init__.py
@@ -2016,7 +2016,10 @@ def retry(retry_count: Optional[int] = None) -> Callable[[Observable], Observabl
     return _retry(retry_count)
 
 
-def sample(interval=None, sampler=None, scheduler: typing.Scheduler = None) -> Callable[[Observable], Observable]:
+def sample(interval: Optional[typing.RelativeTime] = None,
+           sampler: Optional[Observable] = None,
+           scheduler: Optional[typing.Scheduler] = None
+           ) -> Callable[[Observable], Observable]:
     """Samples the observable sequence at each interval.
 
     .. marble::
@@ -2027,7 +2030,7 @@ def sample(interval=None, sampler=None, scheduler: typing.Scheduler = None) -> C
         ----1---3---4---|
 
     Examples:
-        >>> res = sample(sample_observable) # Sampler tick sequence
+        >>> res = sample(None, sample_observable) # Sampler tick sequence
         >>> res = sample(5.0) # 5 seconds
 
     Args:

--- a/rx/operators/__init__.py
+++ b/rx/operators/__init__.py
@@ -3124,7 +3124,9 @@ def to_iterable() -> Callable[[Observable], Observable]:
     return _to_iterable()
 
 
-def to_marbles(timespan: typing.RelativeTime = 0.1, scheduler: typing.Scheduler = None ) -> Callable[[Observable], Observable]:
+def to_marbles(timespan: typing.RelativeTime = 0.1,
+               scheduler: Optional[typing.Scheduler] = None
+               ) -> Callable[[Observable], Observable]:
     """Convert an observable sequence into a marble diagram string.
 
     Args:

--- a/rx/operators/__init__.py
+++ b/rx/operators/__init__.py
@@ -2122,7 +2122,7 @@ def share() -> Callable[[Observable], Observable]:
     return _share()
 
 
-def single(predicate: Predicate = None) -> Callable[[Observable], Observable]:
+def single(predicate: Optional[Predicate] = None) -> Callable[[Observable], Observable]:
     """The single operator.
 
     Returns the only element of an observable sequence that satisfies

--- a/rx/operators/__init__.py
+++ b/rx/operators/__init__.py
@@ -2889,7 +2889,7 @@ def take_while_indexed(predicate: PredicateIndexed) -> Callable[[Observable], Ob
     return _take_while_indexed(predicate)
 
 
-def take_with_time(duration: typing.RelativeTime, scheduler: typing.Scheduler = None
+def take_with_time(duration: typing.RelativeTime, scheduler: Optional[typing.Scheduler] = None
                   ) -> Callable[[Observable], Observable]:
     """Takes elements for the specified duration from the start of the
     observable source sequence.

--- a/rx/operators/__init__.py
+++ b/rx/operators/__init__.py
@@ -3095,7 +3095,7 @@ def to_dict(key_mapper: Mapper, element_mapper: Optional[Mapper] = None
     return _to_dict(key_mapper, element_mapper)
 
 
-def to_future(future_ctor: Callable[[], Future] = None) -> Callable[[Observable], Future]:
+def to_future(future_ctor: Optional[Callable[[], Future]] = None) -> Callable[[Observable], Future]:
     """Converts an existing observable sequence to a Future.
 
     Example:

--- a/rx/operators/__init__.py
+++ b/rx/operators/__init__.py
@@ -2830,7 +2830,7 @@ def take_until_with_time(end_time: typing.AbsoluteOrRelativeTime,
     return _take_until_with_time(end_time, scheduler=scheduler)
 
 
-def take_while(predicate: Callable[[Any], Any]) -> Callable[[Observable], Observable]:
+def take_while(predicate: Predicate) -> Callable[[Observable], Observable]:
     """Returns elements from an observable sequence as long as a
     specified condition is true. The element's index is used in the
     logic of the predicate function.
@@ -2860,7 +2860,7 @@ def take_while(predicate: Callable[[Any], Any]) -> Callable[[Observable], Observ
     return _take_while(predicate)
 
 
-def take_while_indexed(predicate: Callable[[Any, int], Any]) -> Callable[[Observable], Observable]:
+def take_while_indexed(predicate: PredicateIndexed) -> Callable[[Observable], Observable]:
     """Returns elements from an observable sequence as long as a
     specified condition is true. The element's index is used in the
     logic of the predicate function.

--- a/rx/operators/__init__.py
+++ b/rx/operators/__init__.py
@@ -2797,7 +2797,8 @@ def take_until(other: Observable) -> Callable[[Observable], Observable]:
     return _take_until(other)
 
 
-def take_until_with_time(end_time: typing.AbsoluteOrRelativeTime, scheduler: typing.Scheduler = None
+def take_until_with_time(end_time: typing.AbsoluteOrRelativeTime,
+                         scheduler: Optional[typing.Scheduler] = None
                          ) -> Callable[[Observable], Observable]:
     """Takes elements for the specified duration until the specified
     end time, using the specified scheduler to run timers.

--- a/rx/operators/__init__.py
+++ b/rx/operators/__init__.py
@@ -2036,7 +2036,7 @@ def sample(interval=None, sampler=None, scheduler: typing.Scheduler = None) -> C
     return _sample(interval, sampler)
 
 
-def scan(accumulator: Callable[[Any, Any], Any], seed: Any = NotSet) -> Callable[[Observable], Observable]:
+def scan(accumulator: Accumulator, seed: Any = NotSet) -> Callable[[Observable], Observable]:
     """The scan operator.
 
     Applies an accumulator function over an observable sequence and

--- a/rx/operators/__init__.py
+++ b/rx/operators/__init__.py
@@ -2984,7 +2984,9 @@ def timestamp(scheduler: Optional[typing.Scheduler] = None) -> Callable[[Observa
     return _timestamp(scheduler=scheduler)
 
 
-def timeout(duetime: typing.AbsoluteTime, other: Observable = None, scheduler: typing.Scheduler = None
+def timeout(duetime: typing.AbsoluteTime,
+            other: Optional[Observable] = None,
+            scheduler: Optional[typing.Scheduler] = None
             ) -> Callable[[Observable], Observable]:
     """Returns the source observable sequence or the other observable
     sequence if duetime elapses.

--- a/rx/operators/__init__.py
+++ b/rx/operators/__init__.py
@@ -3170,7 +3170,7 @@ def to_set() -> Callable[[Observable], Observable]:
     return _to_set()
 
 
-def while_do(condition: Callable[[Any], bool]) -> Callable[[Observable], Observable]:
+def while_do(condition: Predicate) -> Callable[[Observable], Observable]:
     """Repeats source as long as condition holds emulating a while
     loop.
 

--- a/rx/operators/__init__.py
+++ b/rx/operators/__init__.py
@@ -3075,7 +3075,7 @@ def time_interval(scheduler: Optional[typing.Scheduler] = None) -> Callable[[Obs
     return _time_interval(scheduler=scheduler)
 
 
-def to_dict(key_mapper: Callable[[Any], Any], element_mapper: Callable[[Any], Any] = None
+def to_dict(key_mapper: Mapper, element_mapper: Optional[Mapper] = None
            ) -> Callable[[Observable], Observable]:
     """Converts the observable sequence to a Map if it exists.
 


### PR DESCRIPTION
Following #382 effort. This PR basically adds missing `Optional` qualifier, and enforces the use of "callables" declared in rx.core.typing (`Accumulator`, `Mapper`, ...).