### PR TITLE
Fix join: subscribe scheduler is not forwarded

### DIFF
--- a/rx/core/operators/join.py
+++ b/rx/core/operators/join.py
@@ -105,7 +105,7 @@ def _join(right: Observable,
                 if left_done[0] or not len(right_map):
                     observer.on_completed()
 
-            group.add(right.subscribe_(on_next_right, observer.on_error, on_completed_right))
+            group.add(right.subscribe_(on_next_right, observer.on_error, on_completed_right, scheduler))
             return group
         return Observable(subscribe)
     return join

--- a/rx/core/operators/join.py
+++ b/rx/core/operators/join.py
@@ -29,17 +29,18 @@ def _join(right: Observable,
 
         def subscribe(observer, scheduler=None):
             group = CompositeDisposable()
-            left_done = [False]
+            left_done = False
             left_map = OrderedDict()
-            left_id = [0]
-            right_done = [False]
+            left_id = 0
+            right_done = False
             right_map = OrderedDict()
-            right_id = [0]
+            right_id = 0
 
             def on_next_left(value):
+                nonlocal left_id
                 duration = None
-                current_id = left_id[0]
-                left_id[0] += 1
+                current_id = left_id
+                left_id += 1
                 md = SingleAssignmentDisposable()
 
                 left_map[current_id] = value
@@ -48,7 +49,7 @@ def _join(right: Observable,
                 def expire():
                     if current_id in left_map:
                         del left_map[current_id]
-                    if not len(left_map) and left_done[0]:
+                    if not len(left_map) and left_done:
                         observer.on_completed()
 
                     return group.remove(md)
@@ -66,16 +67,18 @@ def _join(right: Observable,
                     observer.on_next(result)
 
             def on_completed_left():
-                left_done[0] = True
-                if right_done[0] or not len(left_map):
+                nonlocal left_done
+                left_done = True
+                if right_done or not len(left_map):
                     observer.on_completed()
 
             group.add(left.subscribe_(on_next_left, observer.on_error, on_completed_left, scheduler))
 
             def on_next_right(value):
+                nonlocal right_id
                 duration = None
-                current_id = right_id[0]
-                right_id[0] += 1
+                current_id = right_id
+                right_id += 1
                 md = SingleAssignmentDisposable()
                 right_map[current_id] = value
                 group.add(md)
@@ -83,7 +86,7 @@ def _join(right: Observable,
                 def expire():
                     if current_id in right_map:
                         del right_map[current_id]
-                    if not len(right_map) and right_done[0]:
+                    if not len(right_map) and right_done:
                         observer.on_completed()
 
                     return group.remove(md)
@@ -101,8 +104,9 @@ def _join(right: Observable,
                     observer.on_next(result)
 
             def on_completed_right():
-                right_done[0] = True
-                if left_done[0] or not len(right_map):
+                nonlocal right_done
+                right_done = True
+                if left_done or not len(right_map):
                     observer.on_completed()
 
             group.add(right.subscribe_(on_next_right, observer.on_error, on_completed_right, scheduler))

--- a/tests/test_observable/test_join.py
+++ b/tests/test_observable/test_join.py
@@ -869,7 +869,52 @@ class TestJoin(unittest.TestCase):
                 )
 
         results = scheduler.start(create=create)
-        assert subscribe_schedulers['x'] == scheduler
-        assert subscribe_schedulers['y'] == scheduler
-        assert subscribe_schedulers['duration_x'] == scheduler
-        assert subscribe_schedulers['duration_y'] == scheduler
+        assert subscribe_schedulers['x'] is scheduler
+        assert subscribe_schedulers['y'] is scheduler
+        assert subscribe_schedulers['duration_x'] is scheduler
+        assert subscribe_schedulers['duration_y'] is scheduler
+
+    def test_join_op_forward_scheduler_None(self):
+
+        subscribe_schedulers = {
+            'x': 'unknown',
+            'y': 'unknown',
+            'duration_x': 'unknown',
+            'duration_y': 'unknown',
+            }
+
+        def subscribe_x(observer, scheduler='not_set'):
+            subscribe_schedulers['x'] = scheduler
+            # need to push one element to trigger duration mapper
+            observer.on_next('foo')
+
+        def subscribe_y(observer, scheduler='not_set'):
+            subscribe_schedulers['y'] = scheduler
+            # need to push one element to trigger duration mapper
+            observer.on_next('bar')
+
+        def subscribe_duration_x(observer, scheduler='not_set'):
+            subscribe_schedulers['duration_x'] = scheduler
+
+        def subscribe_duration_y(observer, scheduler='not_set'):
+            subscribe_schedulers['duration_y'] = scheduler
+
+        xs = rx.create(subscribe_x)
+        ys = rx.create(subscribe_y)
+        duration_x = rx.create(subscribe_duration_x)
+        duration_y = rx.create(subscribe_duration_y)
+
+        stream = xs.pipe(
+            ops.join(
+                ys,
+                lambda x: duration_x,
+                lambda y: duration_y,
+                ),
+            )
+
+        stream.subscribe()
+        assert subscribe_schedulers['x'] is None
+        assert subscribe_schedulers['y'] is None
+        assert subscribe_schedulers['duration_x'] is None
+        assert subscribe_schedulers['duration_y'] is None
+

--- a/tests/test_observable/test_join.py
+++ b/tests/test_observable/test_join.py
@@ -30,7 +30,7 @@ class TimeInterval(object):
     def __str__(self):
         return "%s@%s" % (self.value, self.interval)
 
-    def equals(other):
+    def equals(self, other):
         return other.interval == self.interval and other.value == self.value
 
     def get_hash_code(self):


### PR DESCRIPTION
this PR attempts to fix the `join` operator to continue the ongoing effort to resolve scheduler forwarding issues (#480). 

Bonus:
- convert list hack to `nonlocal` statement
- add a test case: check that the subscribe scheduler is propagated to left & right observables as well as duration observables