### PR TITLE
Fix catch_with_iterable: wrong scheduler used to subscribe to the upstream source

### DIFF
--- a/rx/core/observable/catch.py
+++ b/rx/core/observable/catch.py
@@ -31,12 +31,13 @@ def _catch_with_iterable(sources: Iterable[Observable]) -> Observable:
 
         subscription = SerialDisposable()
         cancelable = SerialDisposable()
-        last_exception = [None]
-        is_disposed = []
+        last_exception = None
+        is_disposed = False
 
         def action(action1, state=None):
             def on_error(exn):
-                last_exception[0] = exn
+                nonlocal last_exception
+                last_exception = exn
                 cancelable.disposable = _scheduler.schedule(action)
 
             if is_disposed:
@@ -45,8 +46,8 @@ def _catch_with_iterable(sources: Iterable[Observable]) -> Observable:
             try:
                 current = next(sources_)
             except StopIteration:
-                if last_exception[0]:
-                    observer.on_error(last_exception[0])
+                if last_exception:
+                    observer.on_error(last_exception)
                 else:
                     observer.on_completed()
             except Exception as ex:  # pylint: disable=broad-except
@@ -59,6 +60,7 @@ def _catch_with_iterable(sources: Iterable[Observable]) -> Observable:
         cancelable.disposable = _scheduler.schedule(action)
 
         def dispose():
-            is_disposed.append(True)
+            nonlocal is_disposed
+            is_disposed= True
         return CompositeDisposable(subscription, cancelable, Disposable(dispose))
     return Observable(subscribe)

--- a/rx/core/observable/catch.py
+++ b/rx/core/observable/catch.py
@@ -26,8 +26,8 @@ def _catch_with_iterable(sources: Iterable[Observable]) -> Observable:
 
     sources_ = iter(sources)
 
-    def subscribe(observer, scheduler=None):
-        scheduler = scheduler or CurrentThreadScheduler.singleton()
+    def subscribe(observer, scheduler_=None):
+        _scheduler = scheduler_ or CurrentThreadScheduler.singleton()
 
         subscription = SerialDisposable()
         cancelable = SerialDisposable()
@@ -37,7 +37,7 @@ def _catch_with_iterable(sources: Iterable[Observable]) -> Observable:
         def action(action1, state=None):
             def on_error(exn):
                 last_exception[0] = exn
-                cancelable.disposable = scheduler.schedule(action)
+                cancelable.disposable = _scheduler.schedule(action)
 
             if is_disposed:
                 return
@@ -54,9 +54,9 @@ def _catch_with_iterable(sources: Iterable[Observable]) -> Observable:
             else:
                 d = SingleAssignmentDisposable()
                 subscription.disposable = d
-                d.disposable = current.subscribe_(observer.on_next, on_error, observer.on_completed, scheduler)
+                d.disposable = current.subscribe_(observer.on_next, on_error, observer.on_completed, scheduler_)
 
-        cancelable.disposable = scheduler.schedule(action)
+        cancelable.disposable = _scheduler.schedule(action)
 
         def dispose():
             is_disposed.append(True)


### PR DESCRIPTION
This PR fixes `catch_with_iterable` which actually does not forward the downstream scheduler to the upstream observable. This should fix #476.

As a bonus, I've converted the list-hack to `nonlocal` statements. Also I've tried to enforce the naming convention that we had with some other operators, i.e.:
- `scheduler`: scheduler given at declaration time (if any)
- `scheduler_`: scheduler coming from the downstream subscribe
- `_scheduler`: operator scheduler