### PR TITLE
Inject optional dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,28 +2,45 @@ matrix:
   include:
 
     - name: "Python 3.6 on Linux"
-      python: "3.6"
       os: linux
       dist: xenial
       language: python
+      python: 3.6
+      service:
+        - xvfb
+      script:
+        - xvfb-run -a python3 setup.py test
+
 
     - name: "Python 3.7 on Linux"
-      python: "3.7"
       os: linux
       dist: xenial
       language: python
+      python: 3.7
+      service:
+        - xvfb
+      script:
+        - xvfb-run -a python3 setup.py test
+
 
     - name: "Python 3.8-dev on Linux"
-      python: "3.8-dev"
       os: linux
       dist: xenial
       language: python
+      python: 3.8-dev
+      service:
+        - xvfb
+      script:
+        - xvfb-run -a python3 setup.py test
+
 
     - name: "Python 3.7 on Linux, with optional dependencies and benchmark"
-      python: "3.7"
       os: linux
       dist: xenial
       language: python
+      python: 3.7
+      service:
+        - xvfb
       install:
         # Native libraries for pycairo / pygobject
         - sudo apt-get install -y libgirepository1.0-dev gir1.2-gtk-3.0
@@ -34,14 +51,14 @@ matrix:
         # Coverage will be reported for the Python 3.7 Linux build
         - pip3 install coveralls
       script:
-        - coverage run --source=rx setup.py test && coveralls
+        - xvfb-run -a coverage run --source=rx setup.py test && coveralls
 
 # Disable MacOS build temporarily, it's failing often on timing assertions
 #    - name: "Python 3.7 on MacOS, with optional dependencies and benchmark"
-#      python: "3.7"
 #      os: osx
 #      osx_image: xcode10.2
 #      language: sh
+#      python: 3.7
 #      install:
 #        # Native libraries for pycairo / pygobject
 #        - brew install pygobject3 gtk+3
@@ -49,9 +66,9 @@ matrix:
 #        - pip3 install eventlet gevent pycairo pygobject pygame pyqt5 pyside2 tornado twisted wxpython
 
     - name: "Python 3.7 on Windows, with optional dependencies and benchmark"
-      python: "3.7"
       os: windows
       language: sh
+      python: 3.7
       install:
         # Get Python 3.7 from choco
         - choco install python3

--- a/examples/asyncio/toasyncgenerator.py
+++ b/examples/asyncio/toasyncgenerator.py
@@ -51,8 +51,8 @@ def to_async_generator(sentinel=None):
 
 
 @asyncio.coroutine
-def go():
-    scheduler = AsyncIOScheduler()
+def go(loop):
+    scheduler = AsyncIOScheduler(loop)
 
     xs = rx.from_([x for x in range(10)], scheduler=scheduler)
     gen = xs.pipe(to_async_generator())
@@ -68,7 +68,8 @@ def go():
 
 def main():
     loop = asyncio.get_event_loop()
-    loop.run_until_complete(go())
+    loop.run_until_complete(go(loop))
+
 
 if __name__ == '__main__':
     main()

--- a/examples/asyncio/toasynciterator.py
+++ b/examples/asyncio/toasynciterator.py
@@ -48,8 +48,8 @@ def to_async_iterable():
     return _to_async_iterable
 
 
-async def go():
-    scheduler = AsyncIOScheduler()
+async def go(loop):
+    scheduler = AsyncIOScheduler(loop)
 
     ai = rx.range(0, 10, scheduler=scheduler).pipe(to_async_iterable())
     async for x in ai:
@@ -58,7 +58,7 @@ async def go():
 
 def main():
     loop = asyncio.get_event_loop()
-    loop.run_until_complete(go())
+    loop.run_until_complete(go(loop))
 
 
 if __name__ == '__main__':

--- a/examples/autocomplete/autocomplete.py
+++ b/examples/autocomplete/autocomplete.py
@@ -19,7 +19,7 @@ from rx import operators as ops
 from rx.subjects import Subject
 from rx.scheduler.eventloop import IOLoopScheduler
 
-scheduler = IOLoopScheduler()
+scheduler = IOLoopScheduler(ioloop.IOLoop.current())
 
 
 def search_wikipedia(term):

--- a/examples/autocomplete/autocomplete_asyncio.py
+++ b/examples/autocomplete/autocomplete_asyncio.py
@@ -42,7 +42,7 @@ def search_wikipedia(term):
 
 class WSHandler(WebSocketHandler):
     def open(self):
-        scheduler = AsyncIOScheduler()
+        scheduler = AsyncIOScheduler(asyncio.get_event_loop())
 
         print("WebSocket opened")
 

--- a/examples/autocomplete/bottle_autocomplete.py
+++ b/examples/autocomplete/bottle_autocomplete.py
@@ -29,7 +29,7 @@ class WikiFinder:
 
 
 app, PORT = Bottle(), 8081
-scheduler = GEventScheduler()
+scheduler = GEventScheduler(gevent)
 
 
 @app.route('/ws')

--- a/examples/chess/chess.py
+++ b/examples/chess/chess.py
@@ -24,7 +24,7 @@ def main():
     background.fill(black)             # fill the background black
     background = background.convert()  # prepare for faster blitting
 
-    scheduler = PyGameScheduler()
+    scheduler = PyGameScheduler(pygame)
 
     mousemove = Subject()
 

--- a/examples/timeflies/timeflies_gtk.py
+++ b/examples/timeflies/timeflies_gtk.py
@@ -5,7 +5,7 @@ from rx.scheduler.mainloop import GtkScheduler
 
 import gi
 gi.require_version('Gtk', '3.0')
-from gi.repository import Gtk, Gdk
+from gi.repository import GLib, Gtk, Gdk
 
 
 class Window(Gtk.Window):
@@ -24,7 +24,7 @@ class Window(Gtk.Window):
 
 
 def main():
-    scheduler = GtkScheduler()
+    scheduler = GtkScheduler(GLib)
     scrolled_window = Gtk.ScrolledWindow()
 
     window = Window()

--- a/examples/timeflies/timeflies_qt.py
+++ b/examples/timeflies/timeflies_qt.py
@@ -6,14 +6,14 @@ from rx.subjects import Subject
 from rx.scheduler.mainloop import QtScheduler
 
 try:
-    from PyQt5 import QtCore
-    from PyQt5.QtWidgets import QApplication, QWidget, QLabel
+    from PySide2 import QtCore
+    from PySide2.QtWidgets import QApplication, QLabel, QWidget
 except ImportError:
     try:
-        from PySide2 import QtCore
-        from PySide2.QtWidgets import QApplication, QLabel, QWidget
+        from PyQt5 import QtCore
+        from PyQt5.QtWidgets import QApplication, QWidget, QLabel
     except ImportError:
-        raise ImportError('Please ensure either PyQT5 or PySide2 is available!')
+        raise ImportError('Please ensure either PySide2 or PyQt5 is available!')
 
 
 class Window(QWidget):

--- a/rx/scheduler/eventloop/asyncioscheduler.py
+++ b/rx/scheduler/eventloop/asyncioscheduler.py
@@ -18,9 +18,15 @@ class AsyncIOScheduler(PeriodicScheduler):
     does not use the asyncio threadsafe methods, if you need those please use
     the AsyncIOThreadSafeScheduler class."""
 
-    def __init__(self, loop: Optional[asyncio.AbstractEventLoop] = None) -> None:
+    def __init__(self, loop: asyncio.AbstractEventLoop) -> None:
+        """Create a new AsyncIOScheduler.
+
+        Args:
+            loop: Instance of asyncio event loop to use; typically, you would
+                get this by asyncio.get_event_loop()
+        """
         super().__init__()
-        self._loop: asyncio.AbstractEventLoop = loop or asyncio.get_event_loop()
+        self._loop: asyncio.AbstractEventLoop = loop
 
     def schedule(self,
                  action: typing.ScheduledAction,

--- a/rx/scheduler/eventloop/asynciothreadsafescheduler.py
+++ b/rx/scheduler/eventloop/asynciothreadsafescheduler.py
@@ -18,8 +18,15 @@ class AsyncIOThreadSafeScheduler(AsyncIOScheduler):
     subclass of AsyncIOScheduler which uses the threadsafe asyncio methods.
     """
 
-    def __init__(self, loop: Optional[asyncio.AbstractEventLoop] = None) -> None:
-        super().__init__(loop=loop)
+    def __init__(self, loop: asyncio.AbstractEventLoop) -> None:
+        """Create a new AsyncIOThreadSafeScheduler.
+
+        Args:
+            loop: Instance of asyncio event loop to use; typically, you would
+                get this by asyncio.get_event_loop()
+        """
+
+        super().__init__(loop)
 
     def schedule(self,
                  action: typing.ScheduledAction,

--- a/rx/scheduler/eventloop/twistedscheduler.py
+++ b/rx/scheduler/eventloop/twistedscheduler.py
@@ -1,7 +1,7 @@
 import logging
 
 from datetime import datetime
-from typing import Optional
+from typing import Any, Optional
 
 from rx.core import typing
 from rx.disposable import CompositeDisposable, Disposable, SingleAssignmentDisposable
@@ -15,9 +15,16 @@ log = logging.getLogger("Rx")
 class TwistedScheduler(PeriodicScheduler):
     """A scheduler that schedules work via the Twisted reactor mainloop."""
 
-    def __init__(self, reactor) -> None:
+    def __init__(self, reactor: Any) -> None:
+        """Create a new TwistedScheduler.
+
+        Args:
+            reactor: The reactor to use; typically, you would get this
+                by from twisted.internet import reactor
+        """
+
         super().__init__()
-        self.reactor = reactor
+        self._reactor = reactor
 
     def schedule(self,
                  action: typing.ScheduledAction,
@@ -63,7 +70,7 @@ class TwistedScheduler(PeriodicScheduler):
             sad.disposable = action(self, state)
 
         log.debug("timeout: %s", seconds)
-        timer = deferLater(self.reactor, seconds, interval).addErrback(lambda _: None)
+        timer = deferLater(self._reactor, seconds, interval).addErrback(lambda _: None)
 
         def dispose() -> None:
             if not timer.called:
@@ -101,4 +108,4 @@ class TwistedScheduler(PeriodicScheduler):
              The scheduler's current time, as a datetime instance.
         """
 
-        return self.to_datetime(float(self.reactor.seconds()))
+        return self.to_datetime(float(self._reactor.seconds()))

--- a/rx/scheduler/mainloop/pygamescheduler.py
+++ b/rx/scheduler/mainloop/pygamescheduler.py
@@ -1,7 +1,7 @@
 import logging
 import threading
 
-from typing import Optional
+from typing import Any, Optional
 
 from rx.core import typing
 from rx.internal import PriorityQueue
@@ -11,7 +11,6 @@ from ..scheduleditem import ScheduledItem
 from ..periodicscheduler import PeriodicScheduler
 
 
-pygame = None
 log = logging.getLogger("Rx")
 
 
@@ -23,11 +22,16 @@ class PyGameScheduler(PeriodicScheduler):
     http://www.pygame.org/docs/ref/time.html
     http://www.pygame.org/docs/ref/event.html"""
 
-    def __init__(self):
-        super().__init__()
-        global pygame
-        import pygame
+    def __init__(self, pygame: Any):
+        """Create a new PyGameScheduler.
 
+        Args:
+            pygame: The PyGame module to use; typically, you would get this by
+                import pygame
+        """
+
+        super().__init__()
+        self._pygame = pygame  # TODO not used, refactor to actually use pygame?
         self._lock = threading.Lock()
         self._queue: PriorityQueue[ScheduledItem[typing.TState]] = PriorityQueue()
 

--- a/rx/scheduler/mainloop/tkinterscheduler.py
+++ b/rx/scheduler/mainloop/tkinterscheduler.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Any, Optional
 
 from rx.core import typing
 from rx.disposable import CompositeDisposable, Disposable, SingleAssignmentDisposable
@@ -12,9 +12,16 @@ class TkinterScheduler(PeriodicScheduler):
     http://infohost.nmt.edu/tcc/help/pubs/tkinter/web/universal.html
     http://effbot.org/tkinterbook/widget.htm"""
 
-    def __init__(self, master) -> None:
+    def __init__(self, root: Any) -> None:
+        """Create a new TkinterScheduler.
+
+        Args:
+            root: The Tk instance to use; typically, you would get this by
+                import tkinter; tkinter.Tk()
+        """
+
         super().__init__()
-        self.master = master
+        self._root = root
 
     def schedule(self,
                  action: typing.ScheduledAction,
@@ -56,10 +63,10 @@ class TkinterScheduler(PeriodicScheduler):
             sad.disposable = self.invoke_action(action, state=state)
 
         msecs = max(0, int(self.to_seconds(duetime) * 1000.0))
-        timer = self.master.after(msecs, invoke_action)
+        timer = self._root.after(msecs, invoke_action)
 
         def dispose() -> None:
-            self.master.after_cancel(timer)
+            self._root.after_cancel(timer)
 
         return CompositeDisposable(sad, Disposable(dispose))
 

--- a/rx/scheduler/mainloop/wxscheduler.py
+++ b/rx/scheduler/mainloop/wxscheduler.py
@@ -1,5 +1,6 @@
 import logging
-from typing import Optional
+
+from typing import Any, Optional
 
 from rx.core import typing
 from rx.disposable import CompositeDisposable, Disposable, SingleAssignmentDisposable
@@ -13,12 +14,19 @@ log = logging.getLogger("Rx")
 class WxScheduler(PeriodicScheduler):
     """A scheduler for a wxPython event loop."""
 
-    def __init__(self, wx) -> None:
+    def __init__(self, wx: Any) -> None:
+        """Create a new WxScheduler.
+
+        Args:
+            wx: The wx module to use; typically, you would get this by
+                import wx
+        """
+
         super().__init__()
-        self.wx = wx
+        self._wx = wx
         self._timers = set()
 
-        class Timer(wx.Timer):
+        class Timer(self._wx.Timer):
 
             def __init__(self, callback) -> None:
                 super().__init__()
@@ -62,7 +70,7 @@ class WxScheduler(PeriodicScheduler):
         timer = self._timer_class(interval)
         timer.Start(
             msecs,
-            self.wx.TIMER_CONTINUOUS if periodic else self.wx.TIMER_ONE_SHOT
+            self._wx.TIMER_CONTINUOUS if periodic else self._wx.TIMER_ONE_SHOT
         )
         self._timers.add(timer)
 

--- a/tests/test_scheduler/test_eventloop/test_eventletscheduler.py
+++ b/tests/test_scheduler/test_eventloop/test_eventletscheduler.py
@@ -8,27 +8,25 @@ from rx.scheduler.eventloop import EventletScheduler
 
 
 eventlet = pytest.importorskip("eventlet")
-if eventlet:
-    import eventlet.hubs
 
 
 class TestEventletScheduler(unittest.TestCase):
 
     def test_eventlet_schedule_now(self):
-        scheduler = EventletScheduler()
+        scheduler = EventletScheduler(eventlet)
         hub = eventlet.hubs.get_hub()
         diff = scheduler.now - datetime.utcfromtimestamp(hub.clock())
         assert abs(diff) < timedelta(milliseconds=1)
 
     def test_eventlet_schedule_now_units(self):
-        scheduler = EventletScheduler()
+        scheduler = EventletScheduler(eventlet)
         diff = scheduler.now
         sleep(0.1)
         diff = scheduler.now - diff
         assert timedelta(milliseconds=80) < diff < timedelta(milliseconds=180)
 
     def test_eventlet_schedule_action(self):
-        scheduler = EventletScheduler()
+        scheduler = EventletScheduler(eventlet)
         ran = False
 
         def action(scheduler, state):
@@ -41,7 +39,7 @@ class TestEventletScheduler(unittest.TestCase):
         assert ran is True
 
     def test_eventlet_schedule_action_due(self):
-        scheduler = EventletScheduler()
+        scheduler = EventletScheduler(eventlet)
         starttime = datetime.now()
         endtime = None
 
@@ -57,7 +55,7 @@ class TestEventletScheduler(unittest.TestCase):
         assert diff > timedelta(seconds=0.18)
 
     def test_eventlet_schedule_action_cancel(self):
-        scheduler = EventletScheduler()
+        scheduler = EventletScheduler(eventlet)
         ran = False
 
         def action(scheduler, state):
@@ -71,7 +69,7 @@ class TestEventletScheduler(unittest.TestCase):
         assert ran is False
 
     def test_eventlet_schedule_action_periodic(self):
-        scheduler = EventletScheduler()
+        scheduler = EventletScheduler(eventlet)
         period = 0.05
         counter = 3
 

--- a/tests/test_scheduler/test_eventloop/test_geventscheduler.py
+++ b/tests/test_scheduler/test_eventloop/test_geventscheduler.py
@@ -12,20 +12,20 @@ gevent = pytest.importorskip("gevent")
 class TestGEventScheduler(unittest.TestCase):
 
     def test_gevent_schedule_now(self):
-        scheduler = GEventScheduler()
+        scheduler = GEventScheduler(gevent)
         hub = gevent.get_hub()
         diff = scheduler.now - datetime.utcfromtimestamp(hub.loop.now())
         assert abs(diff) < timedelta(milliseconds=1)
 
     def test_gevent_schedule_now_units(self):
-        scheduler = GEventScheduler()
+        scheduler = GEventScheduler(gevent)
         diff = scheduler.now
         gevent.sleep(0.1)
         diff = scheduler.now - diff
         assert timedelta(milliseconds=80) < diff < timedelta(milliseconds=180)
 
     def test_gevent_schedule_action(self):
-        scheduler = GEventScheduler()
+        scheduler = GEventScheduler(gevent)
         ran = False
 
         def action(scheduler, state):
@@ -38,7 +38,7 @@ class TestGEventScheduler(unittest.TestCase):
         assert ran is True
 
     def test_gevent_schedule_action_due(self):
-        scheduler = GEventScheduler()
+        scheduler = GEventScheduler(gevent)
         starttime = datetime.now()
         endtime = None
 
@@ -54,7 +54,7 @@ class TestGEventScheduler(unittest.TestCase):
         assert diff > timedelta(seconds=0.18)
 
     def test_gevent_schedule_action_cancel(self):
-        scheduler = GEventScheduler()
+        scheduler = GEventScheduler(gevent)
         ran = False
 
         def action(scheduler, state):

--- a/tests/test_scheduler/test_mainloop/test_gtkscheduler.py
+++ b/tests/test_scheduler/test_mainloop/test_gtkscheduler.py
@@ -26,19 +26,19 @@ if 'GNOME_DESKTOP_SESSION_ID' in os.environ:
 class TestGtkScheduler(unittest.TestCase):
 
     def test_gtk_schedule_now(self):
-        scheduler = GtkScheduler()
+        scheduler = GtkScheduler(GLib)
         diff = scheduler.now - default_now()
         assert abs(diff) < timedelta(milliseconds=1)
 
     def test_gtk_schedule_now_units(self):
-        scheduler = GtkScheduler()
+        scheduler = GtkScheduler(GLib)
         diff = scheduler.now
         sleep(0.1)
         diff = scheduler.now - diff
         assert timedelta(milliseconds=80) < diff < timedelta(milliseconds=180)
 
     def test_gtk_schedule_action(self):
-        scheduler = GtkScheduler()
+        scheduler = GtkScheduler(GLib)
         gate = threading.Semaphore(0)
         ran = False
 
@@ -60,7 +60,7 @@ class TestGtkScheduler(unittest.TestCase):
         assert ran is True
 
     def test_gtk_schedule_action_relative(self):
-        scheduler = GtkScheduler()
+        scheduler = GtkScheduler(GLib)
         gate = threading.Semaphore(0)
         starttime = default_now()
         endtime = None
@@ -85,7 +85,7 @@ class TestGtkScheduler(unittest.TestCase):
         assert diff > timedelta(milliseconds=80)
 
     def test_gtk_schedule_action_absolute(self):
-        scheduler = GtkScheduler()
+        scheduler = GtkScheduler(GLib)
         gate = threading.Semaphore(0)
         starttime = default_now()
         endtime = None
@@ -112,7 +112,7 @@ class TestGtkScheduler(unittest.TestCase):
 
     def test_gtk_schedule_action_cancel(self):
         ran = False
-        scheduler = GtkScheduler()
+        scheduler = GtkScheduler(GLib)
         gate = threading.Semaphore(0)
 
         def action(scheduler, state):
@@ -134,7 +134,7 @@ class TestGtkScheduler(unittest.TestCase):
         assert ran is False
 
     def test_gtk_schedule_action_periodic(self):
-        scheduler = GtkScheduler()
+        scheduler = GtkScheduler(GLib)
         gate = threading.Semaphore(0)
         period = 0.05
         counter = 3

--- a/tests/test_scheduler/test_mainloop/test_pygamescheduler.py
+++ b/tests/test_scheduler/test_mainloop/test_pygamescheduler.py
@@ -14,19 +14,19 @@ pygame = pytest.importorskip("pygame")
 class TestPyGameScheduler(unittest.TestCase):
 
     def test_pygame_schedule_now(self):
-        scheduler = PyGameScheduler()
+        scheduler = PyGameScheduler(pygame)
         diff = scheduler.now - default_now()
         assert abs(diff) < timedelta(milliseconds=1)
 
     def test_pygame_schedule_now_units(self):
-        scheduler = PyGameScheduler()
+        scheduler = PyGameScheduler(pygame)
         diff = scheduler.now
         sleep(0.1)
         diff = scheduler.now - diff
         assert timedelta(milliseconds=80) < diff < timedelta(milliseconds=180)
 
     def test_pygame_schedule_action(self):
-        scheduler = PyGameScheduler()
+        scheduler = PyGameScheduler(pygame)
         ran = False
 
         def action(scheduler, state):
@@ -39,7 +39,7 @@ class TestPyGameScheduler(unittest.TestCase):
         assert ran is True
 
     def test_pygame_schedule_action_due_relative(self):
-        scheduler = PyGameScheduler()
+        scheduler = PyGameScheduler(pygame)
         starttime = default_now()
         endtime = None
 
@@ -61,7 +61,7 @@ class TestPyGameScheduler(unittest.TestCase):
         assert diff > timedelta(milliseconds=180)
 
     def test_pygame_schedule_action_due_absolute(self):
-        scheduler = PyGameScheduler()
+        scheduler = PyGameScheduler(pygame)
         starttime = default_now()
         endtime = None
 
@@ -83,7 +83,7 @@ class TestPyGameScheduler(unittest.TestCase):
         assert diff > timedelta(milliseconds=180)
 
     def test_pygame_schedule_action_cancel(self):
-        scheduler = PyGameScheduler()
+        scheduler = PyGameScheduler(pygame)
         ran = False
 
         def action(scheduler, state):

--- a/tests/test_scheduler/test_mainloop/test_tkinterscheduler.py
+++ b/tests/test_scheduler/test_mainloop/test_tkinterscheduler.py
@@ -11,7 +11,8 @@ from rx.internal.basic import default_now
 tkinter = pytest.importorskip("tkinter")
 
 try:
-    root = tkinter.Tcl()
+    root = tkinter.Tk()
+    root.withdraw() # Don't actually draw anything
     display = True
 except Exception:
     display = False

--- a/tests/test_scheduler/test_mainloop/test_wxscheduler.py
+++ b/tests/test_scheduler/test_mainloop/test_wxscheduler.py
@@ -9,6 +9,12 @@ from rx.internal.basic import default_now
 wx = pytest.importorskip('wx')
 
 
+def make_app():
+    app = wx.App()
+    wx.Frame(None)  # We need this for some reason, or the loop won't run
+    return app
+
+
 class AppExit(wx.Timer):
 
     def __init__(self, app) -> None:
@@ -34,7 +40,7 @@ class TestWxScheduler(unittest.TestCase):
         assert timedelta(milliseconds=80) < diff < timedelta(milliseconds=180)
 
     def test_wx_schedule_action(self):
-        app = wx.AppConsole()
+        app = make_app()
         exit = AppExit(app)
         scheduler = WxScheduler(wx)
         ran = False
@@ -51,7 +57,7 @@ class TestWxScheduler(unittest.TestCase):
         assert ran is True
 
     def test_wx_schedule_action_relative(self):
-        app = wx.AppConsole()
+        app = make_app()
         exit = AppExit(app)
         scheduler = WxScheduler(wx)
         starttime = default_now()
@@ -71,7 +77,7 @@ class TestWxScheduler(unittest.TestCase):
         assert timedelta(milliseconds=80) < diff < timedelta(milliseconds=180)
 
     def test_wx_schedule_action_absolute(self):
-        app = wx.AppConsole()
+        app = make_app()
         exit = AppExit(app)
         scheduler = WxScheduler(wx)
         starttime = default_now()
@@ -92,7 +98,7 @@ class TestWxScheduler(unittest.TestCase):
         assert timedelta(milliseconds=80) < diff < timedelta(milliseconds=180)
 
     def test_wx_schedule_action_cancel(self):
-        app = wx.AppConsole()
+        app = make_app()
         exit = AppExit(app)
         scheduler = WxScheduler(wx)
         ran = False
@@ -110,7 +116,7 @@ class TestWxScheduler(unittest.TestCase):
         assert ran is False
 
     def test_wx_schedule_action_periodic(self):
-        app = wx.AppConsole()
+        app = make_app()
         exit = AppExit(app)
         scheduler = WxScheduler(wx)
         period = 0.05


### PR DESCRIPTION
For consistency among the mainloop/eventloop schedulers, as well as slightly more control over lifetime of references which might clash with one another during tests, I would like to propose adopting a policy of simply requiring the user to pass in modules / instances of the appropriate type into the constructors (usually they would have these available from "outside" anyway).

EDIT Forgot to add, I discovered that what appeared to be “headless” means of testing the `TkInterScheduler` and `WxScheduler` don’t actually work properly — so I’ve changed those to use the regular style (which users would also apply) and enabled “virtual frame buffer” support on Travis to make this work on CI as well.