### PR TITLE
(wip) fix travis jobs py37 with optional dependencies (linux & windows)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ matrix:
         # update pip as a workaround to PyQt5.14 installation failure
         - pip3 install --upgrade pip
         # Pre-built wheel for wxpython
-        - pip3 install -U -f https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-16.04 wxpython
+        - pip3 install -U -f "https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-16.04" wxpython~=4.0.0
         # Install the various optional packages
         - pip3 install eventlet gevent pycairo pygobject pygame pyqt5 pyside2 tornado twisted
         # Coverage will be reported for the Python 3.7 Linux build

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,10 +44,12 @@ matrix:
       install:
         # Native libraries for pycairo / pygobject
         - sudo apt-get install -y libgirepository1.0-dev gir1.2-gtk-3.0
+        # update pip as a workaround to PyQt5.14 installation failure
+        - pip3 install --upgrade pip
         # Pre-built wheel for wxpython
         - pip3 install -U -f https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-16.04 wxpython
         # Install the various optional packages
-        - pip3 install eventlet gevent pycairo pygobject pygame pyqt5!=5.14.1 pyside2 tornado twisted
+        - pip3 install eventlet gevent pycairo pygobject pygame pyqt5 pyside2 tornado twisted
         # Coverage will be reported for the Python 3.7 Linux build
         - pip3 install coveralls
       script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,7 @@ matrix:
         # Pre-built wheel for wxpython
         - pip3 install -U -f "https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-16.04" wxpython~=4.0.0
         # Install the various optional packages
-        - pip3 install eventlet gevent pycairo pygobject pygame pyqt5 pyside2 tornado twisted
+        - pip3 install eventlet gevent pycairo pygobject pygame pyqt5 pyside2 tornado twisted pytest-twisted
         # Coverage will be reported for the Python 3.7 Linux build
         - pip3 install coveralls
       script:
@@ -65,7 +65,7 @@ matrix:
 #        # Native libraries for pycairo / pygobject
 #        - brew install pygobject3 gtk+3
 #        # Install the various optional packages
-#        - pip3 install eventlet gevent pycairo pygobject pygame pyqt5 pyside2 tornado twisted wxpython
+#        - pip3 install eventlet gevent pycairo pygobject pygame pyqt5 pyside2 tornado twisted pytest-twisted wxpython
 
     - name: "Python 3.7 on Windows, with optional dependencies and benchmark"
       os: windows


### PR DESCRIPTION
**Work in progress**

### Linux build 3.7 with dependencies:
- update pip before installing PyQt5 should fix the PyQt5 error, no need to forbid specific version anymore. 
https://github.com/python-pillow/Pillow/pull/4527
- pip try to install wxpython 4.1.0 from extra repo https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-16.04, but the last version available which is compatible with python 3.7 is wxpython 4.0.7.