### PR TITLE
Added more marble diagrams in doc, fixed some typos

### DIFF
--- a/rx/__init__.py
+++ b/rx/__init__.py
@@ -495,7 +495,7 @@ def hot(string: str,
           -2-3-|
 
     Each character in the string will advance time by timespan
-    (exept for space). Characters that are not special (see the table below)
+    (except for space). Characters that are not special (see the table below)
     will be interpreted as a value to be emitted. Numbers will be cast
     to int or float.
 
@@ -916,7 +916,7 @@ def to_async(func: Callable, scheduler: Optional[typing.Scheduler] = None) -> Ca
             specified, defaults to Scheduler.timeout.
 
     Returns:
-        Aynchronous function.
+        Asynchronous function.
     """
     from .core.observable.toasync import _to_async
     return _to_async(func, scheduler)
@@ -949,7 +949,7 @@ def with_latest_from(*sources: Observable) -> Observable:
     """Merges the specified observable sequences into one observable
     sequence by creating a tuple only when the first
     observable sequence produces an element. The observables can be
-    passed either as seperate arguments or as a list.
+    passed either as separate arguments or as a list.
 
     .. marble::
         :alt: with_latest_from

--- a/rx/__init__.py
+++ b/rx/__init__.py
@@ -12,6 +12,15 @@ __version__ = "3.0.0-beta4"
 def amb(*sources: Observable) -> Observable:
     """Propagates the observable sequence that reacts first.
 
+    .. marble::
+        :alt: amb
+
+        ---8--6--9-----------|
+        --1--2--3---5--------|
+        ----------10-20-30---|
+        [        amb()       ]
+        --1--2--3---5--------|
+
     Example:
         >>> winner = rx.amb(xs, ys, zs)
 
@@ -53,6 +62,14 @@ def catch(*sources: Observable) -> Observable:
     """Continues an observable sequence that is terminated by an
     exception with the next observable sequence.
 
+    .. marble::
+        :alt: catch
+
+        ---1---2---3-*
+                     a-7-8-|
+        [      catch(a)    ]
+        ---1---2---3---7-8-|
+
     Examples:
         >>> res = rx.catch(xs, ys, zs)
 
@@ -68,6 +85,14 @@ def catch(*sources: Observable) -> Observable:
 def catch_with_iterable(sources: Iterable[Observable]) -> Observable:
     """Continues an observable sequence that is terminated by an
     exception with the next observable sequence.
+
+    .. marble::
+        :alt: catch
+
+        ---1---2---3-*
+                     a-7-8-|
+        [      catch(a)    ]
+        ---1---2---3---7-8-|
 
     Examples:
         >>> res = rx.catch([xs, ys, zs])
@@ -86,7 +111,15 @@ def catch_with_iterable(sources: Iterable[Observable]) -> Observable:
 
 
 def create(subscribe: Callable[[typing.Observer, Optional[typing.Scheduler]], typing.Disposable]):
-    """Create observable from subscribe function."""
+    """Create observable from subscribe function.
+
+    .. marble::
+        :alt: create
+
+        [     create(a)    ]
+        ---1---2---3---4---|
+
+    """
 
     return Observable(subscribe)
 
@@ -95,6 +128,14 @@ def combine_latest(*sources: Observable) -> Observable:
     """Merges the specified observable sequences into one observable
     sequence by creating a tuple whenever any of the
     observable sequences produces an element.
+
+    .. marble::
+        :alt: combine_latest
+
+        ---a-----b--c------|
+        --1---2--------3---|
+        [ combine_latest() ]
+        ---a1-a2-b2-c2-c3--|
 
     Examples:
         >>> obs = rx.combine_latest(obs1, obs2, obs3)
@@ -110,6 +151,14 @@ def combine_latest(*sources: Observable) -> Observable:
 def concat(*sources: Observable) -> Observable:
     """Concatenates all the observable sequences.
 
+    .. marble::
+        :alt: concat
+
+        ---1--2--3--|
+        --6--8--|
+        [     concat()     ]
+        ---1--2--3----6--8-|
+
     Examples:
         >>> res = rx.concat(xs, ys, zs)
 
@@ -123,6 +172,14 @@ def concat(*sources: Observable) -> Observable:
 
 def concat_with_iterable(sources: Iterable[Observable]) -> Observable:
     """Concatenates all the observable sequences.
+
+    .. marble::
+        :alt: concat
+
+        ---1--2--3--|
+        --6--8--|
+        [     concat()     ]
+        ---1--2--3----6--8-|
 
     Examples:
         >>> res = rx.concat_with_iterable([xs, ys, zs])
@@ -143,6 +200,13 @@ def defer(observable_factory: Callable[[typing.Scheduler], Union[Observable, _Fu
     """Returns an observable sequence that invokes the specified
     factory function whenever a new observer subscribes.
 
+    .. marble::
+        :alt: defer
+
+        [     defer(1,2,3)     ]
+        ---1--2--3--|
+                ---1--2--3--|
+
     Example:
         >>> res = rx.defer(lambda: of(1, 2, 3))
 
@@ -160,6 +224,12 @@ def defer(observable_factory: Callable[[typing.Scheduler], Union[Observable, _Fu
 
 def empty(scheduler: Optional[typing.Scheduler] = None) -> Observable:
     """Returns an empty observable sequence.
+
+    .. marble::
+        :alt: empty
+
+        [     empty()     ]
+        --|
 
     Example:
         >>> obs = rx.empty()
@@ -197,6 +267,12 @@ def from_callable(supplier: Callable[[], Any], scheduler: Optional[typing.Schedu
     """Returns an observable sequence that contains a single element
     generate from a supplier, using the specified scheduler to send out
     observer messages.
+
+    .. marble::
+        :alt: from_callable
+
+        [   from_callable()    ]
+        ---1--2--3--|
 
     Examples:
         >>> res = rx.from_callable(lambda: calculate_value())
@@ -252,6 +328,13 @@ def from_future(future: _Future) -> Observable:
 def from_iterable(iterable: Iterable, scheduler: Optional[typing.Scheduler] = None) -> Observable:
     """Converts an iterable to an observable sequence.
 
+    .. marble::
+        :alt: from_iterable
+
+        [   from_iterable(1,2,3)    ]
+        ---1--2--3--|
+
+
     Example:
         >>> rx.from_iterable([1,2,3])
 
@@ -279,6 +362,12 @@ def from_marbles(string: str,
                  ) -> Observable:
     """Convert a marble diagram string to a cold observable sequence, using
     an optional scheduler to enumerate the events.
+
+    .. marble::
+        :alt: from_marbles
+
+        [  from_marbles(-1-2-3-)   ]
+        -1-2-3-|
 
     Each character in the string will advance time by timespan
     (exept for space). Characters that are not special (see the table below)
@@ -398,6 +487,13 @@ def hot(string: str,
     """Convert a marble diagram string to a hot observable sequence, using
     an optional scheduler to enumerate the events.
 
+    .. marble::
+        :alt: hot
+
+        [  from_marbles(-1-2-3-)   ]
+        -1-2-3-|
+          -2-3-|
+
     Each character in the string will advance time by timespan
     (exept for space). Characters that are not special (see the table below)
     will be interpreted as a value to be emitted. Numbers will be cast
@@ -463,6 +559,15 @@ def if_then(condition: Callable[[], bool],
             ) -> Observable:
     """Determines whether an observable collection contains values.
 
+    .. marble::
+        :alt: if_then
+
+        ---1--2--3--|
+        --6--8--|
+        [    if_then()     ]
+        ---1--2--3--|
+
+
     Examples:
         >>> res = rx.if_then(condition, obs1)
         >>> res = rx.if_then(condition, obs1, obs2)
@@ -489,6 +594,12 @@ def interval(period: typing.RelativeTime, scheduler: Optional[typing.Scheduler] 
     """Returns an observable sequence that produces a value after each
     period.
 
+    .. marble::
+        :alt: interval
+
+        [  interval()   ]
+        ---1---2---3---4--->
+
     Example:
         >>> res = rx.interval(1.0)
 
@@ -509,6 +620,14 @@ def merge(*sources: Observable) -> Observable:
     """Merges all the observable sequences into a single observable
     sequence.
 
+    .. marble::
+        :alt: merge
+
+        ---1---2---3---4-|
+        -a---b---c---d--|
+        [     merge()      ]
+        -a-1-b-2-c-3-d-4-|
+
     Example:
         >>> res = rx.merge(obs1, obs2, obs3)
 
@@ -524,6 +643,12 @@ def never() -> Observable:
     """Returns a non-terminating observable sequence, which can be used
     to denote an infinite duration (e.g. when using reactive joins).
 
+    .. marble::
+        :alt: never
+
+        [     never()     ]
+        -->
+
     Returns:
         An observable sequence whose observers will never get called.
     """
@@ -534,6 +659,12 @@ def never() -> Observable:
 def of(*args: Any) -> Observable:
     """This method creates a new Observable instance with a variable
     number of arguments, regardless of number or type of the arguments.
+
+    .. marble::
+        :alt: of
+
+        [    of(1,2,3)    ]
+        ---1--2--3--|
 
     Example:
         >>> res = rx.of(1,2,3)
@@ -548,6 +679,15 @@ def of(*args: Any) -> Observable:
 def on_error_resume_next(*sources: Union[Observable, _Future]) -> Observable:
     """Continues an observable sequence that is terminated normally or
     by an exception with the next observable sequence.
+
+    .. marble::
+        :alt: on_error_resume_next
+
+        --1--2--*
+        a--3--4--*
+         b--6-|
+        [on_error_resume_next(a,b)]
+        --1--2----3--4----6-|
 
     Examples:
         >>> res = rx.on_error_resume_next(xs, ys, zs)
@@ -568,6 +708,12 @@ def range(start: int,
     """Generates an observable sequence of integral numbers within a
     specified range, using the specified scheduler to send out observer
     messages.
+
+    .. marble::
+        :alt: range
+
+        [    range(4)     ]
+        --0--1--2--3--|
 
     Examples:
         >>> res = rx.range(10)
@@ -592,6 +738,12 @@ def return_value(value: Any, scheduler: Optional[typing.Scheduler] = None) -> Ob
     using the specified scheduler to send out observer messages.
     There is an alias called 'just'.
 
+    .. marble::
+        :alt: return_value
+
+        [ return_value(4) ]
+        -4-|
+
     Examples:
         >>> res = rx.return_value(42)
         >>> res = rx.return_value(42, timeout_scheduler)
@@ -614,6 +766,12 @@ def repeat_value(value: Any = None, repeat_count: Optional[int] = None) -> Obser
     """Generates an observable sequence that repeats the given element
     the specified number of times.
 
+    .. marble::
+        :alt: repeat_value
+
+        [ repeat_value(4) ]
+        -4-4-4-4->
+
     Examples:
         1 - res = rx.repeat_value(42)
         2 - res = rx.repeat_value(42, 4)
@@ -634,6 +792,13 @@ def repeat_value(value: Any = None, repeat_count: Optional[int] = None) -> Obser
 def start(func: Callable, scheduler: Optional[typing.Scheduler] = None) -> Observable:
     """Invokes the specified function asynchronously on the specified
     scheduler, surfacing the result through an observable sequence.
+
+    .. marble::
+        :alt: start
+
+        [ start(lambda i: return 4) ]
+        -4-|
+          -4-|
 
     Example:
         >>> res = rx.start(lambda: pprint('hello'))
@@ -678,6 +843,12 @@ def throw(exception: Exception, scheduler: Optional[typing.Scheduler] = None) ->
     using the specified scheduler to send out the single OnError
     message.
 
+    .. marble::
+        :alt: throw
+
+        [ throw() ]
+        -*
+
     Example:
         >>> res = rx.throw(Exception('Error'))
 
@@ -697,6 +868,12 @@ def timer(duetime: typing.AbsoluteOrRelativeTime, period: Optional[typing.Relati
           scheduler: Optional[typing.Scheduler] = None) -> Observable:
     """Returns an observable sequence that produces a value after
     duetime has elapsed and then after each period.
+
+    .. marble::
+        :alt: timer
+
+        [ timer(2) ]
+        --0-|
 
     Examples:
         >>> res = rx.timer(datetime(...))
@@ -774,6 +951,14 @@ def with_latest_from(*sources: Observable) -> Observable:
     observable sequence produces an element. The observables can be
     passed either as seperate arguments or as a list.
 
+    .. marble::
+        :alt: with_latest_from
+
+        ---1---2---3----4-|
+        --a-----b----c-d----|
+        [with_latest_from() ]
+        ---1,a-2,a-3,b--4,d-|
+
     Examples:
         >>> obs = rx.with_latest_from(obs1)
         >>> obs = rx.with_latest_from([obs1, obs2, obs3])
@@ -791,6 +976,14 @@ def zip(*args: Observable) -> Observable:
     sequence by creating a tuple whenever all of the
     observable sequences have produced an element at a corresponding
     index.
+
+    .. marble::
+        :alt: zip
+
+        --1--2---3-----4---|
+        -a----b----c-d-----|
+        [       zip()      ]
+        --1,a-2,b--3,c-4,d-|
 
     Example:
         >>> res = rx.zip(obs1, obs2)

--- a/rx/core/observable/observable.py
+++ b/rx/core/observable/observable.py
@@ -223,11 +223,11 @@ class Observable(typing.Observable):
         The operators are composed to right. A composition of zero
         operators gives back the original source.
 
-        source.pipe() == source
-        source.pipe(f) == f(source)
-        source.pipe(g, f) == f(g(source))
-        source.pipe(h, g, f) == f(g(h(source)))
-        ...
+        Examples:
+            >>> source.pipe() == source
+            >>> source.pipe(f) == f(source)
+            >>> source.pipe(g, f) == f(g(source))
+            >>> source.pipe(h, g, f) == f(g(h(source)))
 
         Returns the composed observable.
         """

--- a/rx/operators/__init__.py
+++ b/rx/operators/__init__.py
@@ -151,7 +151,7 @@ def buffer_when(closing_mapper: Callable[[], Observable]) -> Callable[[Observabl
         closing_mapper: A function invoked to define the closing of each
             produced buffer. A buffer is started when the previous one is
             closed, resulting in non-overlapping buffers. The buffer is closed
-            when one item is emmited or when the observable completes.
+            when one item is emitted or when the observable completes.
 
     Returns:
         A function that takes an observable source and returns an
@@ -185,7 +185,7 @@ def buffer_toggle(openings: Observable,
         closing_mapper: A function invoked to define the closing of each
             produced buffer. Value from openings Observable that initiated
             the associated buffer is provided as argument to the function. The
-            buffer is closed when one item is emmited or when the observable
+            buffer is closed when one item is emitted or when the observable
             completes.
 
     Returns:
@@ -1062,7 +1062,7 @@ def first_or_default(predicate: Optional[Predicate] = None,
             exists.  If not specified, defaults to None.
 
     Returns:
-        A function that takes an observable source and reutrn an
+        A function that takes an observable source and returns an
         observable sequence containing the first element in the
         observable sequence that satisfies the condition in the
         predicate, or a default value if no such element exists.
@@ -1643,7 +1643,7 @@ def min(comparer: Optional[Comparer] = None) -> Callable[[Observable], Observabl
 
     Returns:
         An operator function that takes an observable source and
-        reuturns an observable sequence containing a single element
+        returns an observable sequence containing a single element
         with the minimum element in the source sequence.
     """
     from rx.core.operators.min import _min
@@ -1735,6 +1735,7 @@ def observe_on(scheduler: typing.Scheduler) -> Callable[[Observable], Observable
     """
     from rx.core.operators.observeon import _observe_on
     return _observe_on(scheduler)
+
 
 def on_error_resume_next(second: Observable) -> Callable[[Observable], Observable]:
     """Continues an observable sequence that is terminated normally
@@ -1934,7 +1935,7 @@ def publish_value(initial_value: Any, mapper: Optional[Mapper] = None) -> Callab
             subscription on.
 
     Returns:
-        An operator function that takes an obserable source and returns
+        An operator function that takes an observable source and returns
         an observable sequence that contains the elements of a
         sequence produced by multicasting the source sequence within a
         mapper function.
@@ -2410,7 +2411,7 @@ def skip_until_with_time(start_time: typing.AbsoluteOrRelativeTime,
             `datetime.utcnow()`, no elements will be skipped.
 
     Returns:
-        An operator function that takes an obserable source and
+        An operator function that takes an observable source and
         returns an observable sequence with the elements skipped
         until the specified start time.
     """
@@ -2574,7 +2575,7 @@ def some(predicate: Optional[Predicate] = None) -> Callable[[Observable], Observ
 
     Returns:
         An operator function that takes an observable source and
-        returnsobservable sequence containing a single element
+        returns an observable sequence containing a single element
         determining whether some elements in the source sequence
         pass the test in the specified predicate if given, else if some
         items are in the sequence.
@@ -2984,7 +2985,7 @@ def take_with_time(duration: typing.RelativeTime, scheduler: Optional[typing.Sch
         :alt: take_with_time
 
         -----1--2--3--4----|
-        [ take_whith_time()]
+        [ take_with_time() ]
         -----1--2----------|
 
     Example:
@@ -3191,7 +3192,7 @@ def to_future(future_ctor: Optional[Callable[[], Future]] = None) -> Callable[[O
         future_ctor: [Optional] The constructor of the future.
 
     Returns:
-        An operator function that takes an obserable source and returns
+        An operator function that takes an observable source and returns
         a future with the last value from the observable sequence.
     """
     from rx.core.operators.tofuture import _to_future
@@ -3211,7 +3212,9 @@ def to_iterable() -> Callable[[Observable], Observable]:
     from rx.core.operators.toiterable import _to_iterable
     return _to_iterable()
 
+
 to_list = to_iterable
+
 
 def to_marbles(timespan: typing.RelativeTime = 0.1,
                scheduler: Optional[typing.Scheduler] = None
@@ -3413,7 +3416,7 @@ def with_latest_from(*sources: Observable) -> Callable[[Observable], Observable]
     Merges the specified observable sequences into one observable
     sequence by creating a tuple only when the first
     observable sequence produces an element. The observables can be
-    passed either as seperate arguments or as a list.
+    passed either as separate arguments or as a list.
 
     .. marble::
         :alt: with_latest_from

--- a/rx/operators/__init__.py
+++ b/rx/operators/__init__.py
@@ -240,9 +240,9 @@ def buffer_with_time(timespan: typing.RelativeTime,
         -------1,2,3-4,5,6-|
 
     Examples:
-        # non-overlapping segments of 1 second
+        >>> # non-overlapping segments of 1 second
         >>> res = buffer_with_time(1.0)
-        # segments of 1 second with time shift 0.5 seconds
+        >>> # segments of 1 second with time shift 0.5 seconds
         >>> res = buffer_with_time(1.0, 0.5)
 
     Args:
@@ -276,9 +276,9 @@ def buffer_with_time_or_count(timespan, count, scheduler=None) -> Callable[[Obse
         ------1,2,3-4,5,6--|
 
     Examples:
-        # 5s or 50 items in an array
+        >>> # 5s or 50 items in an array
         >>> res = source.buffer_with_time_or_count(5.0, 50)
-        # 5s or 50 items in an array
+        >>> # 5s or 50 items in an array
         >>> res = source.buffer_with_time_or_count(5.0, 50, Scheduler.timeout)
 
     Args:
@@ -544,9 +544,9 @@ def delay_with_mapper(subscription_delay=None,
         --------1--2--3--4-|
 
     Examples:
-        # with mapper only
+        >>> # with mapper only
         >>> res = source.delay_with_mapper(lambda x: Scheduler.timer(5.0))
-        # with delay and mapper
+        >>> # with delay and mapper
         >>> res = source.delay_with_mapper(rx.timer(2.0), lambda x: rx.timer(x))
 
     Args:
@@ -814,8 +814,8 @@ def element_at_or_default(index: int, default_value: Any = None) -> Callable[[Ob
         >>> res = source.element_at_or_default(5, 0)
 
     Args:
-        index -- The zero-based index of the element to retrieve.
-        default_value -- [Optional] The default value if the index is
+        index: The zero-based index of the element to retrieve.
+        default_value: [Optional] The default value if the index is
             outside the bounds of the source sequence.
 
     Returns:
@@ -884,7 +884,7 @@ def filter(predicate: Predicate) -> Callable[[Observable], Observable]:
 
     Args:
         predicate: A function to test each source element for a
-        condition.
+            condition.
 
     Returns:
         An operator function that takes an observable source and
@@ -936,7 +936,7 @@ def finally_action(action: Callable) -> Callable[[Observable], Observable]:
         --1--2--3--4--6-7-|
 
     Example:
-        res = finally_action(lambda: print('sequence ended')
+        >>> res = finally_action(lambda: print('sequence ended')
 
     Args:
         action: Action to invoke after the source observable sequence


### PR DESCRIPTION
I added some more marble diagrams in the factory operators and fixed few typos.
There are still missing diagrams, some of them will require some evolutions in dooble (other characters in operator descriptions).

Also I wonder if some operators should be removed from operators/__init__.py (and kept only in __init__.py): amb and zip from example do they make sense when called with a single observable as input ?