### PR TITLE
Disallow pytest 4.6.0 for now

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
         'Topic :: Software Development :: Libraries :: Python Modules'
     ],
     setup_requires=['pytest-runner'],
-    tests_require=['pytest>=4.4.1', 'pytest-asyncio>=0.10.0', 'coverage>=4.5.3'],
+    tests_require=['pytest>=4.4.1,<4.6.0', 'pytest-asyncio>=0.10.0', 'coverage>=4.5.3'],
 
     package_data={'rx': ['py.typed']},
     packages=['rx', 'rx.internal', 'rx.core', 'rx.core.abc',


### PR DESCRIPTION
It appears that pytest 4.6.0 breaks our unittests on Travis (except python 3.8). I propose we disallow that version for the moment.