### PR TITLE
feat(take_while): add `inclusive` option.

### DIFF
--- a/rx/core/operators/takewhile.py
+++ b/rx/core/operators/takewhile.py
@@ -3,7 +3,8 @@ from typing import Any, Callable
 from rx.core import Observable
 from rx.core.typing import Predicate, PredicateIndexed
 
-def _take_while(predicate: Predicate) -> Callable[[Observable], Observable]:
+
+def _take_while(predicate: Predicate, inclusive: bool = False) -> Callable[[Observable], Observable]:
     def take_while(source: Observable) -> Observable:
         """Returns elements from an observable sequence as long as a
         specified condition is true. The element's index is used in the
@@ -40,6 +41,8 @@ def _take_while(predicate: Predicate) -> Callable[[Observable], Observable]:
                 if running:
                     observer.on_next(value)
                 else:
+                    if inclusive:
+                        observer.on_next(value)
                     observer.on_completed()
 
             return source.subscribe_(on_next, observer.on_error, observer.on_completed, scheduler)
@@ -47,7 +50,7 @@ def _take_while(predicate: Predicate) -> Callable[[Observable], Observable]:
     return take_while
 
 
-def _take_while_indexed(predicate: PredicateIndexed) -> Callable[[Observable], Observable]:
+def _take_while_indexed(predicate: PredicateIndexed, inclusive: bool = False) -> Callable[[Observable], Observable]:
     def take_while_indexed(source: Observable) -> Observable:
         """Returns elements from an observable sequence as long as a
         specified condition is true. The element's index is used in the
@@ -87,6 +90,8 @@ def _take_while_indexed(predicate: PredicateIndexed) -> Callable[[Observable], O
                 if running:
                     observer.on_next(value)
                 else:
+                    if inclusive:
+                        observer.on_next(value)
                     observer.on_completed()
 
             return source.subscribe_(on_next, observer.on_error, observer.on_completed, scheduler)

--- a/rx/operators/__init__.py
+++ b/rx/operators/__init__.py
@@ -2846,7 +2846,7 @@ def take_until_with_time(end_time: typing.AbsoluteOrRelativeTime,
     return _take_until_with_time(end_time, scheduler=scheduler)
 
 
-def take_while(predicate: Predicate, inclusive: Optional[bool] = False) -> Callable[[Observable], Observable]:
+def take_while(predicate: Predicate, inclusive: bool = False) -> Callable[[Observable], Observable]:
     """Returns elements from an observable sequence as long as a
     specified condition is true. The element's index is used in the
     logic of the predicate function.
@@ -2877,7 +2877,7 @@ def take_while(predicate: Predicate, inclusive: Optional[bool] = False) -> Calla
     return _take_while(predicate, inclusive)
 
 
-def take_while_indexed(predicate: PredicateIndexed, inclusive: Optional[bool] = False) -> Callable[[Observable], Observable]:
+def take_while_indexed(predicate: PredicateIndexed, inclusive: bool = False) -> Callable[[Observable], Observable]:
     """Returns elements from an observable sequence as long as a
     specified condition is true. The element's index is used in the
     logic of the predicate function.

--- a/rx/operators/__init__.py
+++ b/rx/operators/__init__.py
@@ -2846,7 +2846,7 @@ def take_until_with_time(end_time: typing.AbsoluteOrRelativeTime,
     return _take_until_with_time(end_time, scheduler=scheduler)
 
 
-def take_while(predicate: Predicate) -> Callable[[Observable], Observable]:
+def take_while(predicate: Predicate, inclusive: Optional[bool] = False) -> Callable[[Observable], Observable]:
     """Returns elements from an observable sequence as long as a
     specified condition is true. The element's index is used in the
     logic of the predicate function.
@@ -2862,9 +2862,10 @@ def take_while(predicate: Predicate) -> Callable[[Observable], Observable]:
         >>> take_while(lambda value: value < 10)
 
     Args:
-        predicate: A function to test each element for a condition; the
-            second parameter of the function represents the index of
-            the source element.
+        predicate: A function to test each element for a condition.
+        inclusive: [Optional]  When set to True the value that caused
+            the predicate function to return False will also be emitted.
+            If not specified, defaults to False.
 
     Returns:
         An operator function that takes an observable source and
@@ -2873,10 +2874,10 @@ def take_while(predicate: Predicate) -> Callable[[Observable], Observable]:
         test no longer passes.
     """
     from rx.core.operators.takewhile import _take_while
-    return _take_while(predicate)
+    return _take_while(predicate, inclusive)
 
 
-def take_while_indexed(predicate: PredicateIndexed) -> Callable[[Observable], Observable]:
+def take_while_indexed(predicate: PredicateIndexed, inclusive: Optional[bool] = False) -> Callable[[Observable], Observable]:
     """Returns elements from an observable sequence as long as a
     specified condition is true. The element's index is used in the
     logic of the predicate function.
@@ -2893,16 +2894,19 @@ def take_while_indexed(predicate: PredicateIndexed) -> Callable[[Observable], Ob
 
     Args:
         predicate: A function to test each element for a condition; the
-        second parameter of the function represents the index of the
-        source element.
+            second parameter of the function represents the index of the
+            source element.
+        inclusive: [Optional]  When set to True the value that caused
+            the predicate function to return False will also be emitted.
+            If not specified, defaults to False.
 
     Returns:
         An observable sequence that contains the elements from the
-    input sequence that occur before the element at which the test no
-    longer passes.
+        input sequence that occur before the element at which the test no
+        longer passes.
     """
     from rx.core.operators.takewhile import _take_while_indexed
-    return _take_while_indexed(predicate)
+    return _take_while_indexed(predicate, inclusive)
 
 
 def take_with_time(duration: typing.RelativeTime, scheduler: Optional[typing.Scheduler] = None

--- a/tests/test_observable/test_takewhile.py
+++ b/tests/test_observable/test_takewhile.py
@@ -185,3 +185,49 @@ class TestTakeWhile(unittest.TestCase):
         assert results.messages == [on_next(205, 100), on_next(210, 2), on_next(
             260, 5), on_next(290, 13), on_next(320, 3), on_completed(350)]
         assert xs.subscriptions == [subscribe(200, 350)]
+
+    def test_take_while_index_inclusive_false(self):
+        scheduler = TestScheduler()
+        xs = scheduler.create_hot_observable(on_next(90, -1), on_next(110, -1), on_next(205, 100), on_next(210, 2), on_next(260, 5), on_next(
+            290, 13), on_next(320, 3), on_next(350, 7), on_next(390, 4), on_next(410, 17), on_next(450, 8), on_next(500, 23), on_completed(600))
+
+        def factory():
+            return xs.pipe(ops.take_while_indexed(lambda x, i: i < 5, inclusive=False))
+        results = scheduler.start(factory)
+
+        assert results.messages == [on_next(205, 100), on_next(210, 2), on_next(
+            260, 5), on_next(290, 13), on_next(320, 3), on_completed(350)]
+        assert xs.subscriptions == [subscribe(200, 350)]
+
+    def test_take_while_index_inclusive_true(self):
+        scheduler = TestScheduler()
+        xs = scheduler.create_hot_observable(on_next(90, -1), on_next(110, -1), on_next(205, 100), on_next(210, 2), on_next(260, 5), on_next(
+            290, 13), on_next(320, 3), on_next(350, 7), on_next(390, 4), on_next(410, 17), on_next(450, 8), on_next(500, 23), on_completed(600))
+
+        def factory_inclusive():
+            return xs.pipe(ops.take_while_indexed(lambda x, i: i < 4, inclusive=True))
+        results_inclusive = scheduler.start(factory_inclusive)
+
+        assert results_inclusive.messages == [on_next(205, 100), on_next(210, 2), on_next(
+            260, 5), on_next(290, 13), on_next(320, 3), on_completed(320)]
+        assert xs.subscriptions == [subscribe(200, 320)]
+
+    def test_take_while_complete_after_inclusive_true(self):
+        scheduler = TestScheduler()
+        xs = scheduler.create_hot_observable(on_next(90, -1), on_next(110, -1), on_next(210, 2), on_next(260, 5), on_next(290, 13), on_next(
+            320, 3), on_next(350, 7), on_next(390, 4), on_next(410, 17), on_next(450, 8), on_next(500, 23), on_completed(600))
+        invoked = 0
+
+        def factory():
+            def predicate(x):
+                nonlocal invoked
+
+                invoked += 1
+                return is_prime(x)
+            return xs.pipe(ops.take_while(predicate, inclusive=True))
+        results = scheduler.start(factory)
+
+        assert results.messages == [on_next(210, 2), on_next(260, 5), on_next(
+            290, 13), on_next(320, 3), on_next(350, 7), on_next(390, 4), on_completed(390)]
+        assert xs.subscriptions == [subscribe(200, 390)]
+        assert(invoked == 6)


### PR DESCRIPTION
Thanks for your work. :+1: 
Here a PR that adds an `inclusive` option to the `take_while` operator.
When `inclusive` is set to `True`, the operator emit the value that caused the `predicate` function to return `False`.