### PR TITLE
add type annotations for static operators

### DIFF
--- a/rx/__init__.py
+++ b/rx/__init__.py
@@ -449,8 +449,10 @@ def hot(string, timespan: typing.RelativeTime=0.1, duetime:typing.AbsoluteOrRela
     return _hot(string, timespan, duetime, lookup=lookup, error=error, scheduler=scheduler)
 
 
-def if_then(condition: Callable[[], bool], then_source: Observable,
-            else_source: Observable = None) -> Observable:
+def if_then(condition: Callable[[], bool],
+            then_source: Union[Observable, _Future],
+            else_source: Union[None, Observable, _Future] = None
+            ) -> Observable:
     """Determines whether an observable collection contains values.
 
     Examples:

--- a/rx/__init__.py
+++ b/rx/__init__.py
@@ -157,7 +157,7 @@ def defer(observable_factory: Callable[[abc.Scheduler], Observable]) -> Observab
     return _defer(observable_factory)
 
 
-def empty(scheduler: typing.Scheduler = None) -> Observable:
+def empty(scheduler: Optional[typing.Scheduler] = None) -> Observable:
     """Returns an empty observable sequence.
 
     Example:

--- a/rx/__init__.py
+++ b/rx/__init__.py
@@ -364,7 +364,7 @@ def generate_with_relative_time(initial_state: Any,
     return _generate_with_relative_time(initial_state, condition, iterate, time_mapper)
 
 
-def generate(initial_state, condition, iterate) -> Observable:
+def generate(initial_state: Any, condition: Predicate, iterate: Mapper) -> Observable:
     """Generates an observable sequence by running a state-driven loop
     producing the sequence's elements, using the specified scheduler to
     send out observer messages.

--- a/rx/__init__.py
+++ b/rx/__init__.py
@@ -477,7 +477,7 @@ def if_then(condition: Callable[[], bool],
     return _if_then(condition, then_source, else_source)
 
 
-def interval(period, scheduler: Optional[typing.Scheduler] = None) -> Observable:
+def interval(period: typing.RelativeTime, scheduler: Optional[typing.Scheduler] = None) -> Observable:
     """Returns an observable sequence that produces a value after each
     period.
 

--- a/rx/__init__.py
+++ b/rx/__init__.py
@@ -714,7 +714,7 @@ def timer(duetime: typing.AbsoluteOrRelativeTime, period: Optional[typing.Relati
     return _timer(duetime, period, scheduler)
 
 
-def to_async(func: Callable, scheduler=None) -> Callable:
+def to_async(func: Callable, scheduler: Optional[typing.Scheduler] = None) -> Callable:
     """Converts the function into an asynchronous function. Each
     invocation of the resulting asynchronous function causes an
     invocation of the original synchronous function on the specified

--- a/rx/__init__.py
+++ b/rx/__init__.py
@@ -4,6 +4,7 @@ from asyncio.futures import Future as _Future
 from typing import Iterable, Callable, Any, Optional, Union, Mapping, Hashable
 
 from .core import Observable, typing, pipe
+from .core.typing import Mapper
 
 __version__ = "3.0.0-beta4"
 
@@ -173,7 +174,7 @@ def empty(scheduler: Optional[typing.Scheduler] = None) -> Observable:
     return _empty(scheduler)
 
 
-def for_in(values, mapper) -> Observable:
+def for_in(values: Iterable[Any], mapper: Mapper) -> Observable:
     """Concatenates the observable sequences obtained by running the
     specified result mapper for each element in source.
 

--- a/rx/__init__.py
+++ b/rx/__init__.py
@@ -623,7 +623,7 @@ def repeat_value(value: Any = None, repeat_count: Optional[int] = None) -> Obser
     return _repeat_value(value, repeat_count)
 
 
-def start(func, scheduler=None) -> Observable:
+def start(func: Callable, scheduler: Optional[typing.Scheduler] = None) -> Observable:
     """Invokes the specified function asynchronously on the specified
     scheduler, surfacing the result through an observable sequence.
 

--- a/rx/__init__.py
+++ b/rx/__init__.py
@@ -31,7 +31,6 @@ def case(mapper: Callable[[], Any],
 
     Examples:
         >>> res = rx.case(mapper, { '1': obs1, '2': obs2 })
-        >>> res = rx.case(mapper, [obs1, obs2])
         >>> res = rx.case(mapper, { '1': obs1, '2': obs2 }, obs0)
 
     Args:

--- a/rx/__init__.py
+++ b/rx/__init__.py
@@ -649,7 +649,7 @@ def start(func: Callable, scheduler: Optional[typing.Scheduler] = None) -> Obser
     return _start(func, scheduler)
 
 
-def start_async(function_async) -> Observable:
+def start_async(function_async: Callable[[], _Future]) -> Observable:
     """Invokes the asynchronous function, surfacing the result through
     an observable sequence.
 

--- a/rx/__init__.py
+++ b/rx/__init__.py
@@ -214,7 +214,7 @@ def from_callable(supplier: Callable[[], Any], scheduler: Optional[typing.Schedu
     return _from_callable(supplier, scheduler)
 
 
-def from_callback(func: Callable, mapper: typing.Mapper = None) -> Callable[[], Observable]:
+def from_callback(func: Callable, mapper: Optional[Mapper] = None) -> Callable[[], Observable]:
     """Converts a callback function to an observable sequence.
 
     Args:

--- a/rx/__init__.py
+++ b/rx/__init__.py
@@ -140,7 +140,7 @@ def concat_with_iterable(sources: Iterable[Observable]) -> Observable:
     return _concat_with_iterable(sources)
 
 
-def defer(observable_factory: Callable[[typing.Scheduler], Observable]) -> Observable:
+def defer(observable_factory: Callable[[typing.Scheduler], Union[Observable, _Future]]) -> Observable:
     """Returns an observable sequence that invokes the specified
     factory function whenever a new observer subscribes.
 
@@ -546,7 +546,7 @@ def of(*args: Any) -> Observable:
     return from_iterable(args)
 
 
-def on_error_resume_next(*sources: Observable) -> Observable:
+def on_error_resume_next(*sources: Union[Observable, _Future]) -> Observable:
     """Continues an observable sequence that is terminated normally or
     by an exception with the next observable sequence.
 

--- a/rx/__init__.py
+++ b/rx/__init__.py
@@ -4,7 +4,7 @@ from asyncio.futures import Future as _Future
 from typing import Iterable, Callable, Any, Optional, Union, Mapping, Sequence
 
 from .core import Observable, typing, pipe
-from .core.typing import Mapper
+from .core.typing import Mapper, Predicate
 
 __version__ = "3.0.0-beta4"
 
@@ -337,7 +337,11 @@ def from_marbles(string: str, timespan: typing.RelativeTime = 0.1, scheduler: ty
 cold = from_marbles
 
 
-def generate_with_relative_time(initial_state, condition, iterate, time_mapper) -> Observable:
+def generate_with_relative_time(initial_state: Any,
+                                condition: Predicate,
+                                iterate: Mapper,
+                                time_mapper: Callable[[Any], typing.RelativeTime]
+                                ) -> Observable:
     """Generates an observable sequence by iterating a state from an
     initial state until the condition fails.
 

--- a/rx/__init__.py
+++ b/rx/__init__.py
@@ -24,7 +24,7 @@ def amb(*sources: Observable) -> Observable:
 
 
 def case(mapper: Callable[[], Any],
-         sources: Union[Sequence, Mapping],
+         sources: Mapping,
          default_source: Optional[Union[Observable, _Future]] = None
          ) -> Observable:
     """Uses mapper to determine which source in sources to use.

--- a/rx/__init__.py
+++ b/rx/__init__.py
@@ -272,8 +272,12 @@ from_ = from_iterable
 from_list = from_iterable
 
 
-def from_marbles(string: str, timespan: typing.RelativeTime = 0.1, scheduler: typing.Scheduler = None,
-                 lookup = None, error: Exception = None) -> Observable:
+def from_marbles(string: str,
+                 timespan: typing.RelativeTime = 0.1,
+                 scheduler: Optional[typing.Scheduler] = None,
+                 lookup: Optional[Mapping] = None,
+                 error: Optional[Exception] = None
+                 ) -> Observable:
     """Convert a marble diagram string to a cold observable sequence, using
     an optional scheduler to enumerate the events.
 
@@ -385,8 +389,13 @@ def generate(initial_state: Any, condition: Predicate, iterate: Mapper) -> Obser
     return _generate(initial_state, condition, iterate)
 
 
-def hot(string, timespan: typing.RelativeTime=0.1, duetime:typing.AbsoluteOrRelativeTime = 0.0,
-        scheduler: typing.Scheduler = None, lookup=None, error: Exception = None) -> Observable:
+def hot(string: str,
+        timespan: typing.RelativeTime=0.1,
+        duetime:typing.AbsoluteOrRelativeTime = 0.0,
+        scheduler: Optional[typing.Scheduler] = None,
+        lookup: Optional[Mapping] = None,
+        error: Optional[Exception] = None
+        ) -> Observable:
     """Convert a marble diagram string to a hot observable sequence, using
     an optional scheduler to enumerate the events.
 

--- a/rx/__init__.py
+++ b/rx/__init__.py
@@ -1,7 +1,7 @@
 # pylint: disable=too-many-lines,redefined-outer-name,redefined-builtin
 
 from asyncio.futures import Future as _Future
-from typing import Iterable, Callable, Any, Optional, Union, Mapping, Hashable
+from typing import Iterable, Callable, Any, Optional, Union, Mapping, Sequence
 
 from .core import Observable, typing, pipe
 from .core.typing import Mapper
@@ -23,14 +23,15 @@ def amb(*sources: Observable) -> Observable:
     return _amb(*sources)
 
 
-def case(mapper: Callable[[], Hashable],
-         sources: Mapping[Hashable, Observable],
-         default_source: Optional[Observable] = None
+def case(mapper: Callable[[], Any],
+         sources: Union[Sequence, Mapping],
+         default_source: Optional[Union[Observable, _Future]] = None
          ) -> Observable:
     """Uses mapper to determine which source in sources to use.
 
     Examples:
         >>> res = rx.case(mapper, { '1': obs1, '2': obs2 })
+        >>> res = rx.case(mapper, [obs1, obs2])
         >>> res = rx.case(mapper, { '1': obs1, '2': obs2 }, obs0)
 
     Args:

--- a/rx/__init__.py
+++ b/rx/__init__.py
@@ -3,7 +3,7 @@
 from asyncio.futures import Future as _Future
 from typing import Iterable, Callable, Any, Optional, Union, Mapping, Hashable
 
-from .core import Observable, abc, typing, pipe
+from .core import Observable, typing, pipe
 
 __version__ = "3.0.0-beta4"
 
@@ -138,7 +138,7 @@ def concat_with_iterable(sources: Iterable[Observable]) -> Observable:
     return _concat_with_iterable(sources)
 
 
-def defer(observable_factory: Callable[[abc.Scheduler], Observable]) -> Observable:
+def defer(observable_factory: Callable[[typing.Scheduler], Observable]) -> Observable:
     """Returns an observable sequence that invokes the specified
     factory function whenever a new observer subscribes.
 

--- a/rx/__init__.py
+++ b/rx/__init__.py
@@ -193,7 +193,7 @@ def for_in(values: Iterable[Any], mapper: Mapper) -> Observable:
     return concat_with_iterable(map(mapper, values))
 
 
-def from_callable(supplier: Callable, scheduler: typing.Scheduler = None) -> Observable:
+def from_callable(supplier: Callable[[], Any], scheduler: Optional[typing.Scheduler] = None) -> Observable:
     """Returns an observable sequence that contains a single element
     generate from a supplier, using the specified scheduler to send out
     observer messages.

--- a/rx/__init__.py
+++ b/rx/__init__.py
@@ -1,11 +1,12 @@
 # pylint: disable=too-many-lines,redefined-outer-name,redefined-builtin
 
 from asyncio.futures import Future as _Future
-from typing import Iterable, Callable, Any, Optional, Union
+from typing import Iterable, Callable, Any, Optional, Union, Mapping, Hashable
 
 from .core import Observable, abc, typing, pipe
 
 __version__ = "3.0.0-beta4"
+
 
 def amb(*sources: Observable) -> Observable:
     """Propagates the observable sequence that reacts first.
@@ -21,7 +22,10 @@ def amb(*sources: Observable) -> Observable:
     return _amb(*sources)
 
 
-def case(mapper, sources, default_source=None) -> Observable:
+def case(mapper: Callable[[], Hashable],
+         sources: Mapping[Hashable, Observable],
+         default_source: Optional[Observable] = None
+         ) -> Observable:
     """Uses mapper to determine which source in sources to use.
 
     Examples:

--- a/rx/__init__.py
+++ b/rx/__init__.py
@@ -250,7 +250,7 @@ def from_future(future: _Future) -> Observable:
     return _from_future(future)
 
 
-def from_iterable(iterable: Iterable, scheduler: typing.Scheduler = None) -> Observable:
+def from_iterable(iterable: Iterable, scheduler: Optional[typing.Scheduler] = None) -> Observable:
     """Converts an iterable to an observable sequence.
 
     Example:

--- a/rx/core/observable/case.py
+++ b/rx/core/observable/case.py
@@ -1,4 +1,4 @@
-from typing import Optional, Union, Mapping, Callable, Sequence, Any
+from typing import Optional, Union, Mapping, Callable, Any
 from asyncio import Future
 
 from rx import empty, defer, from_future
@@ -7,7 +7,7 @@ from rx.internal.utils import is_future
 
 
 def _case(mapper: Callable[[], Any],
-          sources: Union[Sequence, Mapping],
+          sources: Mapping,
           default_source: Optional[Union[Observable, Future]] = None
           ) -> Observable:
 

--- a/rx/core/observable/case.py
+++ b/rx/core/observable/case.py
@@ -1,9 +1,15 @@
+from typing import Optional, Mapping, Callable, Hashable
+
 from rx import empty, defer, from_future
 from rx.core import Observable
 from rx.internal.utils import is_future
 
 
-def _case(mapper, sources, default_source=None) -> Observable:
+def _case(mapper: Callable[[], Hashable],
+          sources: Mapping[Hashable, Observable],
+          default_source: Optional[Observable] = None
+          ) -> Observable:
+
     default_source = default_source or empty()
 
     def factory(_) -> Observable:

--- a/rx/core/observable/case.py
+++ b/rx/core/observable/case.py
@@ -1,13 +1,14 @@
-from typing import Optional, Mapping, Callable, Hashable
+from typing import Optional, Union, Mapping, Callable, Sequence, Any
+from asyncio import Future
 
 from rx import empty, defer, from_future
 from rx.core import Observable
 from rx.internal.utils import is_future
 
 
-def _case(mapper: Callable[[], Hashable],
-          sources: Mapping[Hashable, Observable],
-          default_source: Optional[Observable] = None
+def _case(mapper: Callable[[], Any],
+          sources: Union[Sequence, Mapping],
+          default_source: Optional[Union[Observable, Future]] = None
           ) -> Observable:
 
     default_source = default_source or empty()

--- a/rx/core/observable/combinelatest.py
+++ b/rx/core/observable/combinelatest.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable, Iterable, Union, List, cast
+from typing import Optional
 
 from rx.core import Observable, typing
 from rx.disposable import CompositeDisposable, SingleAssignmentDisposable
@@ -19,7 +19,10 @@ def _combine_latest(*sources: Observable) -> Observable:
 
     parent = sources[0]
 
-    def subscribe(observer: typing.Observer, scheduler: typing.Scheduler = None):
+    def subscribe(observer: typing.Observer,
+                  scheduler: Optional[typing.Scheduler] = None
+                  ) -> CompositeDisposable:
+
         n = len(sources)
         has_value = [False] * n
         has_value_all = [False]

--- a/rx/core/observable/defer.py
+++ b/rx/core/observable/defer.py
@@ -1,11 +1,12 @@
 from typing import Callable
 
 from rx import throw, from_future
-from rx.core import Observable, abc
+from rx.core import Observable
+from rx.core.typing import Scheduler
 from rx.internal.utils import is_future
 
 
-def _defer(observable_factory: Callable[[abc.Scheduler], Observable]) -> Observable:
+def _defer(observable_factory: Callable[[Scheduler], Observable]) -> Observable:
     """Returns an observable sequence that invokes the specified factory
     function whenever a new observer subscribes.
 

--- a/rx/core/observable/defer.py
+++ b/rx/core/observable/defer.py
@@ -1,4 +1,5 @@
-from typing import Callable
+from typing import Callable, Union
+from asyncio import Future
 
 from rx import throw, from_future
 from rx.core import Observable
@@ -6,7 +7,7 @@ from rx.core.typing import Scheduler
 from rx.internal.utils import is_future
 
 
-def _defer(observable_factory: Callable[[Scheduler], Observable]) -> Observable:
+def _defer(observable_factory: Callable[[Scheduler], Union[Observable, Future]]) -> Observable:
     """Returns an observable sequence that invokes the specified factory
     function whenever a new observer subscribes.
 

--- a/rx/core/observable/empty.py
+++ b/rx/core/observable/empty.py
@@ -1,12 +1,14 @@
 from typing import Any, Optional
 
-from rx.core import typing
-from rx.core import Observable
+from rx.core import typing, Observable
 from rx.scheduler import immediate_scheduler
 
 
 def _empty(scheduler: Optional[typing.Scheduler] = None) -> Observable:
-    def subscribe(observer: typing.Observer, scheduler_: Optional[typing.Scheduler] = None) -> typing.Disposable:
+    def subscribe(observer: typing.Observer,
+                  scheduler_: Optional[typing.Scheduler] = None
+                  ) -> typing.Disposable:
+
         _scheduler = scheduler or scheduler_ or immediate_scheduler
 
         def action(_: typing.Scheduler, __: Any) -> None:

--- a/rx/core/observable/fromfuture.py
+++ b/rx/core/observable/fromfuture.py
@@ -19,11 +19,14 @@ def _from_future(future: Future) -> Observable:
         and failure.
     """
 
-    def subscribe(observer: typing.Observer, scheduler: Optional[typing.Scheduler] = None) -> typing.Disposable:
+    def subscribe(observer: typing.Observer,
+                  scheduler: Optional[typing.Scheduler] = None
+                  ) -> typing.Disposable:
+
         def done(future):
             try:
                 value = future.result()
-            except Exception as ex:
+            except Exception as ex:  # pylint: disable=broad-except
                 observer.on_error(ex)
             else:
                 observer.on_next(value)

--- a/rx/core/observable/generate.py
+++ b/rx/core/observable/generate.py
@@ -1,9 +1,16 @@
+from typing import Any
+
 from rx.core import Observable
+from rx.core.typing import Mapper, Predicate
 from rx.scheduler import current_thread_scheduler
 from rx.disposable import MultipleAssignmentDisposable
 
 
-def _generate(initial_state, condition, iterate) -> Observable:
+def _generate(initial_state: Any,
+              condition: Predicate,
+              iterate: Mapper
+              ) -> Observable:
+
     def subscribe(observer, scheduler=None):
         scheduler = scheduler or current_thread_scheduler
         first = [True]

--- a/rx/core/observable/generate.py
+++ b/rx/core/observable/generate.py
@@ -13,23 +13,26 @@ def _generate(initial_state: Any,
 
     def subscribe(observer, scheduler=None):
         scheduler = scheduler or current_thread_scheduler
-        first = [True]
-        state = [initial_state]
+        first = True
+        state = initial_state
         mad = MultipleAssignmentDisposable()
 
         def action(scheduler, state1=None):
+            nonlocal first
+            nonlocal state
+
             has_result = False
             result = None
 
             try:
-                if first[0]:
-                    first[0] = False
+                if first:
+                    first = False
                 else:
-                    state[0] = iterate(state[0])
+                    state = iterate(state)
 
-                has_result = condition(state[0])
+                has_result = condition(state)
                 if has_result:
-                    result = state[0]
+                    result = state
 
             except Exception as exception:  # pylint: disable=broad-except
                 observer.on_error(exception)

--- a/rx/core/observable/generatewithrelativetime.py
+++ b/rx/core/observable/generatewithrelativetime.py
@@ -61,7 +61,7 @@ def _generate_with_relative_time(initial_state: Any,
                     result = state
                     time = time_mapper(state)
 
-            except Exception as e:
+            except Exception as e:  # pylint: disable=broad-except
                 observer.on_error(e)
                 return
 

--- a/rx/core/observable/generatewithrelativetime.py
+++ b/rx/core/observable/generatewithrelativetime.py
@@ -1,9 +1,16 @@
+from typing import Any, Callable
+
 from rx.core import Observable
+from rx.core.typing import Predicate, Mapper, RelativeTime
 from rx.scheduler import timeout_scheduler
 from rx.disposable import MultipleAssignmentDisposable
 
 
-def _generate_with_relative_time(initial_state, condition, iterate, time_mapper) -> Observable:
+def _generate_with_relative_time(initial_state: Any,
+                                 condition: Predicate,
+                                 iterate: Mapper,
+                                 time_mapper: Callable[[Any], RelativeTime]
+                                 ) -> Observable:
     """Generates an observable sequence by iterating a state from an
     initial state until the condition fails.
 

--- a/rx/core/observable/generatewithrelativetime.py
+++ b/rx/core/observable/generatewithrelativetime.py
@@ -33,33 +33,40 @@ def _generate_with_relative_time(initial_state: Any,
     def subscribe(observer, scheduler=None):
         scheduler = scheduler or timeout_scheduler
         mad = MultipleAssignmentDisposable()
-        state = [initial_state]
-        has_result = [False]
-        result = [None]
-        first = [True]
-        time = [None]
+        state = initial_state
+        has_result = False
+        result = None
+        first = True
+        time = None
 
         def action(scheduler, _):
-            if has_result[0]:
-                observer.on_next(result[0])
+            nonlocal state
+            nonlocal has_result
+            nonlocal result
+            nonlocal first
+            nonlocal time
+
+            if has_result:
+                observer.on_next(result)
 
             try:
-                if first[0]:
-                    first[0] = False
+                if first:
+                    first = False
                 else:
-                    state[0] = iterate(state[0])
+                    state = iterate(state)
 
-                has_result[0] = condition(state[0])
-                if has_result[0]:
-                    result[0] = state[0]
-                    time[0] = time_mapper(state[0])
+                has_result = condition(state)
+
+                if has_result:
+                    result = state
+                    time = time_mapper(state)
 
             except Exception as e:
                 observer.on_error(e)
                 return
 
-            if has_result[0]:
-                mad.disposable = scheduler.schedule_relative(time[0], action)
+            if has_result:
+                mad.disposable = scheduler.schedule_relative(time, action)
             else:
                 observer.on_completed()
 

--- a/rx/core/observable/ifthen.py
+++ b/rx/core/observable/ifthen.py
@@ -1,13 +1,16 @@
-from typing import Callable, Optional
+from typing import Callable, Union, cast
+from asyncio import Future
 
 import rx
-from rx.core import abc
 from rx.core import Observable
+from rx.core.typing import Scheduler
 from rx.internal.utils import is_future
 
 
-def _if_then(condition: Callable[[], bool], then_source: Observable,
-             else_source: Optional[Observable] = None) -> Observable:
+def _if_then(condition: Callable[[], bool],
+             then_source: Union[Observable, Future],
+             else_source: Union[None, Observable, Future] = None
+             ) -> Observable:
     """Determines whether an observable collection contains values.
 
     Example:
@@ -31,10 +34,10 @@ def _if_then(condition: Callable[[], bool], then_source: Observable,
 
     else_source = else_source or rx.empty()
 
-    then_source = rx.from_future(then_source) if is_future(then_source) else then_source
-    else_source = rx.from_future(else_source) if is_future(else_source) else else_source
+    then_source = rx.from_future(cast(Future, then_source)) if is_future(then_source) else then_source
+    else_source = rx.from_future(cast(Future, else_source)) if is_future(else_source) else else_source
 
-    def factory(_: abc.Scheduler):
+    def factory(_: Scheduler):
         return then_source if condition() else else_source
 
     return rx.defer(factory)

--- a/rx/core/observable/ifthen.py
+++ b/rx/core/observable/ifthen.py
@@ -1,4 +1,4 @@
-from typing import Callable, Union, cast
+from typing import Callable, Union
 from asyncio import Future
 
 import rx
@@ -34,8 +34,8 @@ def _if_then(condition: Callable[[], bool],
 
     else_source = else_source or rx.empty()
 
-    then_source = rx.from_future(cast(Future, then_source)) if is_future(then_source) else then_source
-    else_source = rx.from_future(cast(Future, else_source)) if is_future(else_source) else else_source
+    then_source = rx.from_future(then_source) if is_future(then_source) else then_source
+    else_source = rx.from_future(else_source) if is_future(else_source) else else_source
 
     def factory(_: Scheduler):
         return then_source if condition() else else_source

--- a/rx/core/observable/ifthen.py
+++ b/rx/core/observable/ifthen.py
@@ -1,4 +1,4 @@
-from typing import Callable, Union
+from typing import Callable, Union, cast
 from asyncio import Future
 
 import rx
@@ -34,8 +34,8 @@ def _if_then(condition: Callable[[], bool],
 
     else_source = else_source or rx.empty()
 
-    then_source = rx.from_future(then_source) if is_future(then_source) else then_source
-    else_source = rx.from_future(else_source) if is_future(else_source) else else_source
+    then_source = rx.from_future(cast(Future, then_source)) if is_future(then_source) else then_source
+    else_source = rx.from_future(cast(Future, else_source)) if is_future(else_source) else else_source
 
     def factory(_: Scheduler):
         return then_source if condition() else else_source

--- a/rx/core/observable/interval.py
+++ b/rx/core/observable/interval.py
@@ -4,5 +4,8 @@ from rx import timer
 from rx.core import Observable, typing
 
 
-def _interval(period, scheduler: Optional[typing.Scheduler] = None) -> Observable:
+def _interval(period: typing.RelativeTime,
+              scheduler: Optional[typing.Scheduler] = None
+              ) -> Observable:
+
     return timer(period, period, scheduler)

--- a/rx/core/observable/marbles.py
+++ b/rx/core/observable/marbles.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple, Optional, Mapping, Union, Any
+from typing import List, Tuple, Optional, Mapping
 import re
 import threading
 from datetime import datetime, timedelta
@@ -34,7 +34,7 @@ tokens = re.compile(pattern)
 def hot(string: str,
         timespan: RelativeTime = 0.1,
         duetime: AbsoluteOrRelativeTime = 0.0,
-        lookup: Optional[Mapping[Union[int, float, str], Any]] = None,
+        lookup: Optional[Mapping] = None,
         error: Optional[Exception] = None,
         scheduler: Optional[Scheduler] = None
         ) -> Observable:
@@ -98,7 +98,7 @@ def hot(string: str,
 
 def from_marbles(string: str,
                  timespan: RelativeTime = 0.1,
-                 lookup: Optional[Mapping[Union[int, float, str], Any]] = None,
+                 lookup: Optional[Mapping] = None,
                  error: Optional[Exception] = None,
                  scheduler: Optional[Scheduler] = None
                  ) -> Observable:
@@ -128,7 +128,7 @@ def from_marbles(string: str,
 def parse(string: str,
           timespan: RelativeTime = 1.0,
           time_shift: RelativeTime = 0.0,
-          lookup: Optional[Mapping[Union[int, float, str], Any]] = None,
+          lookup: Optional[Mapping] = None,
           error: Optional[Exception] = None,
           raise_stopped: bool = False
           ) -> List[Tuple[RelativeTime, notification.Notification]]:

--- a/rx/core/observable/onerrorresumenext.py
+++ b/rx/core/observable/onerrorresumenext.py
@@ -1,3 +1,6 @@
+from typing import Union
+from asyncio import Future
+
 import rx
 from rx.scheduler import current_thread_scheduler
 from rx.core import Observable
@@ -5,7 +8,7 @@ from rx.disposable import CompositeDisposable, SingleAssignmentDisposable, Seria
 from rx.internal.utils import is_future
 
 
-def _on_error_resume_next(*sources: Observable) -> Observable:
+def _on_error_resume_next(*sources: Union[Observable, Future]) -> Observable:
     """Continues an observable sequence that is terminated normally or
     by an exception with the next observable sequence.
 

--- a/rx/core/observable/returnvalue.py
+++ b/rx/core/observable/returnvalue.py
@@ -34,7 +34,7 @@ def _return_value(value: Any, scheduler: Optional[typing.Scheduler] = None) -> O
     return Observable(subscribe)
 
 
-def _from_callable(supplier: Callable, scheduler: Optional[typing.Scheduler] = None) -> Observable:
+def _from_callable(supplier: Callable[[], Any], scheduler: Optional[typing.Scheduler] = None) -> Observable:
     def subscribe(observer: typing.Observer, scheduler_: typing.Scheduler = None):
         _scheduler = scheduler or scheduler_ or current_thread_scheduler
 

--- a/rx/core/observable/start.py
+++ b/rx/core/observable/start.py
@@ -1,8 +1,10 @@
+from typing import Optional, Callable
+
 from rx import to_async
 from rx.core import Observable
+from rx.core.typing import Scheduler
 
-
-def _start(func, scheduler=None) -> Observable:
+def _start(func: Callable, scheduler: Optional[Scheduler] = None) -> Observable:
     """Invokes the specified function asynchronously on the specified
     scheduler, surfacing the result through an observable sequence.
 

--- a/rx/core/observable/startasync.py
+++ b/rx/core/observable/startasync.py
@@ -1,8 +1,11 @@
+from typing import Callable
+from asyncio import Future
+
 from rx import throw, from_future
 from rx.core import Observable
 
 
-def _start_async(function_async) -> Observable:
+def _start_async(function_async: Callable[[], Future]) -> Observable:
     try:
         future = function_async()
     except Exception as ex:  # pylint: disable=broad-except

--- a/rx/core/observable/toasync.py
+++ b/rx/core/observable/toasync.py
@@ -1,12 +1,15 @@
-from typing import Callable
+from typing import Callable, Optional
 
 from rx import operators as ops
 from rx.core import Observable
+from rx.core.typing import Scheduler
 from rx.scheduler import timeout_scheduler
 from rx.subjects import AsyncSubject
 
 
-def _to_async(func: Callable, scheduler=None) -> Callable:
+def _to_async(func: Callable,
+              scheduler: Optional[Scheduler] = None
+              ) -> Callable:
     """Converts the function into an asynchronous function. Each
     invocation of the resulting asynchronous function causes an
     invocation of the original synchronous function on the specified
@@ -34,7 +37,7 @@ def _to_async(func: Callable, scheduler=None) -> Callable:
         def action(scheduler, state):
             try:
                 result = func(*args)
-            except Exception as ex:
+            except Exception as ex:  # pylint: disable=broad-except
                 subject.on_error(ex)
                 return
 

--- a/rx/core/observable/toasync.py
+++ b/rx/core/observable/toasync.py
@@ -29,7 +29,7 @@ def _to_async(func: Callable,
         Aynchronous function.
     """
 
-    scheduler = scheduler or timeout_scheduler
+    _scheduler = scheduler or timeout_scheduler
 
     def wrapper(*args) -> Observable:
         subject = AsyncSubject()
@@ -44,6 +44,6 @@ def _to_async(func: Callable,
             subject.on_next(result)
             subject.on_completed()
 
-        scheduler.schedule(action)
+        _scheduler.schedule(action)
         return subject.pipe(ops.as_observable())
     return wrapper

--- a/rx/core/observable/using.py
+++ b/rx/core/observable/using.py
@@ -7,7 +7,8 @@ from rx.disposable import CompositeDisposable, Disposable
 
 
 def _using(resource_factory: Callable[[], typing.Disposable],
-           observable_factory: Callable[[typing.Disposable], Observable]) -> Observable:
+           observable_factory: Callable[[typing.Disposable], Observable]
+           ) -> Observable:
     """Constructs an observable sequence that depends on a resource
     object, whose lifetime is tied to the resulting observable
     sequence's lifetime.
@@ -34,7 +35,7 @@ def _using(resource_factory: Callable[[], typing.Disposable],
                 disp = resource
 
             source = observable_factory(resource)
-        except Exception as exception:
+        except Exception as exception:  # pylint: disable=broad-except
             d = rx.throw(exception).subscribe(observer, scheduler=scheduler)
             return CompositeDisposable(d, disp)
 

--- a/rx/core/observable/zip.py
+++ b/rx/core/observable/zip.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Optional, List
 
 from rx import from_future
 from rx.core import Observable, typing
@@ -28,7 +28,7 @@ def _zip(*args: Observable) -> Observable:
 
     def subscribe(observer: typing.Observer, scheduler: Optional[typing.Scheduler] = None):
         n = len(sources)
-        queues = [[] for _ in range(n)]
+        queues : List[List] = [[] for _ in range(n)]
         is_done = [False] * n
 
         def next(i):

--- a/rx/core/observable/zip.py
+++ b/rx/core/observable/zip.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from rx import from_future
 from rx.core import Observable, typing
 from rx.disposable import CompositeDisposable, SingleAssignmentDisposable
@@ -24,7 +26,7 @@ def _zip(*args: Observable) -> Observable:
 
     sources = list(args)
 
-    def subscribe(observer: typing.Observer, scheduler: typing.Scheduler = None):
+    def subscribe(observer: typing.Observer, scheduler: Optional[typing.Scheduler] = None):
         n = len(sources)
         queues = [[] for _ in range(n)]
         is_done = [False] * n


### PR DESCRIPTION
Following operator type annotations #382, it's time to update static operators!

Some details:

Type hint has been relaxed for the `lookup` parameter in  `from_marbles` operator. After a few tests, `Mapping[Union[str, float, int], Any]` seems to not working well or constrains the keys to be of the same type (tested with mypy & pyre). It applies to `case` operator too. 

In the contrary, mixed types seems to work with positional arguments, i.e. `foo(*args: Union[Observable, Future])` will accepts observables mixed with futures. At least, mypy is ok with it. See `on_error_resume_next`.

Some typing.cast directive are added to silence mypy.