### PR TITLE
Fix missing default scheduler in timer operator 

### DIFF
--- a/rx/core/observable/timer.py
+++ b/rx/core/observable/timer.py
@@ -8,7 +8,7 @@ from rx.disposable import MultipleAssignmentDisposable
 
 def observable_timer_date(duetime, scheduler: Optional[typing.Scheduler] = None):
     def subscribe(observer, scheduler_=None):
-        _scheduler = scheduler or scheduler_
+        _scheduler = scheduler or scheduler_ or TimeoutScheduler.singleton()
 
         def action(scheduler, state):
             observer.on_next(0)

--- a/rx/core/observable/timer.py
+++ b/rx/core/observable/timer.py
@@ -28,20 +28,23 @@ def observable_timer_duetime_and_period(duetime, period, scheduler: Optional[typ
 
         p = max(0.0, _scheduler.to_seconds(period))
         mad = MultipleAssignmentDisposable()
-        dt = [duetime]
-        count = [0]
+        dt = duetime
+        count = 0
 
         def action(scheduler, state):
+            nonlocal dt
+            nonlocal count
+
             if p > 0.0:
                 now = scheduler.now
-                dt[0] = dt[0] + scheduler.to_timedelta(p)
-                if dt[0] <= now:
-                    dt[0] = now + scheduler.to_timedelta(p)
+                dt = dt + scheduler.to_timedelta(p)
+                if dt <= now:
+                    dt = now + scheduler.to_timedelta(p)
 
-            observer.on_next(count[0])
-            count[0] += 1
-            mad.disposable = scheduler.schedule_absolute(dt[0], action)
-        mad.disposable = _scheduler.schedule_absolute(dt[0], action)
+            observer.on_next(count)
+            count += 1
+            mad.disposable = scheduler.schedule_absolute(dt, action)
+        mad.disposable = _scheduler.schedule_absolute(dt, action)
         return mad
     return Observable(subscribe)
 

--- a/tests/test_observable/test_timer.py
+++ b/tests/test_observable/test_timer.py
@@ -22,6 +22,44 @@ def _raise(ex):
 
 
 class TestTimer(unittest.TestCase):
+    def test_oneshot_timer_date_basic(self):
+        scheduler = TestScheduler()
+        date = scheduler.to_datetime(250.0)
+
+        def create():
+            return rx.timer(duetime=date)
+
+        results = scheduler.start(create)
+        assert results.messages == [on_next(250.0, 0), on_completed(250.0)]
+
+    def test_oneshot_timer_date_passed(self):
+        scheduler = TestScheduler()
+        date = scheduler.to_datetime(90.0)
+
+        def create():
+            return rx.timer(date)
+
+        results = scheduler.start(create)
+        assert results.messages == [on_next(200, 0), on_completed(200)]
+
+    def test_oneshot_timer_date_disposed(self):
+        scheduler = TestScheduler()
+        date = scheduler.to_datetime(1010.0)
+
+        def create():
+            return rx.timer(date)
+
+        results = scheduler.start(create)
+        assert results.messages == []
+
+    def test_oneshot_timer_date_observer_throws(self):
+        scheduler = TestScheduler()
+        date = scheduler.to_datetime(250.0)
+        xs = rx.timer(date)
+        xs.subscribe(lambda x: _raise("ex"), scheduler=scheduler)
+
+        self.assertRaises(RxException, scheduler.start)
+
     def test_oneshot_timer_timespan_basic(self):
         scheduler = TestScheduler()
 


### PR DESCRIPTION
This PR adds a default scheduler (TimeoutScheduler) to  `timer` operator when one wants to trigger oneshot with a datetime. Under the hood, `observable_timer_date` is in charge of this particular configuration.

### Example:
```python
from datetime import datetime, timedelta
import rx
from rx import operators as ops

date = datetime.utcnow() + timedelta(seconds=1)

rx.timer(duetime=date).pipe(
    ops.do_action(
        lambda x: print(f'next:{x}'),
        lambda: print('complete'),
    )
).run()
``` 

### Bonus: 
- basic tests. Unfortunately, they don't test this case
- nonlocal statements
