### PR TITLE
Fix unit-tests

### DIFF
--- a/rx/internal/enumerable.py
+++ b/rx/internal/enumerable.py
@@ -24,11 +24,10 @@ class Enumerable(object):
 
             for value in self:
                 if n <= 0:
-                    raise StopIteration
+                    return
                 n -= 1
                 yield value
 
-            raise StopIteration
         return Enumerable(next())
 
     @classmethod
@@ -41,7 +40,6 @@ class Enumerable(object):
                 value += 1
                 n -= 1
 
-            raise StopIteration
         return Enumerable(next())
 
     @classmethod

--- a/rx/linq/enumerable/whiledo.py
+++ b/rx/linq/enumerable/whiledo.py
@@ -7,6 +7,5 @@ def while_do(cls, condition, source):
         while condition(source):
             yield source
 
-        raise StopIteration()
     return Enumerable(next())
 

--- a/tests/test_concurrency/test_mainloopscheduler/py3_asyncioscheduler.py
+++ b/tests/test_concurrency/test_mainloopscheduler/py3_asyncioscheduler.py
@@ -32,7 +32,7 @@ class TestAsyncIOScheduler(unittest.TestCase):
                 ran = True
             scheduler.schedule(action)
 
-            yield from asyncio.sleep(0.1, loop=loop)
+            yield from asyncio.sleep(0.1)
             assert(ran is True)
 
         loop.run_until_complete(go())
@@ -52,7 +52,7 @@ class TestAsyncIOScheduler(unittest.TestCase):
 
             scheduler.schedule_relative(200, action)
 
-            yield from asyncio.sleep(0.3, loop=loop)
+            yield from asyncio.sleep(0.3)
             diff = endtime-starttime
             assert(diff > 0.18)
 
@@ -72,7 +72,7 @@ class TestAsyncIOScheduler(unittest.TestCase):
             d = scheduler.schedule_relative(10, action)
             d.dispose()
 
-            yield from asyncio.sleep(0.1, loop=loop)
+            yield from asyncio.sleep(0.1)
             assert(not ran)
 
         loop.run_until_complete(go())


### PR DESCRIPTION
This is a complement to #668 to fix all unit-tests on python 3.10:

- Asyncio sleep does not accept the loop argument anymore.
- PEP479 changed the behavior of StopIteration raised by generators.