### PR TITLE
Allow any python in the 3.x series >=3.7

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ packages = [
 ]
 
 [tool.poetry.dependencies]
-python = ">= 3.7, < 3.11"
+python = ">= 3.7, < 4.0"
 typing-extensions = "^4.1.1"
 
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION
Before converting from setup.py to pyproject, this upper bound didn't exist.

There's no reason to cap at 3.10. This breaks installations on other poetry projects defined with Python=^3.7 and would force updating this file for every new python version.