### PR TITLE
Fix AsyncIOThreadSafeScheduler deadlock

### DIFF
--- a/rx/scheduler/eventloop/asynciothreadsafescheduler.py
+++ b/rx/scheduler/eventloop/asynciothreadsafescheduler.py
@@ -50,10 +50,14 @@ class AsyncIOThreadSafeScheduler(AsyncIOScheduler):
         handle = self._loop.call_soon_threadsafe(interval)
 
         def dispose() -> None:
+            future: Future = Future()
+
             def cancel_handle() -> None:
                 handle.cancel()
+                future.set_result(0)
 
             self._loop.call_soon_threadsafe(cancel_handle)
+            future.result()
 
         return CompositeDisposable(sad, Disposable(dispose))
 
@@ -92,14 +96,18 @@ class AsyncIOThreadSafeScheduler(AsyncIOScheduler):
         handle.append(self._loop.call_soon_threadsafe(stage2))
 
         def dispose() -> None:
+            future: Future = Future()
+
             def cancel_handle() -> None:
                 try:
                     handle.pop().cancel()
                     handle.pop().cancel()
                 except Exception:
                     pass
+                future.set_result(0)
 
             self._loop.call_soon_threadsafe(cancel_handle)
+            future.result()
 
         return CompositeDisposable(sad, Disposable(dispose))
 

--- a/rx/scheduler/eventloop/asynciothreadsafescheduler.py
+++ b/rx/scheduler/eventloop/asynciothreadsafescheduler.py
@@ -50,14 +50,10 @@ class AsyncIOThreadSafeScheduler(AsyncIOScheduler):
         handle = self._loop.call_soon_threadsafe(interval)
 
         def dispose() -> None:
-            future: Future = Future()
-
             def cancel_handle() -> None:
                 handle.cancel()
-                future.set_result(0)
 
             self._loop.call_soon_threadsafe(cancel_handle)
-            future.result()
 
         return CompositeDisposable(sad, Disposable(dispose))
 
@@ -96,18 +92,14 @@ class AsyncIOThreadSafeScheduler(AsyncIOScheduler):
         handle.append(self._loop.call_soon_threadsafe(stage2))
 
         def dispose() -> None:
-            future: Future = Future()
-
             def cancel_handle() -> None:
                 try:
                     handle.pop().cancel()
                     handle.pop().cancel()
                 except Exception:
                     pass
-                future.set_result(0)
 
             self._loop.call_soon_threadsafe(cancel_handle)
-            future.result()
 
         return CompositeDisposable(sad, Disposable(dispose))
 

--- a/rx/scheduler/eventloop/asynciothreadsafescheduler.py
+++ b/rx/scheduler/eventloop/asynciothreadsafescheduler.py
@@ -50,6 +50,10 @@ class AsyncIOThreadSafeScheduler(AsyncIOScheduler):
         handle = self._loop.call_soon_threadsafe(interval)
 
         def dispose() -> None:
+            if not self._is_loop_running_on_another_thread():
+                handle.cancel()
+                return
+
             future: Future = Future()
 
             def cancel_handle() -> None:
@@ -96,14 +100,21 @@ class AsyncIOThreadSafeScheduler(AsyncIOScheduler):
         handle.append(self._loop.call_soon_threadsafe(stage2))
 
         def dispose() -> None:
-            future: Future = Future()
-
-            def cancel_handle() -> None:
+            def do_cancel_handles():
                 try:
                     handle.pop().cancel()
                     handle.pop().cancel()
                 except Exception:
                     pass
+
+            if not self._is_loop_running_on_another_thread():
+                do_cancel_handles()
+                return
+
+            future: Future = Future()
+
+            def cancel_handle() -> None:
+                do_cancel_handles()
                 future.set_result(0)
 
             self._loop.call_soon_threadsafe(cancel_handle)
@@ -130,3 +141,17 @@ class AsyncIOThreadSafeScheduler(AsyncIOScheduler):
 
         duetime = self.to_datetime(duetime)
         return self.schedule_relative(duetime - self.now, action, state=state)
+
+    def _is_loop_running_on_another_thread(self):
+        if not self._loop.is_running():
+            return False
+        current_loop = None
+        try:
+            # In python 3.7 there asyncio.get_running_loop() is prefered.
+            current_loop = asyncio.get_event_loop()
+        except RuntimeError:
+            # If there is no loop in current thread at all, and it is not main
+            # thread, we get error like:
+            # RuntimeError: There is no current event loop in thread 'Thread-1'
+            pass
+        return self._loop != current_loop

--- a/tests/test_scheduler/test_eventloop/test_asynciothreadsafescheduler.py
+++ b/tests/test_scheduler/test_eventloop/test_asynciothreadsafescheduler.py
@@ -93,73 +93,70 @@ class TestAsyncIOThreadSafeScheduler(unittest.TestCase):
 
         loop.run_until_complete(go())
 
-    def test_asyncio_threadsafe_schedule_action_cancel_same_thread(self):
-        ran = False
-        dispose_completed = False
+    def cancel_same_thread_common(self, test_body):
+        update_state = {
+            'ran': False,
+            'dispose_completed': False
+        }
 
         def action(scheduler, state):
-            nonlocal ran
-            ran = True
+            update_state['ran'] = True
 
         # Make the actual test body run in deamon thread, so that in case of
         # failure it doesn't hang indefinitely.
-        def test_body():
-            nonlocal dispose_completed
+        def thread_target():
             loop = asyncio.new_event_loop()
             scheduler = AsyncIOThreadSafeScheduler(loop)
+
+            test_body(scheduler, action, update_state)
+
+            @asyncio.coroutine
+            def go():
+                yield from asyncio.sleep(0.2, loop=loop)
+
+            loop.run_until_complete(go())
+
+        thread = threading.Thread(target=thread_target)
+        thread.daemon = True
+        thread.start()
+        thread.join(0.3)
+        assert update_state['dispose_completed'] is True
+        assert update_state['ran'] is False
+
+
+    def test_asyncio_threadsafe_cancel_non_relative_same_thread(self):
+        def test_body(scheduler, action, update_state):
+            d = scheduler.schedule(action)
+
+            # Test case when dispose is called on thread on which loop is not
+            # yet running, and non-relative schedele is used.
+            d.dispose()
+            update_state['dispose_completed'] = True
+
+        self.cancel_same_thread_common(test_body)
+
+
+    def test_asyncio_threadsafe_schedule_action_cancel_same_thread(self):
+        def test_body(scheduler, action, update_state):
             d = scheduler.schedule_relative(0.05, action)
 
             # Test case when dispose is called on thread on which loop is not
-            # yet running.
+            # yet running, and relative schedule is used.
             d.dispose()
-            dispose_completed = True
+            update_state['dispose_completed'] = True
 
-            @asyncio.coroutine
-            def go():
-                yield from asyncio.sleep(0.2, loop=loop)
+        self.cancel_same_thread_common(test_body)
 
-            loop.run_until_complete(go())
-
-        thread = threading.Thread(target=test_body)
-        thread.daemon = True
-        thread.start()
-        thread.join(0.3)
-        assert dispose_completed is True
-        assert ran is False
 
     def test_asyncio_threadsafe_schedule_action_cancel_same_loop(self):
-        ran = False
-        dispose_completed = False
-
-        def action(scheduler, state):
-            nonlocal ran
-            ran = True
-
-        # Make the actual test body run in deamon thread, so that in case of
-        # failure it doesn't hang indefinitely.
-        def test_body():
-            nonlocal dispose_completed
-            loop = asyncio.new_event_loop()
-            scheduler = AsyncIOThreadSafeScheduler(loop)
+        def test_body(scheduler, action, update_state):
             d = scheduler.schedule_relative(0.1, action)
 
             def do_dispose():
-                nonlocal dispose_completed
-                dispose_completed = True
                 d.dispose()
+                update_state['dispose_completed'] = True
 
             # Test case when dispose is called in loop's callback.
-            loop.call_soon(do_dispose)
+            scheduler._loop.call_soon(do_dispose)
 
-            @asyncio.coroutine
-            def go():
-                yield from asyncio.sleep(0.2, loop=loop)
-
-            loop.run_until_complete(go())
-
-        thread = threading.Thread(target=test_body)
-        thread.daemon = True
-        thread.start()
-        thread.join(0.3)
-        assert dispose_completed is True
-        assert ran is False
+        self.cancel_same_thread_common(test_body)


### PR DESCRIPTION
Fixes #566 .

If you think about it, canceling is best effort anyway, and there is on guaranties that it will be canceled.


If you're calling dispose from the same thread, you get stuck in deadlock.

If you are calling dispose from another thread, you need to count on the fact, that you might be late, already. So, even with waiting for future result, you have to have in mind that nothing actually got cancelled. It also seems that nobody is even expecting this waiting for future result, since no tests are actually checking it.

It really gets easy to stuck in a dead lock, if you have multiple threads, and one of them runs loop, and it is difficult to avoid both deadlock and _RuntimeError: Non-thread-safe operation invoked on an event loop other than the current one._

Being able to use AsyncIOThreadSafeScheduler from both current thread  and other threads, otherwise it not really thread **safe**.