### PR TITLE
Fix references to scheduler classes in docs/reference_scheduler.rst

### DIFF
--- a/docs/reference_scheduler.rst
+++ b/docs/reference_scheduler.rst
@@ -4,12 +4,12 @@ Schedulers
 ===========
 
 .. automodule:: rx.concurrency
-    :members: ImmediateScheduler, CurrentThreadScheduler, VirtualTimeScheduler,
-                TimeoutScheduler, NewThreadScheduler, ThreadPoolScheduler,
-                EventLoopScheduler, HistoricalScheduler, CatchScheduler
+    :members: CatchScheduler, CurrentThreadScheduler, EventLoopScheduler,
+                HistoricalScheduler, ImmediateScheduler, NewThreadScheduler,
+                ThreadPoolScheduler, TimeoutScheduler, VirtualTimeScheduler
 
 .. automodule:: rx.concurrency.mainloopscheduler
-    :members: AsyncIOScheduler, IOLoopScheduler, GEventScheduler,
-                GtkScheduler, TwistedScheduler, TkinterScheduler,
-                PyGameScheduler, QtScheduler, WxScheduler,
-                EventletScheduler
+    :members: AsyncIOScheduler, AsyncIOThreadSafeScheduler, EventletScheduler,
+                GEventScheduler, GtkScheduler, IOLoopScheduler,
+                PyGameScheduler, QtScheduler, TkinterScheduler
+                TwistedScheduler, WxScheduler


### PR DESCRIPTION
Sorry for the barrage of PRs...

I should have added `AsyncIOThreadSafeScheduler` here earlier. Fixed that now, and sorted the classes alphabetically because of OCD.