### PR TITLE
Introduced Observable >> operator as pipe shorthand

### DIFF
--- a/reactivex/observable/observable.py
+++ b/reactivex/observable/observable.py
@@ -353,5 +353,21 @@ class Observable(abc.ObservableBase[_T_out]):
 
         return slice_(start, stop, step)(self)
 
+    def __rshift__(self, __op1: Callable[[Observable[_T_out]], _A]) -> _A:
+        """Shorthand for :func:`pipe <pipe>` (single argument overload).
+
+        Allows you to pipe through a single operator using `>>`.
+
+        Examples:
+            >>> source >> op == source.pipe(op)
+
+        Args:
+            operator: A single operator.
+
+        Returns:
+             The composed observable.
+        """
+        return self.pipe(__op1)
+
 
 __all__ = ["Observable"]


### PR DESCRIPTION
I was doing something with F# and ReactiveX, and noticed that because of F#'s `|>` operator, their pipelining syntax is a lot cleaner and more readable:
```fsharp
    let reqWithTimeout =
        req
        |> Observable.timeoutSpan (TimeSpan.FromSeconds 1)
        |> Observable.take 1
        |> Observable.catch Observable.empty
```

Here's the full [F# ReactiveX Application](https://github.com/jamesward/easyracer/blob/main/fsharp-reactive/EasyRacer/EasyRacer.fs).

So I thought that by overloading Python's right shift operator (`__rshift__`, `>>`), we could get something similar:
```python
        req() >> ops.timeout(datetime.timedelta(seconds=1)) >> ops.catch(rx.empty()),
```

Here's the [PR converting the entire RxPY application](https://github.com/jamesward/easyracer/pull/437/files) from `pipe`s to `>>`s.

While overloading the `>>` operator to perform pipelining seems like a strange choice, it is not without precedent, as [Airflow is doing the same thing](https://airflow.apache.org/docs/apache-airflow/stable/core-concepts/tasks.html) (note the `first_task >> second_task >> [third_task, fourth_task]` example).

WDYT?