### PR TITLE
upgrade travis jobs with optional dependencies to python 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,11 +34,11 @@ matrix:
         - xvfb-run -a python3 setup.py test
 
 
-    - name: "Python 3.7 on Linux, with optional dependencies and benchmark"
+    - name: "Python 3.8 on Linux, with optional dependencies and benchmark"
       os: linux
       dist: xenial
       language: python
-      python: 3.7
+      python: 3.8
       service:
         - xvfb
       install:
@@ -47,7 +47,7 @@ matrix:
         # Pre-built wheel for wxpython
         - pip3 install -U -f https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-16.04 wxpython
         # Install the various optional packages
-        - pip3 install eventlet gevent pycairo pygobject pygame pyqt5!=5.14.1 pyside2 tornado twisted
+        - pip3 install eventlet gevent pycairo pygobject pygame==2.0dev10 pyqt5 pyside2 tornado twisted
         # Coverage will be reported for the Python 3.7 Linux build
         - pip3 install coveralls
       script:
@@ -65,15 +65,15 @@ matrix:
 #        # Install the various optional packages
 #        - pip3 install eventlet gevent pycairo pygobject pygame pyqt5 pyside2 tornado twisted wxpython
 
-    - name: "Python 3.7 on Windows, with optional dependencies and benchmark"
+    - name: "Python 3.8 on Windows, with optional dependencies and benchmark"
       os: windows
       language: sh
-      python: 3.7
+      python: 3.8
       install:
-        # Get Python 3.7 from choco
-        - choco install python3 --version=3.7.5
-        - ln -s "/c/Python37/python.exe" "/c/Python37/python3.exe"
-        - export PATH="/c/Python37/:/c/Python37/Scripts/:$PATH"
+        # Get the last Python from choco (should be 3.8, if not, use --version argument)
+        - choco install python3
+        - ln -s "/c/Python38/python.exe" "/c/Python38/python3.exe"
+        - export PATH="/c/Python38/:/c/Python38/Scripts/:$PATH"
         # Install the various optional packages
         - pip3 install eventlet gevent pygame pyqt5 pyside2 tornado twisted wxpython
         # TODO install pycairo and pygobject somehow?


### PR DESCRIPTION
from #511, it seems to be quite complex and time-consuming to maintain tests with optional dependencies on python 3.7. We have to install specific package versions to avoid dependency hell.

The proposal here is to migrate these jobs to py3.8, which should be mature enough right now. All packages work out of the box with no need to specifiy a version, except for pygame which currenctly support 3.8 for a pre-release version (2.0.0dev10).
