### PR TITLE
Remove deprecated loop parameter

### DIFF
--- a/tests/test_scheduler/test_eventloop/test_asyncioscheduler.py
+++ b/tests/test_scheduler/test_eventloop/test_asyncioscheduler.py
@@ -18,7 +18,7 @@ class TestAsyncIOScheduler(unittest.TestCase):
         loop = asyncio.get_event_loop()
         scheduler = AsyncIOScheduler(loop)
         diff = scheduler.now
-        yield from asyncio.sleep(0.1, loop=loop)
+        yield from asyncio.sleep(0.1)
         diff = scheduler.now - diff
         assert timedelta(milliseconds=80) < diff < timedelta(milliseconds=180)
 
@@ -36,7 +36,7 @@ class TestAsyncIOScheduler(unittest.TestCase):
 
             scheduler.schedule(action)
 
-            yield from asyncio.sleep(0.1, loop=loop)
+            yield from asyncio.sleep(0.1)
             assert ran is True
 
         loop.run_until_complete(go())
@@ -56,7 +56,7 @@ class TestAsyncIOScheduler(unittest.TestCase):
 
             scheduler.schedule_relative(0.2, action)
 
-            yield from asyncio.sleep(0.3, loop=loop)
+            yield from asyncio.sleep(0.3)
             assert endtime is not None
             diff = endtime - starttime
             assert diff > 0.18
@@ -78,7 +78,7 @@ class TestAsyncIOScheduler(unittest.TestCase):
             d = scheduler.schedule_relative(0.05, action)
             d.dispose()
 
-            yield from asyncio.sleep(0.3, loop=loop)
+            yield from asyncio.sleep(0.3)
             assert ran is False
 
         loop.run_until_complete(go())

--- a/tests/test_scheduler/test_eventloop/test_asynciothreadsafescheduler.py
+++ b/tests/test_scheduler/test_eventloop/test_asynciothreadsafescheduler.py
@@ -19,7 +19,7 @@ class TestAsyncIOThreadSafeScheduler(unittest.TestCase):
         loop = asyncio.get_event_loop()
         scheduler = AsyncIOThreadSafeScheduler(loop)
         diff = scheduler.now
-        yield from asyncio.sleep(0.1, loop=loop)
+        yield from asyncio.sleep(0.1)
         diff = scheduler.now - diff
         assert timedelta(milliseconds=80) < diff < timedelta(milliseconds=180)
 
@@ -40,7 +40,7 @@ class TestAsyncIOThreadSafeScheduler(unittest.TestCase):
 
             threading.Thread(target=schedule).start()
 
-            yield from asyncio.sleep(0.1, loop=loop)
+            yield from asyncio.sleep(0.1)
             assert ran is True
 
         loop.run_until_complete(go())
@@ -63,7 +63,7 @@ class TestAsyncIOThreadSafeScheduler(unittest.TestCase):
 
             threading.Thread(target=schedule).start()
 
-            yield from asyncio.sleep(0.3, loop=loop)
+            yield from asyncio.sleep(0.3)
             assert endtime is not None
             diff = endtime - starttime
             assert diff > 0.18
@@ -88,7 +88,7 @@ class TestAsyncIOThreadSafeScheduler(unittest.TestCase):
 
             threading.Thread(target=schedule).start()
 
-            yield from asyncio.sleep(0.3, loop=loop)
+            yield from asyncio.sleep(0.3)
             assert ran is False
 
         loop.run_until_complete(go())
@@ -112,7 +112,7 @@ class TestAsyncIOThreadSafeScheduler(unittest.TestCase):
 
             @asyncio.coroutine
             def go():
-                yield from asyncio.sleep(0.2, loop=loop)
+                yield from asyncio.sleep(0.2)
 
             loop.run_until_complete(go())
 


### PR DESCRIPTION
asyncio.sleep's loop parameter has been deprecated since Python 3.8, and is [removed in 3.10](https://docs.python.org/3.10/library/asyncio-task.html#sleeping).  The tests fail on 3.10 unless this is removed.