### PR TITLE
Fixed await on Observable that schedules later

### DIFF
--- a/rx/core/observable/observable.py
+++ b/rx/core/observable/observable.py
@@ -1,9 +1,11 @@
 # By design, pylint: disable=C0302
 import threading
+import asyncio
 from typing import Any, Callable, Optional, Union, TypeVar, cast, overload
 
 from rx.disposable import Disposable
 from rx.scheduler import CurrentThreadScheduler
+from rx.scheduler.eventloop import AsyncIOScheduler
 
 from ..observer import AutoDetachObserver
 from .. import typing, abc
@@ -290,7 +292,8 @@ class Observable(typing.Observable):
             The last item of the observable sequence.
         """
         from ..operators.tofuture import _to_future
-        return iter(self.pipe(_to_future()))
+        loop = asyncio.get_event_loop()
+        return iter(self.pipe(_to_future(scheduler=AsyncIOScheduler(loop=loop))))
 
     def __add__(self, other) -> 'Observable':
         """Pythonic version of :func:`concat <rx.concat>`.

--- a/rx/core/operators/tofuture.py
+++ b/rx/core/operators/tofuture.py
@@ -1,11 +1,13 @@
 from typing import Callable, Optional
 from asyncio import Future
 
+from .. import typing
 from rx.core import Observable
 from rx.internal.exceptions import SequenceContainsNoElementsError
 
 
-def _to_future(future_ctor: Optional[Callable[[], Future]] = None) -> Callable[[Observable], Future]:
+def _to_future(future_ctor: Optional[Callable[[], Future]] = None,
+               scheduler: Optional[typing.Scheduler] = None) -> Callable[[Observable], Future]:
     future_ctor = future_ctor or Future
     future = future_ctor()
 
@@ -44,7 +46,7 @@ def _to_future(future_ctor: Optional[Callable[[], Future]] = None) -> Callable[[
             else:
                 future.set_exception(SequenceContainsNoElementsError())
 
-        source.subscribe_(on_next, on_error, on_completed)
+        source.subscribe_(on_next, on_error, on_completed, scheduler=scheduler)
 
         # No cancellation can be done
         return future

--- a/tests/test_observable/test_tofuture.py
+++ b/tests/test_observable/test_tofuture.py
@@ -3,6 +3,7 @@ import unittest
 import asyncio
 
 import rx
+import rx.operators as ops
 from rx.internal.exceptions import SequenceContainsNoElementsError
 from rx.testing import ReactiveTest
 
@@ -66,3 +67,15 @@ class TestToFuture(unittest.TestCase):
             result = await source
 
         self.assertRaises(SequenceContainsNoElementsError, loop.run_until_complete, go())
+
+    def test_await_with_delay(self):
+        loop = asyncio.get_event_loop()
+        result = None
+
+        async def go():
+            nonlocal result
+            source = rx.return_value(42).pipe(ops.delay(0.1))
+            result = await source
+
+        loop.run_until_complete(go())
+        assert result == 42


### PR DESCRIPTION
In the current implementation, tofuture does not provide a scheduler
when subscribing to the Observable. As a consequence, when used from
await,  if the Observable chain uses an operator that deals with time,
a deadlock occurs because we try to complete the - asyncio - future
from another thread than the mainloop.

In __await__ we can provide an AsyncioScheduler associated to the
current event loop because it is always called from the context of the
current event loop.

Fixes #456