### PR TITLE
fix(docs): IO Concurrency for 3.10+

### DIFF
--- a/docs/get_started.rst
+++ b/docs/get_started.rst
@@ -379,7 +379,7 @@ the coroutine.
                 i.future.set_result(i.data)
 
             print("starting server")
-            server = asyncio.start_server(handle_echo, '127.0.0.1', 8888, loop=loop)
+            server = asyncio.start_server(handle_echo, '127.0.0.1', 8888)
             loop.create_task(server)
 
             sink.subscribe(
@@ -390,7 +390,7 @@ the coroutine.
         return reactivex.create(on_subscribe)
 
 
-    loop = asyncio.get_event_loop()
+    loop = asyncio.new_event_loop()
     proxy = Subject()
     source = tcp_server(proxy, loop)
     aio_scheduler = AsyncIOScheduler(loop=loop)


### PR DESCRIPTION
The current example returns errors when run on Python 3.10+.

The new example should work on Python 3.7+.

# Details

## Missing loop parameter

The function `asyncio.create_server` lost its loop parameter in Python 3.10 as part of a cleanup of the high-level asyncio api. The function `asyncio.create_server` has been implicitly retrieving the current loop since Python 3.7.

[Python 3.10 Removed](https://docs.python.org/3/whatsnew/3.10.html#removed)

[Python 3.10 Changes in the Python API](https://docs.python.org/3/whatsnew/3.10.html#changes-in-the-python-api)

## Missing event loop

The result of `asyncio.get_event_loop()` appears to be system dependent. The [documentation](https://docs.python.org/3/library/asyncio-eventloop.html#asyncio.get_event_loop) reads

_If there is no running event loop set, the function will return the result of `get_event_loop_policy().get_event_loop()` call._

_Because this function has rather complex behavior (especially when custom event loop policies are in use), using the [get_running_loop()](https://docs.python.org/3/library/asyncio-eventloop.html#asyncio.get_running_loop) function is preferred to [get_event_loop()](https://docs.python.org/3/library/asyncio-eventloop.html#asyncio.get_event_loop) in coroutines and callbacks._

Since the example did not start an event loop on my system, I took the liberty of writing `asyncio.new_event_loop()` instead.

## Error encountered

```
Current code returns:

/tmp/io.py:47: DeprecationWarning: There is no current event loop
  loop = asyncio.get_event_loop()

starting server
Task exception was never retrieved

future: <Task finished name='Task-1' coro=<start_server() done, defined at /usr/local/lib/python3.11/asyncio/streams.py:54> exception=TypeError("BaseEventLoop.create_server() got an unexpected keyword argument 'loop'")>
Traceback (most recent call last):
  File "/usr/local/lib/python3.11/asyncio/streams.py", line 85, in start_server
    return await loop.create_server(factory, host, port, **kwds)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: BaseEventLoop.create_server() got an unexpected keyword argument 'loop'
```