### PR TITLE
Drop reference to cached items asap in to_xxx

### DIFF
--- a/rx/core/operators/todict.py
+++ b/rx/core/operators/todict.py
@@ -39,7 +39,9 @@ def _to_dict(key_mapper: Mapper,
                 m[key] = element
 
             def on_completed() -> None:
+                nonlocal m
                 observer.on_next(m)
+                m = dict()
                 observer.on_completed()
 
             return source.subscribe_(on_next, observer.on_error, on_completed, scheduler)

--- a/rx/core/operators/tofuture.py
+++ b/rx/core/operators/tofuture.py
@@ -41,10 +41,12 @@ def _to_future(future_ctor: Optional[Callable[[], Future]] = None,
             future.set_exception(err)
 
         def on_completed():
+            nonlocal last_value
             if has_value:
                 future.set_result(last_value)
             else:
                 future.set_exception(SequenceContainsNoElementsError())
+            last_value = None
 
         source.subscribe_(on_next, on_error, on_completed, scheduler=scheduler)
 

--- a/rx/core/operators/toiterable.py
+++ b/rx/core/operators/toiterable.py
@@ -20,7 +20,9 @@ def _to_iterable() -> Callable[[Observable], Observable]:
                 queue.append(item)
 
             def on_completed():
+                nonlocal queue
                 observer.on_next(queue)
+                queue = []
                 observer.on_completed()
 
             return source.subscribe_(on_next, observer.on_error, on_completed, scheduler)

--- a/rx/core/operators/toset.py
+++ b/rx/core/operators/toset.py
@@ -14,7 +14,9 @@ def _to_set() -> Callable[[Observable], Observable]:
             s = set()
 
             def on_completed():
+                nonlocal s
                 observer.on_next(s)
+                s = set()
                 observer.on_completed()
 
             return source.subscribe_(s.add, observer.on_error, on_completed, scheduler)


### PR DESCRIPTION
This reduces memory consumption on cases where the cached items are
quite big and: The observable is not disposed immediately or the
completion callback triggers other computations.