### PR TITLE
Fix subscribe_on not forwarding scheduler to the source 

### DIFF
--- a/reactivex/operators/_subscribeon.py
+++ b/reactivex/operators/_subscribeon.py
@@ -43,7 +43,7 @@ def subscribe_on_(
 
             def action(scheduler: abc.SchedulerBase, state: Optional[Any] = None):
                 d.disposable = ScheduledDisposable(
-                    scheduler, source.subscribe(observer)
+                    scheduler, source.subscribe(observer, scheduler=scheduler)
                 )
 
             m.disposable = scheduler.schedule(action)

--- a/tests/test_observable/test_subscribeon.py
+++ b/tests/test_observable/test_subscribeon.py
@@ -1,6 +1,6 @@
 import unittest
 
-from reactivex import operators as ops
+from reactivex import operators as ops, create as rx_create
 from reactivex.testing import ReactiveTest, TestScheduler
 
 on_next = ReactiveTest.on_next
@@ -71,6 +71,28 @@ class TestSubscribeOn(unittest.TestCase):
         assert results.messages == []
         assert xs.subscriptions == [subscribe(200, 1000)]
 
+    def test_subscribe_on_scheduler_forwarding(self):
+        scheduler = TestScheduler()
+        forwarded_sheduler = None
+
+        def source():
+            def subscribe(observer, _scheduler):
+                nonlocal forwarded_sheduler
+                forwarded_sheduler = _scheduler
+
+                def action_on_completed(_, __):
+                    observer.on_completed()
+
+                return _scheduler.schedule_absolute(250, action_on_completed)
+
+            return rx_create(subscribe)
+
+        def create():
+            return source().pipe(ops.subscribe_on(scheduler))
+
+        results = scheduler.start(create)
+        assert forwarded_sheduler is scheduler
+        assert results.messages == [on_completed(250)]
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This PR fix the `subscribe_on` operator that actually doesn't forward the scheduler to the source.

This is noticeable when one wants to implement an obsersvable by using a subscribe function:

```python
my_scheduler = EventLoopScheduler()

def source():
    def subscribe(observer, _scheduler):
        # here, _scheduler is None instead of my_scheduler
        ...
    return rx.create(subscribe)

source().pipe(
    ops.subscribe_on(my_scheduler)
).run()
```

I believe this is not aligned with the documentation which states the following:

> wrap the source sequence in order to run its subscription and unsubscription logic on the specified scheduler

I think that also should fix #541.

