### PR TITLE
Try to enforce Sphinx 2

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -47,7 +47,7 @@ version = re.sub('[^0-9.].*$', '', release)
 
 # If your documentation needs a minimal Sphinx version, state it here.
 #
-# needs_sphinx = '1.0'
+needs_sphinx = '2.0'
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
-sphinx
-sphinx-autodoc-typehints
-guzzle_sphinx_theme
+sphinx>=2.0
+sphinx-autodoc-typehints>=1.6.0
+guzzle_sphinx_theme>=0.7.11
 sphinxcontrib_dooble>=1.0


### PR DESCRIPTION
Hmm the readthedocs build is failing, I think it is because I added `special-members: True` which is only supported since Sphinx 2. This PR attempts to enforce it, let's hope RTD supports that (I can't find easily whether it does).

If it still does not work after this, I'll try to find another way -- probably listing special methods explicitly, but I'd rather leave it on `True` (meaning "all of them").