### PR TITLE
Fix mypy errors: Observer, Scheduler, PriorityQueue, SchedulerItem, AsyncSubject

### DIFF
--- a/rx/core/observer/observer.py
+++ b/rx/core/observer/observer.py
@@ -1,6 +1,7 @@
 from typing import Any, Callable, Optional
 
 from .. import typing
+from rx.internal import noop, default_error
 
 
 class Observer(typing.Observer, typing.Disposable):
@@ -9,34 +10,15 @@ class Observer(typing.Observer, typing.Disposable):
     OnCompleted are terminal messages.
     """
 
-    @staticmethod
-    def default_on_next(value: Any) -> None:
-        """Default `on_next()` function. Does nothing."""
-        pass
-
-    @staticmethod
-    def default_on_error(error: Exception) -> None:
-        """Default `on_error()` function. Raises the given exception."""
-        if isinstance(error, BaseException):
-            raise error
-        else:
-            raise Exception(error)
-
-    @staticmethod
-    def default_on_completed() -> None:
-        """Default `on_completed()` function. Does nothing."""
-        pass
-
     def __init__(self,
                  on_next: Optional[typing.OnNext] = None,
                  on_error: Optional[typing.OnError] = None,
                  on_completed: Optional[typing.OnCompleted] = None
                  ) -> None:
-
         self.is_stopped = False
-        self._handler_on_next = on_next or Observer.default_on_next
-        self._handler_on_error = on_error or Observer.default_on_error
-        self._handler_on_completed = on_completed or Observer.default_on_completed
+        self._handler_on_next = on_next or noop
+        self._handler_on_error = on_error or default_error
+        self._handler_on_completed = on_completed or noop
 
     def on_next(self, value: Any) -> None:
         """Notify the observer of a new element in the sequence."""

--- a/rx/core/observer/observer.py
+++ b/rx/core/observer/observer.py
@@ -9,18 +9,34 @@ class Observer(typing.Observer, typing.Disposable):
     OnCompleted are terminal messages.
     """
 
+    @staticmethod
+    def default_on_next(value: Any) -> None:
+        """Default `on_next()` function. Does nothing."""
+        pass
+
+    @staticmethod
+    def default_on_error(error: Exception) -> None:
+        """Default `on_error()` function. Raises the given exception."""
+        if isinstance(error, BaseException):
+            raise error
+        else:
+            raise Exception(error)
+
+    @staticmethod
+    def default_on_completed() -> None:
+        """Default `on_completed()` function. Does nothing."""
+        pass
+
     def __init__(self,
                  on_next: Optional[typing.OnNext] = None,
                  on_error: Optional[typing.OnError] = None,
                  on_completed: Optional[typing.OnCompleted] = None
                  ) -> None:
+
         self.is_stopped = False
-        if on_next is not None:
-            self._on_next_core = on_next
-        if on_error is not None:
-            self._on_error_core = on_error
-        if on_completed is not None:
-            self._on_completed_core = on_completed
+        self._handler_on_next = on_next or Observer.default_on_next
+        self._handler_on_error = on_error or Observer.default_on_error
+        self._handler_on_completed = on_completed or Observer.default_on_completed
 
     def on_next(self, value: Any) -> None:
         """Notify the observer of a new element in the sequence."""
@@ -28,7 +44,10 @@ class Observer(typing.Observer, typing.Disposable):
             self._on_next_core(value)
 
     def _on_next_core(self, value: Any) -> None:
-        pass
+        """For Subclassing purpose. This method is called by `on_next()`
+        method until the observer is stopped.
+        """
+        self._handler_on_next(value)
 
     def on_error(self, error: Exception) -> None:
         """Notify the observer that an exception has occurred.
@@ -42,10 +61,10 @@ class Observer(typing.Observer, typing.Disposable):
             self._on_error_core(error)
 
     def _on_error_core(self, error: Exception) -> None:
-        if isinstance(error, BaseException):
-            raise error
-        else:
-            raise Exception(error)
+        """For Subclassing purpose. This method is called by `on_error()`
+        method until the observer is stopped.
+        """
+        self._handler_on_error(error)
 
     def on_completed(self) -> None:
         """Notifies the observer of the end of the sequence."""
@@ -55,7 +74,10 @@ class Observer(typing.Observer, typing.Disposable):
             self._on_completed_core()
 
     def _on_completed_core(self) -> None:
-        pass
+        """For Subclassing purpose. This method is called by `on_completed()`
+        method until the observer is stopped.
+        """
+        self._handler_on_completed()
 
     def dispose(self) -> None:
         """Disposes the observer, causing it to transition to the

--- a/rx/internal/priorityqueue.py
+++ b/rx/internal/priorityqueue.py
@@ -1,6 +1,6 @@
 import heapq
 from sys import maxsize
-from typing import Generic, List
+from typing import Generic, List, Tuple
 
 from rx.core.typing import T1
 
@@ -11,7 +11,7 @@ class PriorityQueue(Generic[T1]):
     MIN_COUNT = ~maxsize
 
     def __init__(self) -> None:
-        self.items: List[T1] = []
+        self.items: List[Tuple[T1, int]] = []
         self.count = PriorityQueue.MIN_COUNT  # Monotonic increasing for sort stability
 
     def __len__(self):

--- a/rx/scheduler/scheduleditem.py
+++ b/rx/scheduler/scheduleditem.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import Generic, Optional
+from typing import Generic, Optional, Any
 
 from rx.core import typing
 from rx.disposable import SingleAssignmentDisposable
@@ -40,5 +40,8 @@ class ScheduledItem(Generic[typing.TState]):  # pylint: disable=unsubscriptable-
     def __gt__(self, other: 'ScheduledItem') -> bool:
         return self.duetime > other.duetime
 
-    def __eq__(self, other: 'ScheduledItem') -> bool:
-        return self.duetime == other.duetime
+    def __eq__(self, other: Any) -> bool:
+        try:
+            return self.duetime == other.duetime
+        except AttributeError:
+            return NotImplemented

--- a/rx/subjects/asyncsubject.py
+++ b/rx/subjects/asyncsubject.py
@@ -1,5 +1,5 @@
 import threading
-from typing import Any
+from typing import Any, List, Optional
 
 from rx.disposable import Disposable
 from rx.core import Observable
@@ -24,8 +24,8 @@ class AsyncSubject(Observable, Observer):
         self.is_stopped = False
         self.value = None
         self.has_value = False
-        self.observers = []
-        self.exception = None
+        self.observers: List[Observer] = []
+        self.exception: Optional[Exception] = None
 
         self.lock = threading.RLock()
 
@@ -33,7 +33,7 @@ class AsyncSubject(Observable, Observer):
         if self.is_disposed:
             raise DisposedException()
 
-    def _subscribe_core(self, observer, scheduler=None):
+    def _subscribe_core(self, observer: Observer, scheduler=None):
         with self.lock:
             self.check_disposed()
             if not self.is_stopped:
@@ -103,6 +103,6 @@ class AsyncSubject(Observable, Observer):
     def dispose(self) -> None:
         with self.lock:
             self.is_disposed = True
-            self.observers = None
+            self.observers = []
             self.exception = None
             self.value = None


### PR DESCRIPTION
This PR corrects some of the errors reported by mypy and pylint. A lot of errors remain so I will try to keep PRs as short as possible.

### Observer
Currently, we monkey patch `_on_next_core`, `_on_error_core` and `_on_completed_core` in the `__init__` method. It feels a bit weird. 
If one calls the `Observer` constructor without specifying handler functions, _on_xxx_core methods are ... well, object methods, i.e. `_on_xxx_core(self: object, ...)`.
If handler functions are given in the constructor, _on_xxx_core methods become simple object members which appear to be functions i.e. `on_xxx_core(...)`. 
Since other sub-classes are based on `_on_xxx_core` methods (SchedulerObserver, ObserveOnObserver) like 'protected' pseudo-private methods, I've just added an extra layer of wrapping.
```
rx/core/observer/observer.py:30: error: Name '_on_next_core' already defined on line 19
rx/core/observer/observer.py:44: error: Name '_on_error_core' already defined on line 21
rx/core/observer/observer.py:57: error: Name '_on_completed_core' already defined on line 23
```

Pylint related errors:
```
************* Module rx.core.observer.scheduledobserver
rx/core/observer/scheduledobserver.py:26:4: E0202: An attribute defined in rx.core.observer.observer line 19 hides this method (method-hidden)
rx/core/observer/scheduledobserver.py:31:4: E0202: An attribute defined in rx.core.observer.observer line 21 hides this method (method-hidden)
rx/core/observer/scheduledobserver.py:36:4: E0202: An attribute defined in rx.core.observer.observer line 23 hides this method (method-hidden)
************* Module rx.core.observer.observeonobserver
rx/core/observer/observeonobserver.py:8:4: E0202: An attribute defined in rx.core.observer.observer line 19 hides this method (method-hidden)
rx/core/observer/observeonobserver.py:12:4: E0202: An attribute defined in rx.core.observer.observer line 21 hides this method (method-hidden)
rx/core/observer/observeonobserver.py:16:4: E0202: An attribute defined in rx.core.observer.observer line 23 hides this method (method-hidden)
************* Module rx.core.observer.observer
rx/core/observer/observer.py:30:4: E0202: An attribute defined in rx.core.observer.observer line 19 hides this method (method-hidden)
rx/core/observer/observer.py:44:4: E0202: An attribute defined in rx.core.observer.observer line 21 hides this method (method-hidden)
rx/core/observer/observer.py:57:4: E0202: An attribute defined in rx.core.observer.observer line 23 hides this method (method-hidden)
```

### PriorityQueue
Correct the heap type, i.e. `List[Tuple[T1, int]]`. This can be infer from the `ScheduledItem.enqueue` method:
```python
heapq.heappush(self.items, (item, self.count))
```
```
rx/internal/priorityqueue.py:24: error: Value of type "T1" is not indexable
rx/internal/priorityqueue.py:29: error: Value of type "T1" is not indexable
rx/internal/priorityqueue.py:37: error: Cannot infer type argument 1 of "heappush"
rx/internal/priorityqueue.py:44: error: Value of type "T1" is not indexable
```

### SchedulerItem
It appears that `__eq__` is supposed to accept any type of others, something related with Liskov principle. By the way, I'm sorry for having requesting this strict annotation in PR [362](https://github.com/ReactiveX/RxPY/pull/362#discussion_r279300892).

More readings on mypy issue tracker:
https://github.com/python/mypy/issues/2783
https://github.com/python/mypy/issues/6710
Proposal to add an unsafe decorator:
https://github.com/python/mypy/issues/5704

I think we should keep it as simple as possible, so I changed type hint from `ScheduledItem` to `Any` and implemented approximately the example suggested by mypy.
```
rx/scheduler/scheduleditem.py:43: error: Argument 1 of "__eq__" incompatible with supertype "object"
rx/scheduler/scheduleditem.py:43: note: It is recommended for "__eq__" to work with arbitrary objects, for example:
rx/scheduler/scheduleditem.py:43: note:     def __eq__(self, other: object) -> bool:
rx/scheduler/scheduleditem.py:43: note:         if not isinstance(other, ScheduledItem):
rx/scheduler/scheduleditem.py:43: note:             return NotImplemented
rx/scheduler/scheduleditem.py:43: note:         return <logic to compare two ScheduledItem instances>
```

### missing to_timedelta in rx.core.typing.Scheduler
`to_timedelta` is not declared in rx.core.typing. I took the opportunity to add `to_seconds` and `to_datetime`.
```
rx/subjects/replaysubject.py:43: error: "Scheduler" has no attribute "to_timedelta"
```

### AsyncSubject:
Add some annotations to help mypy. Also, on_dispose, the list of observers is now reset to an empty list. Not sure if it's required but mypy was complaining.
```
rx/subjects/asyncsubject.py:27: error: Need type annotation for 'observers'
rx/subjects/asyncsubject.py:90: error: Incompatible types in assignment (expression has type "Exception", variable has type "None")
rx/subjects/asyncsubject.py:106: error: Incompatible types in assignment (expression has type "None", variable has type "List[Any]")
```

