### PR TITLE
Fix ConnectableObservable: scheduler is not forwarded

### DIFF
--- a/rx/core/observable/connectableobservable.py
+++ b/rx/core/observable/connectableobservable.py
@@ -28,7 +28,7 @@ class ConnectableObservable(Observable):
             def dispose():
                 self.has_subscription = False
 
-            subscription = self.source.subscribe(self.subject, scheduler)
+            subscription = self.source.subscribe(self.subject, scheduler=scheduler)
             self.subscription = CompositeDisposable(subscription, Disposable(dispose))
 
         return self.subscription

--- a/tests/test_observable/test_connectableobservable.py
+++ b/tests/test_observable/test_connectableobservable.py
@@ -241,3 +241,19 @@ class TestConnectableObservable(unittest.TestCase):
             subscribe(225, 241),
             subscribe(249, 255),
             subscribe(275, 295)]
+
+    def test_connectable_observable_forward_scheduler(self):
+        scheduler = TestScheduler()
+        subscribe_scheduler = 'unknown'
+
+        def subscribe(observer, scheduler=None):
+            nonlocal subscribe_scheduler
+            subscribe_scheduler = scheduler
+
+        xs = rx.create(subscribe)
+        subject = MySubject()
+
+        conn = ConnectableObservable(xs, subject)
+        conn.connect(scheduler)
+
+        assert subscribe_scheduler is scheduler


### PR DESCRIPTION
This PR fixes `ConnectableObservable.connect(self, scheduler)` method, where the source observable is not subscribed with the downstream subscribe scheduler.

I guess this is related to the fact that scheduler is a keyword argument only, so scheduler must be given as `subscribe(observer, scheduler=scheduler)`, otherwise it will be dismissed.

A simple test case has been added.

This should fix some operators which are based on `connect(scheduler)` method like `ref_count`, and, by extension, to `share`. This should also fix #489.