### PR TITLE
Fix mypy errors in rx.scheduler

### DIFF
--- a/rx/core/abc/scheduler.py
+++ b/rx/core/abc/scheduler.py
@@ -20,3 +20,18 @@ class Scheduler(ABC):
     @abstractmethod
     def schedule_absolute(self, duetime, action, state=None):
         return NotImplemented
+
+    @classmethod
+    @abstractmethod
+    def to_seconds(cls, value):
+        return NotImplemented
+
+    @classmethod
+    @abstractmethod
+    def to_datetime(cls, value):
+        return NotImplemented
+
+    @classmethod
+    @abstractmethod
+    def to_timedelta(cls, value):
+        return NotImplemented

--- a/rx/core/notification.py
+++ b/rx/core/notification.py
@@ -99,7 +99,10 @@ class OnNext(Notification):
         return observer.on_next(self.value)
 
     def __str__(self):
-        return "OnNext(%s)" % str(self.value)
+        val = self.value
+        if isinstance(val, int):
+            val = float(val)
+        return "OnNext(%s)" % str(val)
 
 
 class OnError(Notification):

--- a/rx/core/typing.py
+++ b/rx/core/typing.py
@@ -119,6 +119,56 @@ class Scheduler(abc.Scheduler):
 
         return NotImplemented
 
+    @classmethod
+    @abstractmethod
+    def to_seconds(cls, value: AbsoluteOrRelativeTime) -> float:
+        """Converts time value to seconds. This method handles both absolute
+        (datetime) and relative (timedelta) values. If the argument is already
+        a float, it is simply returned unchanged.
+
+        Args:
+            value: the time value to convert to seconds.
+
+        Returns:
+            The value converted to seconds.
+        """
+
+        return NotImplemented
+
+    @classmethod
+    @abstractmethod
+    def to_datetime(cls, value: AbsoluteOrRelativeTime) -> datetime:
+        """Converts time value to datetime. This method handles both absolute
+        (float) and relative (timedelta) values. If the argument is already
+        a datetime, it is simply returned unchanged.
+
+        Args:
+            value: the time value to convert to datetime.
+
+        Returns:
+            The value converted to datetime.
+        """
+
+        return NotImplemented
+
+    @classmethod
+    @abstractmethod
+    def to_timedelta(cls, value: AbsoluteOrRelativeTime) -> timedelta:
+        """Converts time value to timedelta. This method handles both absolute
+        (datetime) and relative (float) values. If the argument is already
+        a timedelta, it is simply returned unchanged. If the argument is an
+        absolute time, the result value will be the timedelta since the epoch,
+        January 1st, 1970, 00:00:00.
+
+        Args:
+            value: the time value to convert to timedelta.
+
+        Returns:
+            The value converted to timedelta.
+        """
+
+        return NotImplemented
+
 
 class PeriodicScheduler(abc.PeriodicScheduler):
     """PeriodicScheduler abstract base class."""

--- a/rx/core/typing.py
+++ b/rx/core/typing.py
@@ -155,7 +155,7 @@ ScheduledSingleOrPeriodicAction = Union[ScheduledAction, ScheduledPeriodicAction
 
 Startable = Union[abc.Startable, Thread]
 StartableTarget = Callable[..., None]
-StartableFactory = Callable[[StartableTarget, Optional[Tuple]], Startable]
+StartableFactory = Callable[[StartableTarget], Startable]
 
 
 class Observer(Generic[T_in], abc.Observer):

--- a/rx/internal/concurrency.py
+++ b/rx/internal/concurrency.py
@@ -1,11 +1,10 @@
 from threading import Thread
-from typing import Optional, Tuple
 
 from rx.core.typing import StartableTarget
 
 
-def default_thread_factory(target: StartableTarget, args: Optional[Tuple] = None) -> Thread:
-    return Thread(target=target, args=args or (), daemon=True)
+def default_thread_factory(target: StartableTarget) -> Thread:
+    return Thread(target=target, daemon=True)
 
 
 def synchronized(lock):

--- a/rx/scheduler/catchscheduler.py
+++ b/rx/scheduler/catchscheduler.py
@@ -126,7 +126,7 @@ class CatchScheduler(PeriodicScheduler):
         disp: SingleAssignmentDisposable = SingleAssignmentDisposable()
         failed: bool = False
 
-        def periodic(state: typing.TState) -> Optional[typing.TState]:
+        def periodic(state: Optional[typing.TState] = None) -> Optional[typing.TState]:
             nonlocal failed
             if failed:
                 return None

--- a/rx/scheduler/currentthreadscheduler.py
+++ b/rx/scheduler/currentthreadscheduler.py
@@ -63,8 +63,9 @@ class CurrentThreadScheduler(Scheduler):
         """Ensure that each thread has at most a single instance."""
 
         thread = threading.current_thread()
-        self: 'CurrentThreadScheduler' = CurrentThreadScheduler._global.get(thread)
-        if not self:
+        try:
+            self = CurrentThreadScheduler._global[thread]
+        except KeyError:
             self = super().__new__(cls)
             CurrentThreadScheduler._global[thread] = self
         return self

--- a/rx/scheduler/currentthreadscheduler.py
+++ b/rx/scheduler/currentthreadscheduler.py
@@ -17,7 +17,7 @@ log = logging.getLogger('Rx')
 
 class Trampoline(object):
     @classmethod
-    def run(cls, queue: PriorityQueue[ScheduledItem[typing.TState]]) -> None:
+    def run(cls, queue: PriorityQueue[ScheduledItem]) -> None:
         while queue:
             item: ScheduledItem = queue.peek()
             if item.is_cancelled():
@@ -37,8 +37,7 @@ class _Local(threading.local):
     def __init__(self) -> None:
         super().__init__()
         self.idle: bool = True
-        self.queue: PriorityQueue[
-            ScheduledItem[typing.TState]] = PriorityQueue()
+        self.queue: PriorityQueue[ScheduledItem] = PriorityQueue()
 
 
 class CurrentThreadScheduler(Scheduler):
@@ -134,7 +133,7 @@ class CurrentThreadScheduler(Scheduler):
         if duetime > self.now:
             log.warning("Do not schedule blocking work!")
 
-        si: ScheduledItem[typing.TState] = ScheduledItem(self, state, action, duetime)
+        si: ScheduledItem = ScheduledItem(self, state, action, duetime)
 
         local: _Local = CurrentThreadScheduler._local
         local.queue.enqueue(si)

--- a/rx/scheduler/eventloop/asynciothreadsafescheduler.py
+++ b/rx/scheduler/eventloop/asynciothreadsafescheduler.py
@@ -2,7 +2,7 @@ import logging
 import asyncio
 
 from concurrent.futures import Future
-from typing import Optional
+from typing import List, Optional
 
 from rx.core import typing
 from rx.disposable import CompositeDisposable, Disposable, SingleAssignmentDisposable
@@ -50,7 +50,7 @@ class AsyncIOThreadSafeScheduler(AsyncIOScheduler):
         handle = self._loop.call_soon_threadsafe(interval)
 
         def dispose() -> None:
-            future = Future()
+            future: Future = Future()
 
             def cancel_handle() -> None:
                 handle.cancel()
@@ -88,7 +88,7 @@ class AsyncIOThreadSafeScheduler(AsyncIOScheduler):
 
         # the operations on the list used here are atomic, so there is no
         # need to protect its access with a lock
-        handle = []
+        handle: List[asyncio.Handle] = []
 
         def stage2() -> None:
             handle.append(self._loop.call_later(seconds, interval))
@@ -96,7 +96,7 @@ class AsyncIOThreadSafeScheduler(AsyncIOScheduler):
         handle.append(self._loop.call_soon_threadsafe(stage2))
 
         def dispose() -> None:
-            future = Future()
+            future: Future = Future()
 
             def cancel_handle() -> None:
                 try:

--- a/rx/scheduler/eventloop/twistedscheduler.py
+++ b/rx/scheduler/eventloop/twistedscheduler.py
@@ -60,8 +60,6 @@ class TwistedScheduler(PeriodicScheduler):
             (best effort).
         """
 
-        from twisted.internet.task import deferLater
-
         seconds = max(0.0, self.to_seconds(duetime))
 
         sad = SingleAssignmentDisposable()
@@ -70,7 +68,7 @@ class TwistedScheduler(PeriodicScheduler):
             sad.disposable = action(self, state)
 
         log.debug("timeout: %s", seconds)
-        timer = deferLater(self._reactor, seconds, interval).addErrback(lambda _: None)
+        timer = self._reactor.callLater(seconds, interval)
 
         def dispose() -> None:
             if not timer.called:

--- a/rx/scheduler/eventloopscheduler.py
+++ b/rx/scheduler/eventloopscheduler.py
@@ -31,7 +31,7 @@ class EventLoopScheduler(PeriodicScheduler, typing.Disposable):
         self._thread_factory: typing.StartableFactory = thread_factory or default_thread_factory
         self._thread: Optional[typing.Startable] = None
         self._condition = threading.Condition(threading.Lock())
-        self._queue: PriorityQueue[ScheduledItem[typing.TState]] = PriorityQueue()
+        self._queue: PriorityQueue[ScheduledItem] = PriorityQueue()
         self._ready_list: Deque[ScheduledItem] = deque()
 
         self._exit_if_empty = exit_if_empty
@@ -94,7 +94,7 @@ class EventLoopScheduler(PeriodicScheduler, typing.Disposable):
             raise DisposedException()
 
         dt = self.to_datetime(duetime)
-        si: ScheduledItem[typing.TState] = ScheduledItem(self, state, action, dt)
+        si: ScheduledItem = ScheduledItem(self, state, action, dt)
 
         with self._condition:
             if dt <= self.now:

--- a/rx/scheduler/historicalscheduler.py
+++ b/rx/scheduler/historicalscheduler.py
@@ -31,8 +31,9 @@ class HistoricalScheduler(VirtualTimeScheduler):
 
         return self._clock
 
-    @staticmethod
-    def add(absolute: typing.AbsoluteTime,
+    @classmethod
+    def add(cls,
+            absolute: typing.AbsoluteTime,
             relative: typing.RelativeTime
             ) -> typing.AbsoluteTime:
         """Adds a relative time value to an absolute time value.
@@ -45,4 +46,4 @@ class HistoricalScheduler(VirtualTimeScheduler):
             The resulting absolute virtual time sum value.
         """
 
-        return absolute + HistoricalScheduler.to_timedelta(relative)
+        return cls.to_datetime(absolute) + cls.to_timedelta(relative)

--- a/rx/scheduler/mainloop/gtkscheduler.py
+++ b/rx/scheduler/mainloop/gtkscheduler.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional
+from typing import cast, Any, Optional
 
 from rx.core import typing
 from rx.disposable import CompositeDisposable, Disposable, SingleAssignmentDisposable
@@ -43,9 +43,9 @@ class GtkScheduler(PeriodicScheduler):
 
             nonlocal state
             if periodic:
-                state = action(state)
+                state = cast(typing.ScheduledPeriodicAction, action)(state)
             else:
-                sad.disposable = self.invoke_action(action, state=state)
+                sad.disposable = self.invoke_action(cast(typing.ScheduledAction, action), state=state)
 
             return periodic
 

--- a/rx/scheduler/mainloop/pygamescheduler.py
+++ b/rx/scheduler/mainloop/pygamescheduler.py
@@ -33,7 +33,7 @@ class PyGameScheduler(PeriodicScheduler):
         super().__init__()
         self._pygame = pygame  # TODO not used, refactor to actually use pygame?
         self._lock = threading.Lock()
-        self._queue: PriorityQueue[ScheduledItem[typing.TState]] = PriorityQueue()
+        self._queue: PriorityQueue[ScheduledItem] = PriorityQueue()
 
     def schedule(self,
                  action: typing.ScheduledAction,
@@ -90,7 +90,7 @@ class PyGameScheduler(PeriodicScheduler):
         """
 
         duetime = self.to_datetime(duetime)
-        si: ScheduledItem[typing.TState] = ScheduledItem(self, state, action, duetime)
+        si: ScheduledItem = ScheduledItem(self, state, action, duetime)
 
         with self._lock:
             self._queue.enqueue(si)
@@ -100,7 +100,7 @@ class PyGameScheduler(PeriodicScheduler):
     def run(self) -> None:
         while self._queue:
             with self._lock:
-                item: ScheduledItem[typing.TState] = self._queue.peek()
+                item: ScheduledItem = self._queue.peek()
                 diff = item.duetime - self.now
 
                 if diff > DELTA_ZERO:

--- a/rx/scheduler/mainloop/qtscheduler.py
+++ b/rx/scheduler/mainloop/qtscheduler.py
@@ -1,6 +1,7 @@
 import logging
 
-from typing import Any, Optional
+from datetime import timedelta
+from typing import Any, Optional, Set
 
 from rx.core import typing
 from rx.disposable import CompositeDisposable, Disposable, SingleAssignmentDisposable
@@ -23,7 +24,8 @@ class QtScheduler(PeriodicScheduler):
         """
         super().__init__()
         self._qtcore = qtcore
-        self._periodic_timers = set()
+        timer_class: Any = self._qtcore.QTimer
+        self._periodic_timers: Set[timer_class] = set()
 
     def schedule(self,
                  action: typing.ScheduledAction,
@@ -93,8 +95,8 @@ class QtScheduler(PeriodicScheduler):
             (best effort).
         """
 
-        duetime = self.to_datetime(duetime) - self.now
-        return self.schedule_relative(duetime, action, state=state)
+        delta: timedelta = self.to_datetime(duetime) - self.now
+        return self.schedule_relative(delta, action, state=state)
 
     def schedule_periodic(self,
                           period: typing.RelativeTime,

--- a/rx/scheduler/mainloop/wxscheduler.py
+++ b/rx/scheduler/mainloop/wxscheduler.py
@@ -1,6 +1,6 @@
 import logging
 
-from typing import Any, Optional
+from typing import cast, Any, Optional, Set
 
 from rx.core import typing
 from rx.disposable import CompositeDisposable, Disposable, SingleAssignmentDisposable
@@ -24,9 +24,9 @@ class WxScheduler(PeriodicScheduler):
 
         super().__init__()
         self._wx = wx
-        self._timers = set()
+        timer_class: Any = self._wx.Timer
 
-        class Timer(self._wx.Timer):
+        class Timer(timer_class):
 
             def __init__(self, callback) -> None:
                 super().__init__()
@@ -36,6 +36,7 @@ class WxScheduler(PeriodicScheduler):
                 self.callback()
 
         self._timer_class = Timer
+        self._timers: Set[Timer] = set()
 
     def cancel_all(self) -> None:
         """Cancel all scheduled actions.
@@ -59,9 +60,9 @@ class WxScheduler(PeriodicScheduler):
         def interval() -> None:
             nonlocal state
             if periodic:
-                state = action(state)
+                state = cast(typing.ScheduledPeriodicAction, action)(state)
             else:
-                sad.disposable = action(scheduler, state)
+                sad.disposable = cast(typing.ScheduledAction, action)(scheduler, state)
 
         msecs = max(1, int(self.to_seconds(time) * 1000.0))  # Must be non-zero
 

--- a/rx/scheduler/newthreadscheduler.py
+++ b/rx/scheduler/newthreadscheduler.py
@@ -1,5 +1,7 @@
 import logging
 import threading
+
+from datetime import datetime
 from typing import Optional
 
 from rx.core import typing
@@ -19,7 +21,7 @@ class NewThreadScheduler(PeriodicScheduler):
 
     def __init__(self, thread_factory: Optional[typing.StartableFactory] = None) -> None:
         super().__init__()
-        self.thread_factory = thread_factory or default_thread_factory
+        self.thread_factory: typing.StartableFactory = thread_factory or default_thread_factory
 
     def schedule(self,
                  action: typing.ScheduledAction,
@@ -110,7 +112,7 @@ class NewThreadScheduler(PeriodicScheduler):
                 if disposed.is_set():
                     return
 
-                time: typing.AbsoluteOrRelativeTime = self.now
+                time: datetime = self.now
 
                 state = action(state)
 

--- a/rx/scheduler/periodicscheduler.py
+++ b/rx/scheduler/periodicscheduler.py
@@ -1,4 +1,5 @@
 from abc import abstractmethod
+from datetime import datetime
 from typing import Optional
 
 from rx.core import typing
@@ -34,11 +35,13 @@ class PeriodicScheduler(Scheduler, typing.PeriodicScheduler):
         disp: MultipleAssignmentDisposable = MultipleAssignmentDisposable()
         seconds: float = self.to_seconds(period)
 
-        def periodic(scheduler: typing.Scheduler, state: typing.TState) -> Optional[Disposable]:
+        def periodic(scheduler: typing.Scheduler,
+                     state: Optional[typing.TState] = None
+                     ) -> Optional[Disposable]:
             if disp.is_disposed:
                 return None
 
-            time: typing.AbsoluteOrRelativeTime = scheduler.now
+            now: datetime = scheduler.now
 
             try:
                 state = action(state)
@@ -46,7 +49,7 @@ class PeriodicScheduler(Scheduler, typing.PeriodicScheduler):
                 disp.dispose()
                 raise
 
-            time = seconds - (scheduler.now - time).total_seconds()
+            time = seconds - (scheduler.now - now).total_seconds()
             disp.disposable = scheduler.schedule_relative(time, periodic, state=state)
 
             return None

--- a/rx/scheduler/scheduleditem.py
+++ b/rx/scheduler/scheduleditem.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import Generic, Optional, Any
+from typing import Any, Optional
 
 from rx.core import typing
 from rx.disposable import SingleAssignmentDisposable
@@ -7,16 +7,16 @@ from rx.disposable import SingleAssignmentDisposable
 from .scheduler import Scheduler
 
 
-class ScheduledItem(Generic[typing.TState]):  # pylint: disable=unsubscriptable-object
+class ScheduledItem(object):
 
     def __init__(self,
                  scheduler: Scheduler,
-                 state: Optional[typing.TState],
+                 state: Optional[Any],
                  action: typing.ScheduledAction,
                  duetime: datetime
                  ) -> None:
         self.scheduler: Scheduler = scheduler
-        self.state: Optional[typing.TState] = state
+        self.state: Optional[Any] = state
         self.action: typing.ScheduledAction = action
         self.duetime: datetime = duetime
         self.disposable: SingleAssignmentDisposable = SingleAssignmentDisposable()

--- a/rx/scheduler/scheduler.py
+++ b/rx/scheduler/scheduler.py
@@ -3,9 +3,9 @@ from datetime import datetime, timedelta
 from typing import Optional
 
 from rx.core import typing
-from rx.disposable import Disposable, MultipleAssignmentDisposable
+from rx.disposable import Disposable
 from rx.internal.basic import default_now
-from rx.internal.constants import DELTA_ZERO, UTC_ZERO
+from rx.internal.constants import UTC_ZERO
 
 
 class Scheduler(typing.Scheduler):

--- a/rx/scheduler/virtualtimescheduler.py
+++ b/rx/scheduler/virtualtimescheduler.py
@@ -2,7 +2,7 @@ import logging
 import threading
 from abc import abstractmethod
 from datetime import datetime
-from typing import Optional
+from typing import Any, Optional
 
 from rx.internal import PriorityQueue, ArgumentOutOfRangeException
 from rx.core import typing
@@ -31,7 +31,7 @@ class VirtualTimeScheduler(PeriodicScheduler):
         self._clock = initial_clock
         self._is_enabled = False
         self._lock: threading.Lock = threading.Lock()
-        self._queue: PriorityQueue[ScheduledItem[typing.TState]] = PriorityQueue()
+        self._queue: PriorityQueue[ScheduledItem] = PriorityQueue()
 
     def _get_clock(self):
         with self._lock:
@@ -106,7 +106,7 @@ class VirtualTimeScheduler(PeriodicScheduler):
         """
 
         dt = self.to_datetime(duetime)
-        si: ScheduledItem[typing.TState] = ScheduledItem(self, state, action, dt)
+        si: ScheduledItem = ScheduledItem(self, state, action, dt)
         with self._lock:
             self._queue.enqueue(si)
         return si.disposable
@@ -126,7 +126,7 @@ class VirtualTimeScheduler(PeriodicScheduler):
                 if not self._is_enabled or not self._queue:
                     break
 
-                item: ScheduledItem[typing.TState] = self._queue.dequeue()
+                item: ScheduledItem = self._queue.dequeue()
 
                 if item.duetime > self.now:
                     if isinstance(self._clock, datetime):
@@ -174,7 +174,7 @@ class VirtualTimeScheduler(PeriodicScheduler):
                 if not self._is_enabled or not self._queue:
                     break
 
-                item: ScheduledItem[typing.TState] = self._queue.peek()
+                item: ScheduledItem = self._queue.peek()
 
                 if item.duetime > dt:
                     break

--- a/rx/testing/testscheduler.py
+++ b/rx/testing/testscheduler.py
@@ -36,8 +36,8 @@ class TestScheduler(VirtualTimeScheduler):
         duetime = duetime if isinstance(duetime, float) else self.to_seconds(duetime)
         return super().schedule_absolute(duetime, action, state)
 
-    @staticmethod
-    def add(absolute, relative):
+    @classmethod
+    def add(cls, absolute, relative):
         """Adds a relative virtual time to an absolute virtual time value"""
 
         return absolute + relative


### PR DESCRIPTION
This gets rid of mypy errors for the `rx.scheduler` package. It also includes a minor refactor, namely I thought it might be better to move the temporal converters (`to_datetime` and friends) in a separate place and not couple it to the schedulers so tightly.