### PR TITLE
Removal of misleading information in take_while documentation

### DIFF
--- a/rx/core/operators/takewhile.py
+++ b/rx/core/operators/takewhile.py
@@ -7,8 +7,7 @@ from rx.core.typing import Predicate, PredicateIndexed
 def _take_while(predicate: Predicate, inclusive: bool = False) -> Callable[[Observable], Observable]:
     def take_while(source: Observable) -> Observable:
         """Returns elements from an observable sequence as long as a
-        specified condition is true. The element's index is used in the
-        logic of the predicate function.
+        specified condition is true.
 
         Example:
             >>> take_while(source)

--- a/rx/operators/__init__.py
+++ b/rx/operators/__init__.py
@@ -2985,8 +2985,7 @@ def take_until_with_time(end_time: typing.AbsoluteOrRelativeTime,
 
 def take_while(predicate: Predicate, inclusive: bool = False) -> Callable[[Observable], Observable]:
     """Returns elements from an observable sequence as long as a
-    specified condition is true. The element's index is used in the
-    logic of the predicate function.
+    specified condition is true.
 
     .. marble::
         :alt: take_while


### PR DESCRIPTION
Small thing. Documentation was stating that `element's index is used in logic of the predicate function` which is not true for `take_while` operator