### PR TITLE
Make sure both class and __init__ docstring are included

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -60,6 +60,13 @@ extensions = [
     'sphinxcontrib_dooble',
 ]
 
+# Include a separate entry for special methods, like __init__, where provided.
+autodoc_default_options = {
+    'member-order': 'bysource',
+    'special-members': True,
+    'exclude-members': '__dict__,__weakref__'
+}
+
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
 

--- a/rx/subject/behaviorsubject.py
+++ b/rx/subject/behaviorsubject.py
@@ -17,9 +17,9 @@ class BehaviorSubject(Subject):
         creates a subject that caches its last value and starts with the
         specified value.
 
-        Keyword parameters:
-        :param T value: Initial value sent to observers when no other
-            value has been received by the subject yet.
+        Args:
+            value: Initial value sent to observers when no other value has been
+                received by the subject yet.
         """
 
         super().__init__()
@@ -55,7 +55,7 @@ class BehaviorSubject(Subject):
         """Release all resources.
 
         Releases all resources used by the current instance of the
-        ReplaySubject class and unsubscribe all observers.
+        BehaviorSubject class and unsubscribe all observers.
         """
 
         with self.lock:


### PR DESCRIPTION
As mentioned in https://github.com/ReactiveX/RxPY/issues/270#issuecomment-498248593.

By the way, I'm getting warnings about the guzzle theme, it appears they're using an outdated means of injecting script. I've created [an issue](https://github.com/guzzle/guzzle_sphinx_theme/issues/45).

Also, as part of the "final pass" of the docs, I think it would be good to change references to classes and methods using the appropriate markup, this will render them properly and link where possible.

And speaking about links, I will see if I can get the cross-links to work for function parameter types, today. I think that would be a great improvement, but maybe that's just me...