### PR TITLE
AsyncIOScheduler: add a method to retrieve event loop

### DIFF
--- a/rx/scheduler/eventloop/asyncioscheduler.py
+++ b/rx/scheduler/eventloop/asyncioscheduler.py
@@ -28,6 +28,9 @@ class AsyncIOScheduler(PeriodicScheduler):
         super().__init__()
         self._loop: asyncio.AbstractEventLoop = loop
 
+    def get_event_loop(self) -> asyncio.AbstractEventLoop:
+        return self._loop
+
     def schedule(self,
                  action: typing.ScheduledAction,
                  state: Optional[typing.TState] = None

--- a/tests/test_scheduler/test_eventloop/test_asyncioscheduler.py
+++ b/tests/test_scheduler/test_eventloop/test_asyncioscheduler.py
@@ -82,3 +82,9 @@ class TestAsyncIOScheduler(unittest.TestCase):
             assert ran is False
 
         loop.run_until_complete(go())
+
+    def test_asyncio_get_event_loop(self):
+        loop = asyncio.get_event_loop()
+        scheduler = AsyncIOScheduler(loop)
+        scheduler_loop = scheduler.get_event_loop()
+        assert loop is scheduler_loop


### PR DESCRIPTION
This commit adds a getter to retrieve the event loop from a, asyncio scheduler. This is typically useful when using some asyncio code/library in a subscription function. 
We could also add such getters in the other eventloop schedulers. 