### PR TITLE
Fix concat_with_iterable: subscribe scheduler is not forwarded

### DIFF
--- a/rx/core/observable/concat.py
+++ b/rx/core/observable/concat.py
@@ -8,8 +8,8 @@ from rx.scheduler import CurrentThreadScheduler
 
 def _concat_with_iterable(sources: Iterable[Observable]) -> Observable:
 
-    def subscribe(observer, scheduler=None):
-        scheduler = scheduler or CurrentThreadScheduler.singleton()
+    def subscribe(observer, scheduler_=None):
+        _scheduler = scheduler_ or CurrentThreadScheduler.singleton()
 
         sources_ = iter(sources)
 
@@ -23,7 +23,7 @@ def _concat_with_iterable(sources: Iterable[Observable]) -> Observable:
                 return
 
             def on_completed():
-                cancelable.disposable = scheduler.schedule(action)
+                cancelable.disposable = _scheduler.schedule(action)
 
             try:
                 current = next(sources_)
@@ -34,9 +34,9 @@ def _concat_with_iterable(sources: Iterable[Observable]) -> Observable:
             else:
                 d = SingleAssignmentDisposable()
                 subscription.disposable = d
-                d.disposable = current.subscribe_(observer.on_next, observer.on_error, on_completed, scheduler)
+                d.disposable = current.subscribe_(observer.on_next, observer.on_error, on_completed, scheduler_)
 
-        cancelable.disposable = scheduler.schedule(action)
+        cancelable.disposable = _scheduler.schedule(action)
 
         def dispose():
             nonlocal is_disposed


### PR DESCRIPTION
I believe this PR fixes `concat_with_iterable` behaviour regarding subscribe scheduler propagation. However, I'm not 100% sure of this.  The change lies in the last case:

### scheduler is given in `subscribe` method
- `concat_with_iterable` will schedule sequentialy multiple subscription actions to the upstream sources. These actions will be scheduled with operator's internal scheduler, which is precisely the subscribe scheduler.
- During each subscription action, a source observable will be subscribed using the subscribe scheduler. 

To  summarize, everything is scheduled/subscribed using the subscribe scheduler.

### scheduler is not given in `subscribe` method:
- `concat_with_iterable` will schedule each subscription action with its own internal scheduler, i.e. `CurrentThreadScheduler`.
- During each subscription action, a source observable will be subscribed with scheduler=None, i.e. upstream sources will choose which scheduler to use. **Right before, source observables were subscribed with internal scheduler, i.e. `CurrentThreadScheduler`**
