### PR TITLE
Correct the description of the filter operator

### DIFF
--- a/rx/operators/__init__.py
+++ b/rx/operators/__init__.py
@@ -870,7 +870,7 @@ def expand(mapper: Mapper) -> Callable[[Observable], Observable]:
 
 def filter(predicate: Predicate) -> Callable[[Observable], Observable]:
     """Filters the elements of an observable sequence based on a
-    predicate by incorporating the element's index.
+    predicate.
 
     .. marble::
         :alt: filter


### PR DESCRIPTION
The filter and filter_indexed operators had the same description, but filter would not need the index.