### PR TITLE
Fix mypy support for sdist (PyPI)

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include LICENSE
 include project.cfg
+include rx/py.typed


### PR DESCRIPTION
When creating a source distribution i.e. `python setup.py sdist`, the file  `py.typed`  is not included in the archive, thus is missing after any installation from PyPI, i.e. in `Lib/site-packages/rx` . This file is requested to be present by mypy to work correctly, and should be included in `MANIFEST.in`, as pointed by @frederikaalund :
https://stackoverflow.com/questions/7522250/how-to-include-package-data-with-setuptools-distribute/14159430#14159430
 
This should close #515 

Fun fact, it's working out of the box when creating a wheel, i.e.  `python setup.py bdist_wheel`.

additionnal reading:
https://github.com/encode/httpx/issues/193