### PR TITLE
Make to_iterable return the list 

### DIFF
--- a/rx/core/operators/toiterable.py
+++ b/rx/core/operators/toiterable.py
@@ -20,7 +20,7 @@ def _to_iterable() -> Callable[[Observable], Observable]:
                 queue.append(item)
 
             def on_completed():
-                observer.on_next(iter(queue))
+                observer.on_next(queue)
                 observer.on_completed()
 
             return source.subscribe_(on_next, observer.on_error, on_completed, scheduler)

--- a/rx/operators/__init__.py
+++ b/rx/operators/__init__.py
@@ -3135,6 +3135,8 @@ def to_future(future_ctor: Optional[Callable[[], Future]] = None) -> Callable[[O
 def to_iterable() -> Callable[[Observable], Observable]:
     """Creates an iterable from an observable sequence.
 
+    There is also an alias called ``to_list``.
+
     Returns:
         An operator function that takes an obserable source and
         returns an observable sequence containing a single element with
@@ -3143,6 +3145,7 @@ def to_iterable() -> Callable[[Observable], Observable]:
     from rx.core.operators.toiterable import _to_iterable
     return _to_iterable()
 
+to_list = to_iterable
 
 def to_marbles(timespan: typing.RelativeTime = 0.1,
                scheduler: Optional[typing.Scheduler] = None


### PR DESCRIPTION
Make `to_iterable` return the list directly instead of an iterator (should have been an iterable anyways). Add alias `to_list` to make it symmetric with `from_iterable`/`from_list`. Fixes #395