### PR TITLE
Fix concat:  subscribe scheduler not forwarded  + sources iterable exhaustion 

### DIFF
--- a/rx/core/observable/concat.py
+++ b/rx/core/observable/concat.py
@@ -8,11 +8,9 @@ from rx.scheduler import CurrentThreadScheduler
 
 def _concat_with_iterable(sources: Iterable[Observable]) -> Observable:
 
-    sources_ = iter(sources)
-
     def subscribe(observer, scheduler_=None):
         _scheduler = scheduler_ or CurrentThreadScheduler.singleton()
-
+        sources_ = iter(sources)
         subscription = SerialDisposable()
         cancelable = SerialDisposable()
         is_disposed = False

--- a/rx/core/observable/concat.py
+++ b/rx/core/observable/concat.py
@@ -10,8 +10,8 @@ def _concat_with_iterable(sources: Iterable[Observable]) -> Observable:
 
     sources_ = iter(sources)
 
-    def subscribe(observer, scheduler=None):
-        scheduler = scheduler or CurrentThreadScheduler.singleton()
+    def subscribe(observer, scheduler_=None):
+        _scheduler = scheduler_ or CurrentThreadScheduler.singleton()
 
         subscription = SerialDisposable()
         cancelable = SerialDisposable()
@@ -23,7 +23,7 @@ def _concat_with_iterable(sources: Iterable[Observable]) -> Observable:
                 return
 
             def on_completed():
-                cancelable.disposable = scheduler.schedule(action)
+                cancelable.disposable = _scheduler.schedule(action)
 
             try:
                 current = next(sources_)
@@ -34,9 +34,9 @@ def _concat_with_iterable(sources: Iterable[Observable]) -> Observable:
             else:
                 d = SingleAssignmentDisposable()
                 subscription.disposable = d
-                d.disposable = current.subscribe_(observer.on_next, observer.on_error, on_completed, scheduler)
+                d.disposable = current.subscribe_(observer.on_next, observer.on_error, on_completed, scheduler_)
 
-        cancelable.disposable = scheduler.schedule(action)
+        cancelable.disposable = _scheduler.schedule(action)
 
         def dispose():
             nonlocal is_disposed


### PR DESCRIPTION
This PR fixes the following:
- concat does not forward the subscribe scheduler to the uptream sources. 
- sources iterable is not defined at `subscribe` scope, resulting in iterator exhaustion after the 1st subscription. This is related to #485 

Also this PR enforces the `_scheduler`/`scheduler`/`scheduler_` naming convention.
