### PR TITLE
fix 485

### DIFF
--- a/rx/core/observable/concat.py
+++ b/rx/core/observable/concat.py
@@ -8,10 +8,10 @@ from rx.scheduler import CurrentThreadScheduler
 
 def _concat_with_iterable(sources: Iterable[Observable]) -> Observable:
 
-    sources_ = iter(sources)
-
     def subscribe(observer, scheduler=None):
         scheduler = scheduler or CurrentThreadScheduler.singleton()
+
+        sources_ = iter(sources)
 
         subscription = SerialDisposable()
         cancelable = SerialDisposable()

--- a/tests/test_integration/test_concat_repeat.py
+++ b/tests/test_integration/test_concat_repeat.py
@@ -1,0 +1,17 @@
+import unittest
+
+from rx import operators as ops
+from rx.testing.marbles import marbles_testing
+
+
+class TestConcatIntegration(unittest.TestCase):
+    def test_concat_repeat(self):
+        with marbles_testing() as (start, cold, hot, exp):
+            e1 = cold("-e11-e12|")
+            e2 = cold("-e21-e22|")
+            ex = exp("-e11-e12-e21-e22-e11-e12-e21-e22|")
+
+            obs = e1.pipe(ops.concat(e2), ops.repeat(2))
+
+            results = start(obs)
+            assert results == ex


### PR DESCRIPTION
fix for https://github.com/ReactiveX/RxPY/issues/485
as per @jcafhe  comment https://github.com/ReactiveX/RxPY/issues/485#issuecomment-576574247 moved `sources_` iterator down to `subscribe` scope.