### PR TITLE
operators rework: buffer, sample, catch

### DIFF
--- a/rx/core/observable/observable.py
+++ b/rx/core/observable/observable.py
@@ -30,6 +30,7 @@ class Observable(typing.Observable):
         Args:
             subscribe: Subscribe method implementation.
         """
+
         self.lock = threading.RLock()
         self._subscribe = subscribe
 

--- a/rx/core/observable/observable.py
+++ b/rx/core/observable/observable.py
@@ -30,7 +30,6 @@ class Observable(typing.Observable):
         Args:
             subscribe: Subscribe method implementation.
         """
-
         self.lock = threading.RLock()
         self._subscribe = subscribe
 

--- a/rx/core/operators/sample.py
+++ b/rx/core/operators/sample.py
@@ -1,4 +1,4 @@
-from typing import Callable, Optional
+from typing import Callable, Optional, Union
 
 import rx
 from rx.core import Observable, typing
@@ -33,8 +33,7 @@ def sample_observable(source: Observable, sampler: Observable) -> Observable:
     return Observable(subscribe)
 
 
-def _sample(interval: Optional[typing.RelativeTime] = None,
-            sampler: Optional[Observable] = None,
+def _sample(sampler: Union[typing.RelativeTime, Observable],
             scheduler: Optional[typing.Scheduler] = None
             ) -> Callable[[Observable], Observable]:
 
@@ -51,8 +50,9 @@ def _sample(interval: Optional[typing.RelativeTime] = None,
             Sampled observable sequence.
         """
 
-        if interval is None:
-            return sample_observable(source, sampler)
+        if isinstance(sampler, typing.Observable):
+            return sample_observable(sampler)
+        else:
+            return sample_observable(source, rx.interval(sampler, scheduler=scheduler))
 
-        return sample_observable(source, rx.interval(interval, scheduler=scheduler))
     return sample

--- a/rx/core/operators/sample.py
+++ b/rx/core/operators/sample.py
@@ -51,7 +51,7 @@ def _sample(sampler: Union[typing.RelativeTime, Observable],
         """
 
         if isinstance(sampler, typing.Observable):
-            return sample_observable(sampler)
+            return sample_observable(source, sampler)
         else:
             return sample_observable(source, rx.interval(sampler, scheduler=scheduler))
 

--- a/rx/operators/__init__.py
+++ b/rx/operators/__init__.py
@@ -174,7 +174,7 @@ def buffer_toggle(openings: Observable,
            ---d--|
                        --------e--|
         ----1--2--3--4--5--6--7--8----|
-        [ buffer_toggle()             ]
+        [       buffer_toggle()       ]
         ------1----------------5,6,7--|
 
     >>> res = buffer_toggle(rx.interval(0.5), lambda i: rx.timer(i))
@@ -303,8 +303,8 @@ def catch(handler: Union[Observable, Callable[[Exception, Observable], Observabl
     .. marble::
         :alt: catch
 
-        ---1---2---3---*
-                  a-7-8-|
+        ---1---2---3-*
+                     a-7-8-|
         [      catch(a)    ]
         ---1---2---3---7-8-|
 
@@ -2090,7 +2090,7 @@ def sample(sampler: Union[typing.RelativeTime, Observable],
         :alt: sample
 
         ---1-2-3-4------|
-        [     sample(4) ]
+        [   sample(4)   ]
         ----1---3---4---|
 
     Examples:

--- a/rx/operators/__init__.py
+++ b/rx/operators/__init__.py
@@ -229,8 +229,7 @@ def buffer_with_time_or_count(timespan, count, scheduler=None) -> Callable[[Obse
     return _buffer_with_time_or_count(timespan, count, scheduler)
 
 
-def catch(second: Observable = None,
-          handler: Callable[[Exception, Observable], Observable] = None
+def catch(handler: Union[Observable, Callable[[Exception, Observable], Observable]]
           ) -> Callable[[Observable], Observable]:
     """Continues an observable sequence that is terminated by an
     exception with the next observable sequence.
@@ -248,11 +247,11 @@ def catch(second: Observable = None,
         >>> op = catch(lambda ex: ys(ex))
 
     Args:
-        handler: Exception handler function that returns an observable
-            sequence given the error that occurred in the first
-            sequence.
-        second: Second observable sequence used to produce results
-            when an error occurred in the first sequence.
+        handler: Second observable sequence used to produce
+            results when an error occurred in the first sequence, or an
+            exception handler function that returns an observable sequence
+            given the error and source observable that occurred in the
+            first sequence.
 
     Returns:
         A function taking an observable source and returns an
@@ -261,7 +260,7 @@ def catch(second: Observable = None,
         exception occurred.
     """
     from rx.core.operators.catch import _catch
-    return _catch(second, handler)
+    return _catch(handler)
 
 
 def combine_latest(*others: Observable) -> Callable[[Observable], Observable]:

--- a/rx/operators/__init__.py
+++ b/rx/operators/__init__.py
@@ -2090,7 +2090,7 @@ def sample(sampler: Union[typing.RelativeTime, Observable],
         :alt: sample
 
         ---1-2-3-4------|
-        [     sample(4)    ]
+        [     sample(4) ]
         ----1---3---4---|
 
     Examples:
@@ -2101,13 +2101,14 @@ def sample(sampler: Union[typing.RelativeTime, Observable],
         sampler: Observable used to sample the source observable **or** time
             interval at which to sample (specified as a float denoting
             seconds or an instance of timedelta).
+        scheduler: Scheduler to use only when a time interval is given.
 
     Returns:
         An operator function that takes an observable source and
         returns a sampled observable sequence.
     """
     from rx.core.operators.sample import _sample
-    return _sample(sampler)
+    return _sample(sampler, scheduler)
 
 
 def scan(accumulator: Accumulator, seed: Any = NotSet) -> Callable[[Observable], Observable]:

--- a/rx/operators/__init__.py
+++ b/rx/operators/__init__.py
@@ -2015,8 +2015,7 @@ def retry(retry_count: Optional[int] = None) -> Callable[[Observable], Observabl
     return _retry(retry_count)
 
 
-def sample(interval: Optional[typing.RelativeTime] = None,
-           sampler: Optional[Observable] = None,
+def sample(sampler: Union[typing.RelativeTime, Observable],
            scheduler: Optional[typing.Scheduler] = None
            ) -> Callable[[Observable], Observable]:
     """Samples the observable sequence at each interval.
@@ -2029,11 +2028,12 @@ def sample(interval: Optional[typing.RelativeTime] = None,
         ----1---3---4---|
 
     Examples:
-        >>> res = sample(None, sample_observable) # Sampler tick sequence
+        >>> res = sample(sample_observable) # Sampler tick sequence
         >>> res = sample(5.0) # 5 seconds
 
     Args:
-        interval: Interval at which to sample (specified as a float denoting
+        sampler: Observable used to sample the source observable **or** time
+            interval at which to sample (specified as a float denoting
             seconds or an instance of timedelta).
 
     Returns:
@@ -2041,7 +2041,7 @@ def sample(interval: Optional[typing.RelativeTime] = None,
         returns a sampled observable sequence.
     """
     from rx.core.operators.sample import _sample
-    return _sample(interval, sampler)
+    return _sample(sampler)
 
 
 def scan(accumulator: Accumulator, seed: Any = NotSet) -> Callable[[Observable], Observable]:

--- a/rx/operators/__init__.py
+++ b/rx/operators/__init__.py
@@ -116,7 +116,7 @@ def buffer(boundaries: Observable) -> Callable[[Observable], Observable]:
         ---1-----2,3---4,5------|
 
     Examples:
-        >>> res = window(rx.interval(1.0))
+        >>> res = buffer(rx.interval(1.0))
 
     Args:
         boundaries: Observable sequence whose elements denote the
@@ -137,21 +137,21 @@ def buffer_when(closing_mapper: Callable[[], Observable]) -> Callable[[Observabl
     .. marble::
         :alt: buffer_when
 
-        -----c--|
-                -----c--|
-                        -----c--|
-        ---1--2--3--4--5--6-----|
-        [      buffer_when      ]
-        +-------1-------3,4----6|
+        --------c-|
+                --------c-|
+                        --------c-|
+        ---1--2--3--4--5--6-------|
+        [      buffer_when()      ]
+        +-------1,2-----3,4,5---6-|
 
     Examples:
         >>> res = buffer_when(lambda: rx.timer(0.5))
 
     Args:
-        closing_mapper: A function invoked to define
-            the closing of each produced buffer. A buffer is started
-            when the previous one is closed, resulting in
-            non-overlapping buffers.
+        closing_mapper: A function invoked to define the closing of each
+            produced buffer. A buffer is started when the previous one is
+            closed, resulting in non-overlapping buffers. The buffer is closed
+            when one item is emmited or when the observable completes.
 
     Returns:
         A function that takes an observable source and returns an
@@ -172,19 +172,21 @@ def buffer_toggle(openings: Observable,
 
         ---a-----------b--------------|
            ---d--|
-                       --------e|
+                       --------e--|
         ----1--2--3--4--5--6--7--8----|
         [ buffer_toggle()             ]
-        ---------1--------------5,6,7-|
+        ------1----------------5,6,7--|
 
-    >>> res = window(rx.interval(0.5), lambda i: rx.timer(i))
+    >>> res = buffer_toggle(rx.interval(0.5), lambda i: rx.timer(i))
 
     Args:
         openings: Observable sequence whose elements denote the
             creation of buffers.
         closing_mapper: A function invoked to define the closing of each
-            produced window. Value from openings Observable that initiated
-            the associated buffer is provided as argument to the function.
+            produced buffer. Value from openings Observable that initiated
+            the associated buffer is provided as argument to the function. The
+            buffer is closed when one item is emmited or when the observable
+            completes.
 
     Returns:
         A function that takes an observable source and returns an


### PR DESCRIPTION
As proposed in #375, This PR:
- split `buffer` in 3 distinct operators
- simplify `sample`, the first argument can now be an Observable or a time interval
- simplify `catch`, the 1st argument can be now a handler callable or a n Observable

Also, some `buffer` tests have been added too, since they were missing IMO. I've used marbles testing, and I'm pretty happy, it works ! 

Side note: I'm pretty sure now that for `buffer_when` operator, a buffer is closed and a new one is created as soon as one item is emitted by closing obs, or if the closing obs completes (see tests).  So I guess we can expect the same behavior from `window_when`.   