### PR TITLE
Merge scan

### DIFF
--- a/rx/core/operators/merge_scan.py
+++ b/rx/core/operators/merge_scan.py
@@ -1,0 +1,83 @@
+from typing import Any, Callable
+
+from rx import defer, from_future, of
+from rx.core import Observable
+from rx.core.typing import Accumulator
+from rx.disposable import CompositeDisposable, SingleAssignmentDisposable
+from rx.internal.concurrency import synchronized
+from rx.internal.utils import NotSet, is_future
+
+
+def _merge_scan(accumulator: Accumulator, seed: Any = NotSet) -> Callable[[Observable], Observable]:
+
+    def merge_scan(source: Observable) -> Observable:
+        """Partially applied merge_scan operator.
+
+        Applies an accumulator function, which returns an observable sequence,
+        over an observable sequence and returns each intermediate result.
+
+        Examples:
+            >>> scanned = merge_scan(source)
+
+        Args:
+            source: The observable source to scan.
+
+        Returns:
+            An observable sequence containing the accumulated values.
+        """
+        def subscribe(observer, scheduler=None):
+            accumulator_value = [seed]
+            active = [False]
+            group = CompositeDisposable()
+            is_stopped = [False]
+            queue = []
+
+            def subscribe(xs):
+                subscription = SingleAssignmentDisposable()
+                group.add(subscription)
+
+                @synchronized(source.lock)
+                def on_next(next_accumulator_value):
+                    accumulator_value[0] = next_accumulator_value
+                    observer.on_next(next_accumulator_value)
+
+                @synchronized(source.lock)
+                def on_completed():
+                    group.remove(subscription)
+                    if queue:
+                        s = queue.pop(0)
+                        subscribe(s)
+                    else:
+                        active[0] = False
+                        if is_stopped[0]:
+                            observer.on_completed()
+
+                on_error = synchronized(source.lock)(observer.on_error)
+                subscription.disposable = xs.subscribe_(on_next, on_error, on_completed, scheduler)
+
+            def on_next(value):
+                def accumulate():
+                    has_accumulator_value = accumulator_value[0] is not NotSet
+                    if has_accumulator_value:
+                        acc_source = accumulator(accumulator_value[0], value)
+                        return from_future(acc_source) if is_future(acc_source) else acc_source
+                    else:
+                        return of(value)
+
+                accumulator_source = defer(lambda _: accumulate())
+                if not active[0]:
+                    active[0] = True
+                    subscribe(accumulator_source)
+                else:
+                    queue.append(accumulator_source)
+
+            def on_completed():
+                is_stopped[0] = True
+                if not active[0]:
+                    observer.on_completed()
+
+            group.add(source.subscribe_(on_next, observer.on_error, on_completed, scheduler))
+            return group
+        return Observable(subscribe)
+    return merge_scan
+

--- a/rx/operators/__init__.py
+++ b/rx/operators/__init__.py
@@ -1621,6 +1621,40 @@ def merge_all() -> Callable[[Observable], Observable]:
     return _merge_all()
 
 
+def merge_scan(accumulator: Accumulator, seed: Any = NotSet) -> Callable[[Observable], Observable]:
+    """The merge_scan operator.
+
+    Applies an accumulator function over an observable sequence, where
+    the accumulator function itself returns an observable sequence, and
+    returns each intermediate result. The optional seed value is used
+    as the initial accumulator value. For accumulator not returning an
+    observable sequence, see `scan()`.
+
+    .. marble::
+        :alt: merge_scan
+
+        ----1--2--3--4-----|
+        [merge_scan(acc,i: acc+i)]
+        ----1--3--6--10----|
+
+    Examples:
+        >>> scanned = source.scan(lambda acc, x: of(acc + x))
+        >>> scanned = source.scan(lambda acc, x: of(acc + x), 0)
+
+    Args:
+        accumulator: An accumulator function to be invoked on each
+            element, returning an observable sequence.
+        seed: [Optional] The initial accumulator value.
+
+    Returns:
+        A partially applied operator function that takes an observable
+        source and returns an observable sequence containing the
+        accumulated values.
+    """
+    from rx.core.operators.merge_scan import _merge_scan
+    return _merge_scan(accumulator, seed)
+
+
 def min(comparer: Optional[Comparer] = None) -> Callable[[Observable], Observable]:
     """The `min` operator.
 

--- a/rx/testing/__init__.py
+++ b/rx/testing/__init__.py
@@ -1,4 +1,5 @@
 from .testscheduler import TestScheduler
+from .testsubscriber import TestSubscriber
 from .reactivetest import OnNextPredicate, OnErrorPredicate, ReactiveTest, is_prime
 from .mockdisposable import MockDisposable
 from .recorded import Recorded

--- a/rx/testing/testsubscriber.py
+++ b/rx/testing/testsubscriber.py
@@ -1,0 +1,35 @@
+import threading
+
+from rx import Observable
+from rx.core.notification import OnCompleted, OnError, OnNext
+from rx.scheduler import VirtualTimeScheduler
+from rx.testing import TestScheduler
+from rx.testing.recorded import Recorded
+
+
+class TestSubscriber(object):
+    def __init__(self, observable: Observable, scheduler: VirtualTimeScheduler = TestScheduler()) -> None:
+        super().__init__()
+        self.completed = threading.Event()
+        self.messages = []
+
+        def on_next(value) -> None:
+            self.messages.append(Recorded(scheduler.clock, OnNext(value)))
+
+        def on_error(error) -> None:
+            self.messages.append(Recorded(scheduler.clock, OnError(error)))
+            self.completed.set()
+
+        def on_completed() -> None:
+            self.messages.append(Recorded(scheduler.clock, OnCompleted()))
+            self.completed.set()
+
+        observable.subscribe(
+            on_next=on_next,
+            on_error=on_error,
+            on_completed=on_completed
+        )
+
+    def results(self):
+        self.completed.wait(timeout=0.1)
+        return self.messages

--- a/tests/test_observable/test_merge_scan.py
+++ b/tests/test_observable/test_merge_scan.py
@@ -1,0 +1,182 @@
+import unittest
+import pytest
+
+from rx import from_list, never, of, operators as _
+from rx.testing import ReactiveTest, TestScheduler, TestSubscriber
+
+on_next = ReactiveTest.on_next
+on_completed = ReactiveTest.on_completed
+on_error = ReactiveTest.on_error
+subscribe = ReactiveTest.subscribe
+subscribed = ReactiveTest.subscribed
+disposed = ReactiveTest.disposed
+created = ReactiveTest.created
+
+
+class TestScan(unittest.TestCase):
+
+    def test_merge_scan_seed_never(self):
+        scheduler = TestScheduler()
+        seed = 42
+
+        def create():
+            def func(acc, x):
+                return of(acc + x)
+
+            return never().pipe(_.merge_scan(seed=seed, accumulator=func))
+
+        results = scheduler.start(create)
+        assert results.messages == []
+
+    def test_merge_scan_seed_empty(self):
+        scheduler = TestScheduler()
+        seed = 42
+        xs = scheduler.create_hot_observable(on_next(150, 1), on_completed(250))
+
+        def create():
+            return xs.pipe(_.merge_scan(lambda acc, x: of(acc + x), seed=seed))
+
+        results = scheduler.start(create).messages
+        assert (len(results) == 1)
+        assert (results[0].value.kind == 'C' and results[0].time == 250)
+
+    def test_merge_scan_seed_return(self):
+        scheduler = TestScheduler()
+        seed = 42
+        xs = scheduler.create_hot_observable(on_next(150, 1), on_next(220, 2), on_completed(250))
+
+        def create():
+            return xs.pipe(_.merge_scan(lambda acc, x: of(acc + x), seed=seed))
+
+        results = scheduler.start(create).messages
+        assert (len(results) == 2)
+        assert (results[0].value.kind == 'N' and results[0].value.value == seed + 2 and results[0].time == 220)
+        assert (results[1].value.kind == 'C' and results[1].time == 250)
+
+    def test_merge_scan_seed_on_error(self):
+        ex = 'ex'
+        scheduler = TestScheduler()
+        seed = 42
+        xs = scheduler.create_hot_observable(on_next(150, 1), on_error(250, ex))
+
+        def create():
+            return xs.pipe(_.merge_scan(seed, lambda acc, x: of(acc + x)))
+
+        results = scheduler.start(create).messages
+        assert (len(results) == 1)
+        assert (results[0].value.kind == 'E' and results[0].value.exception == ex and results[0].time == 250)
+
+    def test_merge_scan_seed_somedata(self):
+        scheduler = TestScheduler()
+        seed = 1
+        xs = scheduler.create_hot_observable(on_next(150, 1), on_next(210, 2), on_next(
+            220, 3), on_next(230, 4), on_next(240, 5), on_completed(250))
+
+        def create():
+            return xs.pipe(_.merge_scan(lambda acc, x: of(acc + x), seed=seed))
+
+        results = scheduler.start(create).messages
+        assert (len(results) == 5)
+        assert (results[0].value.kind == 'N' and results[0].value.value == seed + 2 and results[0].time == 210)
+        assert (results[1].value.kind == 'N' and results[1].value.value == seed + 2 + 3 and results[1].time == 220)
+        assert (results[2].value.kind == 'N' and results[2].value.value == seed + 2 + 3 + 4 and results[2].time == 230)
+        assert (results[3].value.kind == 'N' and results[3].value.value ==
+                seed + 2 + 3 + 4 + 5 and results[3].time == 240)
+        assert (results[4].value.kind == 'C' and results[4].time == 250)
+
+    def test_merge_scan_noseed_never(self):
+        scheduler = TestScheduler()
+
+        def create():
+            return never().pipe(_.merge_scan(lambda acc, x: of(acc + x)))
+
+        results = scheduler.start(create)
+        assert results.messages == []
+
+    def test_merge_scan_noseed_empty(self):
+        scheduler = TestScheduler()
+        xs = scheduler.create_hot_observable(on_next(150, 1), on_completed(250))
+
+        def create():
+            return xs.pipe(_.merge_scan(lambda acc, x: of(acc + x)))
+
+        results = scheduler.start(create).messages
+        assert len(results) == 1
+        assert results[0].value.kind == 'C' and results[0].time == 250
+
+    def test_merge_scan_noseed_return(self):
+        scheduler = TestScheduler()
+        xs = scheduler.create_hot_observable(on_next(150, 1), on_next(220, 2), on_completed(250))
+
+        def create():
+            def func(acc, x):
+                if acc is None:
+                    acc = 0
+                return of(acc + x)
+
+            return xs.pipe(_.merge_scan(accumulator=func))
+
+        results = scheduler.start(create).messages
+        assert len(results) == 2
+        assert results[0].value.kind == 'N' and results[0].time == 220 and results[0].value.value == 2
+        assert results[1].value.kind == 'C' and results[1].time == 250
+
+    def test_merge_scan_noseed_on_error(self):
+        ex = 'ex'
+        scheduler = TestScheduler()
+        xs = scheduler.create_hot_observable(on_next(150, 1), on_error(250, ex))
+
+        def create():
+            def func(acc, x):
+                if acc is None:
+                    acc = 0
+
+                return of(acc + x)
+
+            return xs.pipe(_.merge_scan(func))
+
+        results = scheduler.start(create).messages
+        assert len(results) == 1
+        assert results[0].value.kind == 'E' and results[0].time == 250 and results[0].value.exception == ex
+
+    def test_merge_scan_noseed_somedata(self):
+        scheduler = TestScheduler()
+        xs = scheduler.create_hot_observable(on_next(150, 1), on_next(210, 2), on_next(
+            220, 3), on_next(230, 4), on_next(240, 5), on_completed(250))
+
+        def create():
+            def func(acc, x):
+                if acc is None:
+                    acc = 0
+                return of(acc + x)
+
+            return xs.pipe(_.merge_scan(func))
+
+        results = scheduler.start(create).messages
+        assert len(results) == 5
+        assert results[0].value.kind == 'N' and results[0].time == 210 and results[0].value.value == 2
+        assert results[1].value.kind == 'N' and results[1].time == 220 and results[1].value.value == 2 + 3
+        assert results[2].value.kind == 'N' and results[2].time == 230 and results[2].value.value == 2 + 3 + 4
+        assert results[3].value.kind == 'N' and results[3].time == 240 and results[3].value.value == 2 + 3 + 4 + 5
+        assert results[4].value.kind == 'C' and results[4].time == 250
+
+    def test_merge_scan_concurrent(self):
+        accumulator_calls = [0]
+
+        def accumulator(acc, x):
+            accumulator_calls[0] += 1
+            return of(acc + x)
+
+        xs = from_list([1, 2, 3, 4, 5]).pipe(
+            _.merge_scan(accumulator, seed=0)
+        )
+
+        results = TestSubscriber(xs).results()
+        assert len(results) == 6
+        assert results[0].value.kind == 'N' and results[0].value.value == 1
+        assert results[1].value.kind == 'N' and results[1].value.value == 1 + 2
+        assert results[2].value.kind == 'N' and results[2].value.value == 1 + 2 + 3
+        assert results[3].value.kind == 'N' and results[3].value.value == 1 + 2 + 3 + 4
+        assert results[4].value.kind == 'N' and results[4].value.value == 1 + 2 + 3 + 4 + 5
+        assert results[5].value.kind == 'C'
+        assert accumulator_calls[0] == 5  # Accumulator os not called more often than needed


### PR DESCRIPTION
Implemented merge_scan operator. This operator follows the semantics from RxJS [mergeScan](https://rxjs-dev.firebaseapp.com/api/operators/mergeScan). 

I failed to implement this using existing operators. Using scan with an observable seed and an accumulator returning an observable causes the accumulator to be called more often than needed. The implementation is based on existing merge, with some minor tweaks to invoke the accumulator. This caused some code duplication. It's probably possible to come up with some  abstraction solving this, but I didn't want to make more changes than needed in existing code.

Note that I didn't add a max_concurrent option, which RxJS mergeScan does. I fail to understand what such an option would actually do. There are no inner sources to subscribe to, and the accumulator is strictly dependent on the result of previous call.

I created a test-suite with the same tests as for scan. There where some cases I couldn't figure out how to test this properly using the TestScheduler though, so I implemented a TestSubscriber, which subscribes to a regular observable and collects and expose messages. Maybe that was a bit intrusive, but at least it keeps the test-coverage up.