### PR TITLE
docs: fix simple typo, thows -> throws

### DIFF
--- a/rx/core/run.py
+++ b/rx/core/run.py
@@ -14,7 +14,7 @@ def run(source: Observable) -> Any:
 
     Subscribes to the observable source. Then blocks and waits for the
     observable source to either complete or error. Returns the
-    last value emitted, or thows exception if any error occured.
+    last value emitted, or throws exception if any error occured.
 
     Examples:
         >>> result = run(source)


### PR DESCRIPTION
There is a small typo in rx/core/run.py.

Should read `throws` rather than `thows`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md