### PR TITLE
Replaced references to rx.scheduler in docs

### DIFF
--- a/docs/get_started.rst
+++ b/docs/get_started.rst
@@ -230,7 +230,7 @@ To achieve concurrency, you use two operators: :func:`subscribe_on()
 <rx.operators.subscribe_on>` and :func:`observe_on() <rx.operators.observe_on>`.
 Both need a :ref:`Scheduler <reference_scheduler>` which provides a thread for
 each subscription to do work (see section on Schedulers below). The
-:class:`ThreadPoolScheduler <rx.scheduler.ThreadPoolScheduler>` is a good
+:class:`ThreadPoolScheduler <rx.concurrency.ThreadPoolScheduler>` is a good
 choice to create a pool of reusable worker threads.
 
 .. attention::
@@ -267,7 +267,7 @@ using :func:`subscribe_on() <rx.operators.subscribe_on>` as well as an
     from threading import current_thread
 
     from rx import Observable
-    from rx.scheduler import ThreadPoolScheduler
+    from rx.concurrency import ThreadPoolScheduler
 
 
     def intense_calculation(value):

--- a/docs/reference_scheduler.rst
+++ b/docs/reference_scheduler.rst
@@ -3,15 +3,15 @@
 Schedulers
 ===========
 
-.. automodule:: rx.scheduler
+.. automodule:: rx.concurrency
     :members: CatchScheduler, CurrentThreadScheduler, EventLoopScheduler,
                 HistoricalScheduler, ImmediateScheduler, NewThreadScheduler,
                 ThreadPoolScheduler, TimeoutScheduler, VirtualTimeScheduler
 
-.. automodule:: rx.scheduler.eventloop
+.. automodule:: rx.concurrency.mainloopscheduler
     :members: AsyncIOScheduler, AsyncIOThreadSafeScheduler, EventletScheduler,
                 GEventScheduler, IOLoopScheduler, TwistedScheduler
 
-.. automodule:: rx.scheduler.mainloop
+.. automodule:: rx.concurrency.mainloopscheduler
     :members: GtkScheduler, PyGameScheduler, QtScheduler,
                 TkinterScheduler, WxScheduler


### PR DESCRIPTION
I think there are a many more references to rx.scheduler than these, but I think some are valid and some are not, so I'm afraid to break things.