### PR TITLE
[rx] [core] [observable] [catch] fix coding convention 

### DIFF
--- a/rx/core/observable/catch.py
+++ b/rx/core/observable/catch.py
@@ -61,6 +61,6 @@ def _catch_with_iterable(sources: Iterable[Observable]) -> Observable:
 
         def dispose():
             nonlocal is_disposed
-            is_disposed= True
+            is_disposed = True
         return CompositeDisposable(subscription, cancelable, Disposable(dispose))
     return Observable(subscribe)


### PR DESCRIPTION
Hi! first! Thank you! Because I am using RxPy very useful and fun:D

when i read code in 'core/observable/catch', I found typo in violation of PEP8

There is no space to the left of '=' in this code.

Thank you! Have a good Day!