### PR TITLE
Fix collections imports for Python 3.10+

### DIFF
--- a/rx/linq/observable/selectmany.py
+++ b/rx/linq/observable/selectmany.py
@@ -1,13 +1,16 @@
 from rx import Observable
 from rx.internal.utils import adapt_call
 from rx.internal import extensionmethod
-import collections
+try:
+    from collections.abc import Iterable
+except ImportError:
+    from collections import Iterable
 
 
 def _flat_map(source, selector):
     def projection(x, i):
         selector_result = selector(x, i)
-        if isinstance(selector_result, collections.Iterable):
+        if isinstance(selector_result, Iterable):
             result = Observable.from_(selector_result)
         else:
             result = Observable.from_future(selector_result)
@@ -56,7 +59,7 @@ def select_many(self, selector, result_selector=None):
     if result_selector:
         def projection(x, i):
             selector_result = selector(x, i)
-            if isinstance(selector_result, collections.Iterable):
+            if isinstance(selector_result, Iterable):
                 result = Observable.from_(selector_result)
             else:
                 result = Observable.from_future(selector_result)

--- a/rx/linq/observable/sequenceequal.py
+++ b/rx/linq/observable/sequenceequal.py
@@ -1,4 +1,7 @@
-import collections
+try:
+    from collections.abc import Iterable
+except ImportError:
+    from collections import Iterable
 
 from rx import AnonymousObservable, Observable
 from rx.disposables import CompositeDisposable
@@ -29,7 +32,7 @@ def sequence_equal(self, second, comparer=None):
     first = self
     comparer = comparer or default_comparer
 
-    if isinstance(second, collections.Iterable):
+    if isinstance(second, Iterable):
         second = Observable.from_iterable(second)
 
     def subscribe(observer):

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ except ImportError:
 
 setup(
     name='Rx',
-    version='1.6.1',
+    version='1.6.2',
     description='Reactive Extensions (Rx) for Python',
     long_description=("is a library for composing asynchronous and "
         "event-based programs using observable collections and LINQ-style "


### PR DESCRIPTION
Right now RxPY 1.6.1 imports `Iterable` from `collections`, which is deprecated and will break in Python 3.10. The recommended way of doing this now is importing `Iterable` from `collections.abc`. This is a PR for the release/v1.6.x branch which fixes that (in a backwards compatible way), so that projects stuck with RxPY 1.6.x can still upgrade to Python 3.10. My hope is that this can be released as a new minor version (probably 1.6.2) of RxPY.

For context on why this is worth sending out a PR for: we have a project that depends on RxPY via another dependency. Unfortunately, that dependency only supports RxPY <2, and upgrading that seems non-trivial, so it seems easier to fix this 3.10 issue in RxPY.

This PR also includes a commit that bumps the version, but I can remove that if it would simplify things! I know that submitting a PR to the release/v1.6.x branch is a bit odd, let me know if there is a better way of going about this.

Test Plan: I ran `python -m unittest discover tests` before and after this change with both Python 3.9 and Python 2.7. I confirmed the number of tests passed before and after this change was the same (though with 2.7 there were 17 errors even before this change, and with 3.9 there were 17 errors and 5 failures even before this change. Not sure if that is due to any configuration issues on my end).