### PR TITLE
Avoid GEventScheduler deadlock

### DIFF
--- a/rx/scheduler/eventloop/geventscheduler.py
+++ b/rx/scheduler/eventloop/geventscheduler.py
@@ -52,7 +52,7 @@ class GEventScheduler(PeriodicScheduler):
         timer = self._gevent.spawn(interval)
 
         def dispose() -> None:
-            timer.kill()
+            timer.kill(block=False)
 
         return CompositeDisposable(sad, Disposable(dispose))
 
@@ -86,7 +86,7 @@ class GEventScheduler(PeriodicScheduler):
         timer = self._gevent.spawn_later(seconds, interval)
 
         def dispose() -> None:
-            timer.kill()
+            timer.kill(block=False)
 
         return CompositeDisposable(sad, Disposable(dispose))
 


### PR DESCRIPTION
With the following minimal repro, `gevent==20.6.0`, `Python 3.8.2`, the function `buffer_with_time` did not work correctly:

```
import gevent
import rx
from rx import operators as ops
from rx.scheduler.eventloop import GEventScheduler

sched = GEventScheduler(gevent)

rx.interval(0.05).pipe(
    ops.buffer_with_time(0.2, scheduler=sched),
).subscribe(on_next=print)

gevent.sleep(2)
```

The changes in this pull request fix the behaviour.