### PR TITLE
[Repo Assist] Fix ruff lint issues in test_scheduler; remove test_subject/test_scheduler from ruff exclude; standardise setup-python@v5

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -9,7 +9,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up Python 3.12
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.12"
 

--- a/changes.md
+++ b/changes.md
@@ -1,5 +1,13 @@
 # Changes
 
+## Unreleased
+
+- Testing: Fixed ruff lint issues in `tests/test_scheduler/` (import ordering,
+  f-string upgrades, `object` base class removal) and removed it from the
+  ruff exclude list. `tests/test_subject/` also removed from the ruff exclude
+  list as it already passed all checks.
+- CI: Standardised `actions/setup-python` to `@v5` across all workflow jobs.
+
 ## 2.0.0-alpha
 
 - Extension methods and extension class methods have been removed. This

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,8 +76,7 @@ exclude = [
     "examples",
     # Test directories - remove as each stage is completed
     # Stage 1 complete, Stage 2 partial (test_integration complete)
-    "tests/test_subject",
-    "tests/test_scheduler",
+    # test_subject and test_scheduler now pass ruff checks
     "tests/test_observable",
 ]
 
@@ -111,6 +110,8 @@ asyncio_mode = "strict"
 include = ["reactivex", "tests"]
 exclude = [
     # Stage 1 complete, Stage 2 partial (test_integration complete)
+    # test_subject and test_scheduler now pass ruff and pyright (run separately)
+    # keeping them excluded until strict-mode pyright issues are resolved
     "tests/test_subject",
     "tests/test_scheduler",
     "tests/test_observable",

--- a/tests/test_scheduler/test_eventloop/test_asyncioscheduler.py
+++ b/tests/test_scheduler/test_eventloop/test_asyncioscheduler.py
@@ -1,8 +1,8 @@
 import asyncio
 import os
-from typing import Any
 import unittest
 from datetime import datetime, timedelta, timezone
+from typing import Any
 
 import pytest
 

--- a/tests/test_scheduler/test_eventloop/test_ioloopscheduler.py
+++ b/tests/test_scheduler/test_eventloop/test_ioloopscheduler.py
@@ -7,7 +7,7 @@ import pytest
 from reactivex.scheduler.eventloop import IOLoopScheduler
 
 tornado = pytest.importorskip("tornado")
-from tornado import ioloop  # isort: skip
+from tornado import ioloop  # noqa: E402
 
 
 class TestIOLoopScheduler(unittest.TestCase):

--- a/tests/test_scheduler/test_eventloop/test_twistedscheduler.py
+++ b/tests/test_scheduler/test_eventloop/test_twistedscheduler.py
@@ -6,8 +6,8 @@ import pytest
 from reactivex.scheduler.eventloop import TwistedScheduler
 
 twisted = pytest.importorskip("twisted")
-from twisted.internet import defer, reactor  # isort: skip
-from twisted.trial import unittest  # isort: skip
+from twisted.internet import defer, reactor  # noqa: E402
+from twisted.trial import unittest  # noqa: E402
 
 
 class TestTwistedScheduler(unittest.TestCase):

--- a/tests/test_scheduler/test_historicalscheduler.py
+++ b/tests/test_scheduler/test_historicalscheduler.py
@@ -7,7 +7,7 @@ from reactivex.scheduler import HistoricalScheduler
 
 def assert_equals(first, second):
     if len(first) != len(second):
-        print("len(%d) != len(%d)" % (len(first), len(second)))
+        print(f"len({len(first)}) != len({len(second)})")
         assert False
 
     for i in range(len(first)):
@@ -31,7 +31,7 @@ def from_days(days):
     return timedelta(days=days)
 
 
-class Timestamped(object):
+class Timestamped:
     def __init__(self, value, timestamp):
         self.value = value
         self.timestamp = timestamp
@@ -43,7 +43,7 @@ class Timestamped(object):
         return other.value == self.value and other.timestamp == self.timestamp
 
     def __str__(self):
-        return "(%s, %s)" % (self.value, self.timestamp)
+        return f"({self.value}, {self.timestamp})"
 
     def __repr__(self):
         return str(self)

--- a/tests/test_scheduler/test_mainloop/test_gtkscheduler.py
+++ b/tests/test_scheduler/test_mainloop/test_gtkscheduler.py
@@ -10,7 +10,7 @@ from reactivex.internal.basic import default_now
 from reactivex.scheduler.mainloop import GtkScheduler
 
 gi = pytest.importorskip("gi")
-from gi.repository import GLib, Gtk  # isort: skip
+from gi.repository import GLib, Gtk  # noqa: E402, I001
 
 
 gi.require_version("Gtk", "3.0")


### PR DESCRIPTION
- Fix I001 (import ordering) in test_asyncioscheduler.py
- Fix E402 (post-importorskip imports) in test_ioloopscheduler.py,
  test_twistedscheduler.py, and test_gtkscheduler.py using noqa comments
- Fix UP031 (%-formatting → f-strings) and UP004 (object base class)
  in test_historicalscheduler.py
- Remove tests/test_scheduler and tests/test_subject from ruff exclude
  list; both now pass all ruff checks
- Standardise CI to actions/setup-python@v5 in code-quality job

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
