### PR TITLE
Removed __slots__ from rx.scheduler.currentthreadscheduler._Local.

### DIFF
--- a/rx/scheduler/currentthreadscheduler.py
+++ b/rx/scheduler/currentthreadscheduler.py
@@ -32,7 +32,6 @@ class Trampoline(object):
 
 
 class _Local(threading.local):
-    __slots__ = 'idle', 'queue'
 
     def __init__(self) -> None:
         super().__init__()


### PR DESCRIPTION
This prevented idle and queue from being thread-local.
https://github.com/python/cpython/blob/v3.7.3/Lib/_threading_local.py#L107