### PR TITLE
Use setup-python action to cache dependencies

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -8,21 +8,17 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Install Poetry
+        uses: snok/install-poetry@v1
+
       - name: Set up Python 3.9
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v3
         with:
           python-version: 3.9
-
-      - name: Cache Poetry
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.cache/pypoetry
-          key: poetry-cache-${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}
+          cache: poetry
 
       - name: Install dependencies
         run: |
-          pip install poetry
           poetry install
 
       - name: Code checks
@@ -38,23 +34,18 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+
+      - name: Install Poetry
+        uses: snok/install-poetry@v1
+
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v3
         with:
           python-version: ${{ matrix.python-version }}
-
-      - name: Cache Poetry
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.cache/pypoetry
-            ~/Library/Caches/pypoetry
-            C:\Users\*\AppData\Local\pypoetry\Cache
-          key: poetry-cache-${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}
+          cache: poetry
 
       - name: Install dependencies
         run: |
-          pip install poetry
           poetry config installer.parallel false
           poetry install
 
@@ -67,21 +58,17 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Install Poetry
+        uses: snok/install-poetry@v1
+
       - name: Set up Python 3.9
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v3
         with:
           python-version: 3.9
-
-      - name: Cache Poetry
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.cache/pypoetry
-          key: poetry-cache-${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}
-
+          cache: poetry
+      
       - name: Install dependencies
         run: |
-          pip install poetry
           poetry install
 
       - name: Run coverage tests


### PR DESCRIPTION
Signed-off-by: jongwooo <jongwooo.han@gmail.com>

## Details

Updated workflows to cache dependencies using [actions/setup-python](https://github.com/actions/setup-python#caching-packages-dependencies). `setup-python@v3` or newer has caching **built-in**.

### AS-IS

```yaml
- name: Set up Python 3.9
  uses: actions/setup-python@v2
  with:
    python-version: 3.9

- name: Cache Poetry
  uses: actions/cache@v2
  with:
    path: |
      ~/.cache/pypoetry
      ~/Library/Caches/pypoetry
      C:\Users\*\AppData\Local\pypoetry\Cache
    key: poetry-cache-${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}
```

### TO-BE

```yaml
- name: Set up Python 3.9
  uses: actions/setup-python@v3
  with:
    python-version: 3.9
    cache: poetry
```

## References

- [https://github.com/actions/setup-python#caching-packages-dependencies](https://github.com/actions/setup-python#caching-packages-dependencies)
- [https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows](https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows)
- [https://thearchivelog.dev/article/caching-dependencies-to-speed-up-workflows/](https://thearchivelog.dev/article/caching-dependencies-to-speed-up-workflows/)
