### PR TITLE
addition of links to community projects supporting backpressure

### DIFF
--- a/docs/additional_readings.rst
+++ b/docs/additional_readings.rst
@@ -1,3 +1,5 @@
+.. _additional_readings:
+
 Additional Readings
 ===================
 
@@ -17,6 +19,10 @@ Several commercial contents have their associated example code available freely:
 
 * `Packt Reactive Programming in Python <https://github.com/PacktPublishing/Reactive-Programming-in-Python>`_
 
+RxPY 3.0.0 has removed support for backpressure here are the known community projects supporting backpressure:
+
+* `rxbackpressure rxpy extension <https://github.com/MichaelSchneeberger/rxbackpressure>`_
+* `rxpy_backpressure observer decorators <https://github.com/daliclass/rxpy-backpressure>`_
 
 Commercial Material
 --------------------

--- a/docs/migration.rst
+++ b/docs/migration.rst
@@ -201,6 +201,8 @@ can be adopted. So we consider that such features are beyond the scope of RxPY.
 You are encouraged to provide independent implementations as separate packages so
 that they can be shared by the community.
 
+List of community projects supporting backpressure can be found in :ref:`additional_readings`.
+
 Time Is In Seconds
 ------------------
 


### PR DESCRIPTION
Hey - There is some good working going on to support backpressure with rxpy 3 I think its a good idea to list the projects in the migration file to support people moving over from 1.6. 

Thoughts?
