### PR TITLE
Update get_started.rst

### DIFF
--- a/docs/get_started.rst
+++ b/docs/get_started.rst
@@ -181,7 +181,7 @@ It is also possible to create an operator that is not a composition of other
 operators. This allows to fully control the subscription logic and items
 emissions:
 
- .. code:: python
+.. code:: python
 
     import reactivex
 
@@ -195,7 +195,7 @@ emissions:
                     on_next,
                     observer.on_error,
                     observer.on_completed,
-                    scheduler)
+                    scheduler=scheduler)
             return reactivex.create(subscribe)
         return _lowercase
 


### PR DESCRIPTION
-Fixed a typo for proper code markdown.
-The "Custom operator" section gives an error on Python 3.10.6 (Windows 10 64 bits):
    TypeError: Observable.subscribe() takes from 1 to 4 positional arguments but 5 were given

Apparently, the call to "source.subscribe(...)" on line 194, requires that the "scheduler" argument be explicitly named. This would seem to fall in line with https://github.com/ReactiveX/RxPY/blob/7482616d623a6772f0cb649b67fa316e3a82b489/reactivex/observable/observable.py#L75

I'm a beginner with Python as a language, PyCharm as my IDE, and using RxPy, so I might be doing things wrong, but when I name the scheduler argument, things work as expected.