### PR TITLE
Add missing project.cfg to manifest

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 include LICENSE
+include project.cfg

--- a/project.cfg
+++ b/project.cfg
@@ -2,7 +2,7 @@
 name = Rx
 project = RxPY
 # Please make sure the version here remains the same as in rx/__init__.py
-version = 3.0.0
+version = 3.0.1
 description = Reactive Extensions (Rx) for Python
 author = Dag Brattli
 author_email = dag@brattli.net

--- a/rx/__init__.py
+++ b/rx/__init__.py
@@ -8,7 +8,7 @@ from .internal.utils import alias
 
 
 # Please make sure the version here remains the same as in project.cfg
-__version__ = '3.0.0'
+__version__ = '3.0.1'
 
 
 def amb(*sources: Observable) -> Observable:


### PR DESCRIPTION
Looks like the release tar file for v3 is broken by missing project.cfg. Making a new release that included the file to the manifest.