### PR TITLE
Do not used start_with in reduce

### DIFF
--- a/rx/core/operators/reduce.py
+++ b/rx/core/operators/reduce.py
@@ -5,6 +5,7 @@ from rx.internal.utils import NotSet
 from rx.core import Observable, pipe
 from rx.core.typing import Accumulator
 
+
 def _reduce(accumulator: Accumulator, seed: Any = NotSet) -> Callable[[Observable], Observable]:
     """Applies an accumulator function over an observable sequence,
     returning the result of the aggregation as a single element in the
@@ -28,12 +29,8 @@ def _reduce(accumulator: Accumulator, seed: Any = NotSet) -> Callable[[Observabl
         an observable sequence containing a single element with the
         final accumulator value.
     """
-
-
     if seed is not NotSet:
-        initial = ops.start_with(seed)
         scanner = ops.scan(accumulator, seed=seed)
-
-        return pipe(scanner, initial, ops.last())
+        return pipe(scanner, ops.last_or_default(default_value=seed))
 
     return pipe(ops.scan(accumulator), ops.last())

--- a/tests/test_integration/test_group_reduce.py
+++ b/tests/test_integration/test_group_reduce.py
@@ -1,0 +1,30 @@
+import unittest
+
+import rx
+from rx import operators as ops
+
+
+class TestGroupByReduce(unittest.TestCase):
+    def test_groupby_count(self):
+        res = []
+        counts = rx.from_(range(10)).pipe(
+            ops.group_by(lambda i: 'even' if i % 2 == 0 else 'odd'),
+            ops.flat_map(lambda i: i.pipe(
+                ops.count(),
+                ops.map(lambda ii: (i.key, ii)),
+            ))
+        )
+
+        counts.subscribe(on_next=res.append)
+        assert res == [('even', 5), ('odd', 5)]
+
+    def test_window_sum(self):
+        res = []
+        rx.from_(range(6)).pipe(
+            ops.window_with_count(count=3, skip=1),
+            ops.flat_map(lambda i: i.pipe(
+                ops.sum(),
+            )),
+        ).subscribe(on_next=res.append)
+
+        assert res == [3, 6, 9, 12, 9, 5, 0]


### PR DESCRIPTION
start_with is based on concat. As a consequence the source observable
is subscribed only once the start observable completes. If the source
observable is hot, then some items can be missed in the reduce
computation.

Fixes #488