### PR TITLE
Update constants.py to remove deprecated datetime.utcfromtimestamp(0)

### DIFF
--- a/reactivex/internal/constants.py
+++ b/reactivex/internal/constants.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, UTC
 
 DELTA_ZERO = timedelta(0)
-UTC_ZERO = datetime.utcfromtimestamp(0)
+UTC_ZERO = datetime.fromtimestamp(timestamp, UTC)


### PR DESCRIPTION
This fixes the warning 

```
DeprecationWarning: datetime.datetime.utcfromtimestamp() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.fromtimestamp(timestamp, datetime.UTC).
```