### PR TITLE
Enhancement: group_by and group_by_until subject mapper

### DIFF
--- a/rx/core/operators/groupby.py
+++ b/rx/core/operators/groupby.py
@@ -4,13 +4,15 @@ import rx
 from rx import operators as ops
 from rx.core import Observable
 from rx.core.typing import Mapper
+from rx.subject import Subject
 
 
 def _group_by(key_mapper: Mapper,
-              element_mapper: Optional[Mapper] = None
+              element_mapper: Optional[Mapper] = None,
+              subject_mapper: Optional[Callable[[], Subject]] = None,
               ) -> Callable[[Observable], Observable]:
 
     def duration_mapper(_):
         return rx.never()
 
-    return ops.group_by_until(key_mapper, element_mapper, duration_mapper)
+    return ops.group_by_until(key_mapper, element_mapper, duration_mapper, subject_mapper)

--- a/rx/core/operators/groupbyuntil.py
+++ b/rx/core/operators/groupbyuntil.py
@@ -41,7 +41,7 @@ def _group_by_until(key_mapper: Mapper,
 
     element_mapper = element_mapper or identity
 
-    default_subject_mapper = lambda: Subject()
+    default_subject_mapper = Subject
     subject_mapper = subject_mapper or default_subject_mapper
 
     def group_by_until(source: Observable) -> Observable:

--- a/rx/core/operators/groupbyuntil.py
+++ b/rx/core/operators/groupbyuntil.py
@@ -24,10 +24,13 @@ def _group_by_until(key_mapper: Mapper,
     Examples:
         >>> group_by_until(lambda x: x.id, None, lambda : rx.never())
         >>> group_by_until(lambda x: x.id,lambda x: x.name, lambda grp: rx.never())
+        >>> group_by_until(lambda x: x.id, lambda x: x.name, lambda grp: rx.never(), lambda: ReplaySubject())
 
     Args:
         key_mapper: A function to extract the key for each element.
         duration_mapper: A function to signal the expiration of a group.
+        subject_mapper: A function that returns a subject used to initiate
+            a grouped observable. Default mapper returns a Subject object.
 
     Returns: a sequence of observable groups, each of which corresponds to
     a unique key value, containing all elements that share that same key

--- a/rx/operators/__init__.py
+++ b/rx/operators/__init__.py
@@ -1198,11 +1198,14 @@ def group_by(key_mapper: Mapper,
     Examples:
         >>> group_by(lambda x: x.id)
         >>> group_by(lambda x: x.id, lambda x: x.name)
+        >>> group_by(lambda x: x.id, lambda x: x.name, lambda: ReplaySubject())
 
     Keyword arguments:
         key_mapper: A function to extract the key for each element.
         element_mapper: [Optional] A function to map each source
             element to an element in an observable group.
+        subject_mapper: A function that returns a subject used to initiate
+            a grouped observable. Default mapper returns a Subject object.
 
     Returns:
         An operator function that takes an observable source and
@@ -1230,7 +1233,7 @@ def group_by_until(key_mapper: Mapper,
         :alt: group_by_until
 
         --1--2--a--3--b--c-|
-        [    group_by()    ]
+        [ group_by_until() ]
         -+-----+-----------|
                +a-----b--c-|
          +1--2-----3-------|
@@ -1238,12 +1241,15 @@ def group_by_until(key_mapper: Mapper,
     Examples:
         >>> group_by_until(lambda x: x.id, None, lambda : rx.never())
         >>> group_by_until(lambda x: x.id, lambda x: x.name, lambda grp: rx.never())
+        >>> group_by_until(lambda x: x.id, lambda x: x.name, lambda grp: rx.never(), lambda: ReplaySubject())
 
     Args:
         key_mapper: A function to extract the key for each element.
         element_mapper: A function to map each source element to an element in
             an observable group.
         duration_mapper: A function to signal the expiration of a group.
+        subject_mapper: A function that returns a subject used to initiate
+            a grouped observable. Default mapper returns a Subject object.
 
     Returns:
         An operator function that takes an observable source and

--- a/rx/operators/__init__.py
+++ b/rx/operators/__init__.py
@@ -1179,7 +1179,8 @@ def flat_map_latest(mapper: Mapper) -> Callable[[Observable], Observable]:
 
 
 def group_by(key_mapper: Mapper,
-             element_mapper: Optional[Mapper] = None
+             element_mapper: Optional[Mapper] = None,
+             subject_mapper: Optional[Callable[[], Subject]] = None,
              ) -> Callable[[Observable], Observable]:
     """Groups the elements of an observable sequence according to a
     specified key mapper function and comparer and selects the
@@ -1210,12 +1211,13 @@ def group_by(key_mapper: Mapper,
         share that same key value.
     """
     from rx.core.operators.groupby import _group_by
-    return _group_by(key_mapper, element_mapper)
+    return _group_by(key_mapper, element_mapper, subject_mapper)
 
 
 def group_by_until(key_mapper: Mapper,
                    element_mapper: Optional[Mapper],
                    duration_mapper: Callable[[GroupedObservable], Observable],
+                   subject_mapper: Optional[Callable[[], Subject]] = None,
                    ) -> Callable[[Observable], Observable]:
     """Groups the elements of an observable sequence according to a
     specified key mapper function. A duration mapper function is used
@@ -1252,7 +1254,7 @@ def group_by_until(key_mapper: Mapper,
         with such a key value is encountered.
     """
     from rx.core.operators.groupbyuntil import _group_by_until
-    return _group_by_until(key_mapper, element_mapper, duration_mapper)
+    return _group_by_until(key_mapper, element_mapper, duration_mapper, subject_mapper)
 
 
 def group_join(right: Observable,

--- a/tests/test_observable/test_groupby.py
+++ b/tests/test_observable/test_groupby.py
@@ -637,6 +637,8 @@ class TestGroupBy(unittest.TestCase):
         scheduler.schedule_absolute(600, subscription_even)
         scheduler.advance_to(1100)
 
+        # only the last 2 items of odd/even are received because the
+        # ReplaySubject has been configured with a buffer size of 2
         assert observer_odd.messages == [
             on_next(500, 3),
             on_next(500, 5),


### PR DESCRIPTION
This PR adds a new parameter `subject_mapper` to operators `group_by` and `group_by_until`.
The purpose of this is to allow the end-user to specify a specialized subject that will be used to push elements for each grouped observable. This factory should be implemented as a function that returns a Subject object.

This is especially useful when chaining `group_by` with `to_iterable`, where a `ReplaySubject` is mandatory instead of a `Subject`. More details in #467 
Example:
```python
rx.of(1, 2, 3, 4, 5, 6).pipe(
    ops.group_by(lambda x: x % 2, subject_mapper=lambda: ReplaySubject())
    ops.to_iterable(),
    ops.flat_map(lambda groups: rx.from_list(groups)), 
    ops.flat_map(lambda group: group),
    ...
```
I've tried to keep theses changes aligned with rxjs6 as much as possible:
https://github.com/ReactiveX/rxjs/blob/master/src/internal/operators/groupBy.ts#L105


More readings from rxjs:
https://github.com/ReactiveX/rxjs/issues/2028
https://github.com/ReactiveX/rxjs/issues/1945