### PR TITLE
Fix return annotation of Observable.__await__

### DIFF
--- a/reactivex/observable/observable.py
+++ b/reactivex/observable/observable.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import asyncio
 import threading
-from typing import Any, Callable, Iterable, Optional, TypeVar, Union, cast, overload
+from typing import Any, Callable, Generator, Optional, TypeVar, Union, cast, overload
 
 from reactivex import abc
 from reactivex.disposable import Disposable
@@ -256,7 +256,7 @@ class Observable(abc.ObservableBase[_T]):
 
         return run(self)
 
-    def __await__(self) -> Iterable[_T]:
+    def __await__(self) -> Generator[Any, None, _T]:
         """Awaits the given observable.
 
         Returns:
@@ -265,7 +265,10 @@ class Observable(abc.ObservableBase[_T]):
         from ..operators._tofuture import to_future_
 
         loop = asyncio.get_event_loop()
-        return iter(self.pipe(to_future_(scheduler=AsyncIOScheduler(loop=loop))))
+        future: asyncio.Future[_T] = self.pipe(
+            to_future_(scheduler=AsyncIOScheduler(loop=loop))
+        )
+        return future.__await__()
 
     def __add__(self, other: Observable[_T]) -> Observable[_T]:
         """Pythonic version of :func:`concat <reactivex.concat>`.


### PR DESCRIPTION
This fixes issues with mypy type checking when awaiting an observable

Here is an example output from `await subject` on mypy 0.940 (latest at time of PR opening)

```
tests/reactive/test_api_direct.py:1564: error: Incompatible types in "await" (actual type "Subject[Dict[str, Any]]", expected type "Awaitable[Any]")  [misc]
tests/reactive/test_api_direct.py:1564: note: Following member(s) of "Subject[Dict[str, Any]]" have conflicts:
tests/reactive/test_api_direct.py:1564: note:     Expected:
tests/reactive/test_api_direct.py:1564: note:         def __await__(self) -> Generator[Any, None, Any]
tests/reactive/test_api_direct.py:1564: note:     Got:
tests/reactive/test_api_direct.py:1564: note:         def __await__(self) -> Iterable[Dict[str, Any]]
```