### PR TITLE
test: skip tkinter scheduler tests on PyPy (all platforms)

### DIFF
--- a/changes.md
+++ b/changes.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+- CI: Skip `tests/test_scheduler/test_mainloop/test_tkinterscheduler.py` on
+  PyPy (all platforms). The module creates a Tk root at import time; PyPy's
+  `_tkinter` finalizer calls `threading.notify_all` during interpreter
+  shutdown and aborts the xdist worker, failing whichever unrelated test
+  was running. Previously guarded only on macOS+PyPy.
 - Fix: `reactivex.timer(duetime, period)` now correctly resets the initial
   delay on each resubscription (e.g. via `repeat()`). Previously `nonlocal
   duetime` in the subscribe closure mutated the shared outer variable so

--- a/tests/test_scheduler/test_mainloop/test_tkinterscheduler.py
+++ b/tests/test_scheduler/test_mainloop/test_tkinterscheduler.py
@@ -1,5 +1,4 @@
 import os
-import platform
 import sys
 import unittest
 from datetime import timedelta
@@ -10,12 +9,14 @@ import pytest
 from reactivex.internal.basic import default_now
 from reactivex.scheduler.mainloop import TkinterScheduler
 
-# Skip entire module on PyPy + macOS due to threading issues with Tkinter
-# Error: "Tcl_AsyncDelete: async handler deleted by the wrong thread"
-# This occurs when pytest-xdist tries to parallelize tests that use Tkinter
-if platform.system() == "Darwin" and hasattr(sys, "pypy_version_info"):
+# Skip entire module on PyPy due to Tkinter interpreter/finalizer issues.
+# On macOS: "Tcl_AsyncDelete: async handler deleted by the wrong thread".
+# On Linux: PyPy's _tkinter app __del__ calls threading.notify_all during
+# interpreter shutdown, which aborts the xdist worker and fails whichever
+# test it was running.
+if hasattr(sys, "pypy_version_info"):
     pytest.skip(
-        "Tkinter tests are incompatible with PyPy on macOS", allow_module_level=True
+        "Tkinter tests are incompatible with PyPy", allow_module_level=True
     )
 
 tkinter = pytest.importorskip("tkinter")

--- a/tests/test_scheduler/test_mainloop/test_tkinterscheduler.py
+++ b/tests/test_scheduler/test_mainloop/test_tkinterscheduler.py
@@ -15,9 +15,7 @@ from reactivex.scheduler.mainloop import TkinterScheduler
 # interpreter shutdown, which aborts the xdist worker and fails whichever
 # test it was running.
 if hasattr(sys, "pypy_version_info"):
-    pytest.skip(
-        "Tkinter tests are incompatible with PyPy", allow_module_level=True
-    )
+    pytest.skip("Tkinter tests are incompatible with PyPy", allow_module_level=True)
 
 tkinter = pytest.importorskip("tkinter")
 


### PR DESCRIPTION
## Summary

- The module-scope `tkinter.Tk()` in `test_tkinterscheduler.py` triggers a PyPy interpreter-shutdown crash: `_tkinter/app.py` `__del__` → `threading.notify_all` → `Fatal Python error: Aborted`. Inside an xdist worker this kills the worker and fails whichever unrelated test it was running.
- The existing skip guard covered only macOS+PyPy. The same failure now surfaces on Linux+PyPy (observed on #757 CI, cascaded into cancelling the Windows and macOS PyPy jobs on the same run).
- Extend the skip guard to all PyPy platforms.

Example of the failure (from #757's run):
```
Fatal Python error: Aborted
  File \".../pypy3.10/_tkinter/app.py\", line 169 in __del__
  File \".../pypy3.10/threading.py\", line 389 in notify_all
  File \".../pypy3.10/threading.py\", line 568 in set
  File \".../xdist/remote.py\", line 100 in lock
  ...
[gw1] node down: Not properly terminated
FAILED tests/test_observable/test_case.py::TestCase::test_case_three
```

`test_case_three` has nothing to do with tkinter — it just happened to be on the worker when tkinter's finalizer aborted.

## Test plan

- [ ] CI PyPy-3.10 (ubuntu) job passes without `Fatal Python error: Aborted`.
- [ ] CI PyPy-3.10 (macos) job still passes (same skip still applies).
- [ ] CI CPython jobs unchanged — `pytest.importorskip(\"tkinter\")` still runs on CPython, so tkinter tests execute where a display is available and skip otherwise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)