### PR TITLE
bump version to 3.2.0

### DIFF
--- a/project.cfg
+++ b/project.cfg
@@ -2,7 +2,7 @@
 name = Rx
 project = RxPY
 # Please make sure the version here remains the same as in rx/__init__.py
-version = 3.1.1
+version = 3.2.0
 description = Reactive Extensions (Rx) for Python
 author = Dag Brattli
 author_email = dag@brattli.net

--- a/rx/__init__.py
+++ b/rx/__init__.py
@@ -7,7 +7,7 @@ from .core import Observable, pipe, typing
 from .internal.utils import alias
 
 # Please make sure the version here remains the same as in project.cfg
-__version__ = '3.1.1'
+__version__ = '3.2.0'
 
 
 def amb(*sources: Observable) -> Observable:


### PR DESCRIPTION
This PR bumps the version for the next release. The draft release note is here:
https://github.com/ReactiveX/RxPY/releases/tag/untagged-6aa8968b451437bf0928
