### PR TITLE
Fix: from_marbles cannot be reused

### DIFF
--- a/rx/core/observable/marbles.py
+++ b/rx/core/observable/marbles.py
@@ -1,4 +1,4 @@
-from typing import List, Dict, Tuple, Optional
+from typing import List, Tuple, Optional, Mapping, Union, Any
 import re
 import threading
 from datetime import datetime, timedelta
@@ -31,8 +31,13 @@ pattern = r'|'.join([
 tokens = re.compile(pattern)
 
 
-def hot(string: str, timespan: RelativeTime = 0.1, duetime: AbsoluteOrRelativeTime = 0.0,
-        lookup: Dict = None, error: Optional[Exception] = None, scheduler: Optional[Scheduler] = None) -> Observable:
+def hot(string: str,
+        timespan: RelativeTime = 0.1,
+        duetime: AbsoluteOrRelativeTime = 0.0,
+        lookup: Optional[Mapping[Union[int, float, str], Any]] = None,
+        error: Optional[Exception] = None,
+        scheduler: Optional[Scheduler] = None
+        ) -> Observable:
 
     _scheduler = scheduler or new_thread_scheduler
 
@@ -93,7 +98,7 @@ def hot(string: str, timespan: RelativeTime = 0.1, duetime: AbsoluteOrRelativeTi
 
 def from_marbles(string: str,
                  timespan: RelativeTime = 0.1,
-                 lookup: Dict = None,
+                 lookup: Optional[Mapping[Union[int, float, str], Any]] = None,
                  error: Optional[Exception] = None,
                  scheduler: Optional[Scheduler] = None
                  ) -> Observable:
@@ -120,8 +125,13 @@ def from_marbles(string: str,
     return Observable(subscribe)
 
 
-def parse(string: str, timespan: RelativeTime = 1.0, time_shift: RelativeTime = 0.0, lookup: Dict = None,
-          error: Optional[Exception] = None, raise_stopped: bool = False) -> List[Tuple[RelativeTime, notification.Notification]]:
+def parse(string: str,
+          timespan: RelativeTime = 1.0,
+          time_shift: RelativeTime = 0.0,
+          lookup: Optional[Mapping[Union[int, float, str], Any]] = None,
+          error: Optional[Exception] = None,
+          raise_stopped: bool = False
+          ) -> List[Tuple[RelativeTime, notification.Notification]]:
     """Convert a marble diagram string to a list of messages.
 
     Each character in the string will advance time by timespan

--- a/tests/test_observable/test_marbles.py
+++ b/tests/test_observable/test_marbles.py
@@ -361,6 +361,39 @@ class TestFromMarble(unittest.TestCase):
                 ]
         assert results == expected
 
+    def test_from_marbles_reuse(self):
+        string = "a--b---c--|"
+        "         012345678901234567890"
+        obs = rx.from_marbles(string)
+        scheduler = TestScheduler()
+        results = scheduler.start(self.create_factory(obs)).messages
+        expected = [
+            ReactiveTest.on_next(200.0, 'a'),
+            ReactiveTest.on_next(200.3, 'b'),
+            ReactiveTest.on_next(200.7, 'c'),
+            ReactiveTest.on_completed(201.0),
+            ]
+        assert results == expected
+
+        scheduler = TestScheduler()
+        results = scheduler.start(self.create_factory(obs)).messages
+        expected = [
+            ReactiveTest.on_next(200.0, 'a'),
+            ReactiveTest.on_next(200.3, 'b'),
+            ReactiveTest.on_next(200.7, 'c'),
+            ReactiveTest.on_completed(201.0),
+            ]
+        assert results == expected
+
+        scheduler = TestScheduler()
+        results = scheduler.start(self.create_factory(obs)).messages
+        expected = [
+            ReactiveTest.on_next(200.0, 'a'),
+            ReactiveTest.on_next(200.3, 'b'),
+            ReactiveTest.on_next(200.7, 'c'),
+            ReactiveTest.on_completed(201.0),
+            ]
+        assert results == expected
 
 class TestHot(unittest.TestCase):
     def create_factory(self, observable):


### PR DESCRIPTION
When playing with testing marbles, I've noticed a subtle bug with `from_marbles`. Basically, once you subscribe to it and wait for completion, the Observable is 'drained' and cannot be used anymore.

This is due to the fact that the disposable is declared at operator scope, not at subscribe scope. I took the opportunity to do some refactoring too.

