### PR TITLE
Pytest is fixed, set minimum to 4.6.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
         'Topic :: Software Development :: Libraries :: Python Modules'
     ],
     setup_requires=['pytest-runner'],
-    tests_require=['pytest>=4.4.1,<4.6.0', 'pytest-asyncio>=0.10.0', 'coverage>=4.5.3'],
+    tests_require=['pytest>=4.6.1', 'pytest-asyncio>=0.10.0', 'coverage>=4.5.3'],
 
     package_data={'rx': ['py.typed']},
     packages=['rx', 'rx.internal', 'rx.core', 'rx.core.abc',


### PR DESCRIPTION
It looks like they fixed the issue at pytest. I propose we just require the latest version as a minimum, otherwise we'd get a rather complicated gapped version range.

Lesson perhaps about "involuntary beta-testing" here, maybe the versions should be pinned to a single fixed version which is known to work, and then updated deliberately after testing?