### PR TITLE
Fix mypy errors about overloaded methods

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -55,6 +55,7 @@ needs_sphinx = '2.0'
 extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.napoleon',
+    'sphinxcontrib_autodoc_filterparams',
     'sphinx_autodoc_typehints',
     'guzzle_sphinx_theme',
     'sphinxcontrib_dooble',
@@ -96,6 +97,24 @@ def format_annotation(annotation):
     return _format_annotation(annotation)
 
 sphinx_autodoc_typehints.format_annotation = format_annotation
+
+# End hack.
+
+
+# Hack to remove bogus **kwargs parameter from cases where the implementing
+# function for a bunch of overloaded functions is defined with a variadic
+# position parameter. In those cases, mypy complains unless it also has a
+# variadic keyword parameter, but we don't want that in documentation.
+
+hide_params = {
+    'rx.core.observable.observable.Observable.pipe': {'**kwargs'},
+    'rx.core.pipe': {'**kwargs'}
+}
+
+
+def sphinxcontrib_autodoc_filterparams(fun, param):
+    hide = hide_params.get(fun.__module__ + '.' + fun.__qualname__)
+    return hide is None or param not in hide
 
 # End hack.
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,3 +2,4 @@ sphinx>=2.0
 sphinx-autodoc-typehints>=1.6.0
 guzzle_sphinx_theme>=0.7.11
 sphinxcontrib_dooble>=1.0
+sphinxcontrib_autodoc_filterparams>=0.0.1

--- a/rx/core/observable/observable.py
+++ b/rx/core/observable/observable.py
@@ -156,52 +156,33 @@ class Observable(typing.Observable):
         return Disposable(auto_detach_observer.dispose)
 
     @overload
+    # pylint: no-self-use
+    def pipe(self) -> 'Observable':
+        ...  # pylint: disable=pointless-statement
+
+    @overload
+    # pylint: disable=function-redefined, no-self-use
+    def pipe(self, op1: Callable[['Observable'], A]) -> A:
+        ...  # pylint: disable=pointless-statement
+
+    @overload
+    # pylint: disable=function-redefined, no-self-use
     def pipe(self,
-             *operators: Callable[['Observable'], 'Observable']
-             ) -> 'Observable':  # pylint: disable=no-self-use
-        """Compose multiple operators left to right.
-
-        Composes zero or more operators into a functional composition.
-        The operators are composed from left to right. A composition of zero
-        operators gives back the original source.
-
-        Examples:
-            >>> source.pipe() == source
-            >>> source.pipe(f) == f(source)
-            >>> source.pipe(g, f) == f(g(source))
-            >>> source.pipe(h, g, f) == f(g(h(source)))
-
-        Args:
-            operators: Sequence of operators.
-
-        Returns:
-             The composed observable.
-        """
-        ...
-
-    @overload
-    def pipe(self) -> 'Observable':  # pylint: disable=function-redefined, no-self-use
-        ...  # pylint: disable=pointless-statement
-
-    @overload
-    def pipe(self, op1: Callable[['Observable'], A]) -> A:  # pylint: disable=function-redefined, no-self-use
-        ...  # pylint: disable=pointless-statement
-
-    @overload
-    def pipe(self,  # pylint: disable=function-redefined, no-self-use
              op1: Callable[['Observable'], A],
              op2: Callable[[A], B]) -> B:
         ...  # pylint: disable=pointless-statement
 
     @overload
-    def pipe(self,  # pylint: disable=function-redefined, no-self-use
+    # pylint: disable=function-redefined, no-self-use
+    def pipe(self,
              op1: Callable[['Observable'], A],
              op2: Callable[[A], B],
              op3: Callable[[B], C]) -> C:
         ...  # pylint: disable=pointless-statement
 
     @overload
-    def pipe(self,  # pylint: disable=function-redefined, no-self-use
+    # pylint: disable=function-redefined, no-self-use
+    def pipe(self,
              op1: Callable[['Observable'], A],
              op2: Callable[[A], B],
              op3: Callable[[B], C],
@@ -209,7 +190,8 @@ class Observable(typing.Observable):
         ...  # pylint: disable=pointless-statement
 
     @overload
-    def pipe(self,  # pylint: disable=function-redefined, no-self-use, too-many-arguments
+    # pylint: disable=function-redefined, no-self-use, too-many-arguments
+    def pipe(self,
              op1: Callable[['Observable'], A],
              op2: Callable[[A], B],
              op3: Callable[[B], C],
@@ -218,7 +200,8 @@ class Observable(typing.Observable):
         ...  # pylint: disable=pointless-statement
 
     @overload
-    def pipe(self,  # pylint: disable=function-redefined, no-self-use, too-many-arguments
+    # pylint: disable=function-redefined, no-self-use, too-many-arguments
+    def pipe(self,
              op1: Callable[['Observable'], A],
              op2: Callable[[A], B],
              op3: Callable[[B], C],
@@ -228,7 +211,8 @@ class Observable(typing.Observable):
         ...  # pylint: disable=pointless-statement
 
     @overload
-    def pipe(self,  # pylint: disable=function-redefined, no-self-use, too-many-arguments
+    # pylint: disable=function-redefined, no-self-use, too-many-arguments
+    def pipe(self,
              op1: Callable[['Observable'], A],
              op2: Callable[[A], B],
              op3: Callable[[B], C],
@@ -238,8 +222,15 @@ class Observable(typing.Observable):
              op7: Callable[[F], G]) -> G:
         ...  # pylint: disable=pointless-statement
 
-    # pylint: disable=function-redefined
-    def pipe(self, *operators: Callable[['Observable'], Any]) -> Any:
+    @overload
+    # pylint: disable=function-redefined, no-self-use
+    def pipe(self,
+             *operators: Callable[['Observable'], 'Observable']
+             ) -> 'Observable':
+        ...  # pylint: disable=pointless-statement
+
+    # pylint: disable=function-redefined, no-self-use
+    def pipe(self, *operators: Callable[['Observable'], Any], **kwargs) -> Any:
         """Compose multiple operators left to right.
 
         Composes zero or more operators into a functional composition.
@@ -254,10 +245,12 @@ class Observable(typing.Observable):
 
         Args:
             operators: Sequence of operators.
+            **kwargs: Ignore this, only present to satisfy mypy type checker.
 
         Returns:
              The composed observable.
         """
+
         from ..pipe import pipe
         return pipe(*operators)(self)
 

--- a/rx/core/pipe.py
+++ b/rx/core/pipe.py
@@ -11,42 +11,28 @@ G = TypeVar('G')
 
 
 @overload
-def pipe(*operators: Callable[['Observable'], 'Observable']) -> Callable[['Observable'], 'Observable']:  # type: ignore
-    """Compose multiple operators left to right.
-
-    Composes zero or more operators into a functional composition. The
-    operators are composed to left to right. A composition of zero
-    operators gives back the source.
-
-    Examples:
-        >>> pipe()(source) == source
-        >>> pipe(f)(source) == f(source)
-        >>> pipe(f, g)(source) == g(f(source))
-        >>> pipe(f, g, h)(source) == h(g(f(source)))
-        ...
-
-    Returns:
-        The composed observable.
-    """
-    ...
-
-@overload
-def pipe() -> Callable[[A], A]:  # pylint: disable=function-redefined
+def pipe() -> Callable[[A], A]:
     ...  # pylint: disable=pointless-statement
 
 
 @overload
-def pipe(op1: Callable[[A], B]) -> Callable[[A], B]:  # pylint: disable=function-redefined
+# pylint: disable=function-redefined
+def pipe(op1: Callable[[A], B]
+         ) -> Callable[[A], B]:
     ...  # pylint: disable=pointless-statement
 
 
 @overload
-def pipe(op1: Callable[[A], B], op2: Callable[[B], C]) -> Callable[[A], C]:  # pylint: disable=function-redefined
+# pylint: disable=function-redefined
+def pipe(op1: Callable[[A], B],
+         op2: Callable[[B], C]
+         ) -> Callable[[A], C]:
     ...  # pylint: disable=pointless-statement
 
 
 @overload
-def pipe(op1: Callable[[A], B],  # pylint: disable=function-redefined
+# pylint: disable=function-redefined
+def pipe(op1: Callable[[A], B],
          op2: Callable[[B], C],
          op3: Callable[[C], D]
          ) -> Callable[[A], D]:
@@ -54,7 +40,8 @@ def pipe(op1: Callable[[A], B],  # pylint: disable=function-redefined
 
 
 @overload
-def pipe(op1: Callable[[A], B],  # pylint: disable=function-redefined
+# pylint: disable=function-redefined
+def pipe(op1: Callable[[A], B],
          op2: Callable[[B], C],
          op3: Callable[[C], D],
          op4: Callable[[D], E]
@@ -63,7 +50,8 @@ def pipe(op1: Callable[[A], B],  # pylint: disable=function-redefined
 
 
 @overload
-def pipe(op1: Callable[[A], B],  # pylint: disable=function-redefined
+# pylint: disable=function-redefined,too-many-arguments
+def pipe(op1: Callable[[A], B],
          op2: Callable[[B], C],
          op3: Callable[[C], D],
          op4: Callable[[D], E],
@@ -73,7 +61,8 @@ def pipe(op1: Callable[[A], B],  # pylint: disable=function-redefined
 
 
 @overload
-def pipe(op1: Callable[[A], B],  # pylint: disable=function-redefined,too-many-arguments
+# pylint: disable=function-redefined,too-many-arguments
+def pipe(op1: Callable[[A], B],
          op2: Callable[[B], C],
          op3: Callable[[C], D],
          op4: Callable[[D], E],
@@ -83,8 +72,16 @@ def pipe(op1: Callable[[A], B],  # pylint: disable=function-redefined,too-many-a
     ...  # pylint: disable=pointless-statement
 
 
+@overload
+# pylint: disable=function-redefined,too-many-arguments
+def pipe(*operators: Callable[['Observable'], 'Observable']  # type: ignore
+         ) -> Callable[['Observable'], 'Observable']:        # type: ignore
+
+    ...  # pylint: disable=pointless-statement
+
+
 # pylint: disable=function-redefined
-def pipe(*operators: Callable[[Any], Any]) -> Callable[[Any], Any]:
+def pipe(*operators: Callable[[Any], Any], **kwargs) -> Callable[[Any], Any]:
     """Compose multiple operators left to right.
 
     Composes zero or more operators into a functional composition. The
@@ -97,6 +94,10 @@ def pipe(*operators: Callable[[Any], Any]) -> Callable[[Any], Any]:
         >>> pipe(f, g)(source) == g(f(source))
         >>> pipe(f, g, h)(source) == h(g(f(source)))
         ...
+
+    Args:
+        operators: Sequence of operators.
+        **kwargs: Ignore this, only present to satisfy mypy type checker.
 
     Returns:
         The composed observable.


### PR DESCRIPTION
It took me a while to figure out what mypy was expecting, precisely, with the overload pattern used in `rx.core.observable.Observable.pipe` and `rx.core.pipe`. Eventually, I found that if the variant of the function which actually implements the logic (the one without the `overload` annotation) has a positional variadic argument `*args` then it must also have a variadic keyword argument `**kwargs`.

Not sure why that is the case, but I have it from one of the authors. Anyway, adding `**kwargs` did made the mypy errors disappear.

But I guess it would be better to somehow prevent those bogus `**kwargs` from showing up in the documentation, so I've made a very simple [sphinx extension](https://github.com/erikkemperman/sphinxcontrib-autodoc-filterparams) which allows to hide designated arguments.