### PR TITLE
[Repo Assist] test: fix pyright strict-mode errors in tests/test_subject/

### DIFF
--- a/changes.md
+++ b/changes.md
@@ -2,27 +2,26 @@
 
 ## Unreleased
 
-<<<<<<< repo-assist/fix-issue-480-scheduler-forwarding-ea9c5c512fb11be9
 - Operators: Fixed scheduler forwarding in `pairwise`, `to_marbles`, and
   `delay_with_mapper` (subscription-delay path). These operators now pass the
   `scheduler` argument through to `source.subscribe(...)` and, in the case of
   `delay_with_mapper`, to the subscription-delay observable, consistent with
   all other pipeable operators. Closes #480 (partial — the operators listed
   in the issue that were not yet fixed).
-
-=======
 - CI: Skip `tests/test_scheduler/test_mainloop/test_tkinterscheduler.py` on
   PyPy (all platforms). The module creates a Tk root at import time; PyPy's
   `_tkinter` finalizer calls `threading.notify_all` during interpreter
   shutdown and aborts the xdist worker, failing whichever unrelated test
   was running. Previously guarded only on macOS+PyPy.
->>>>>>> master
 - Fix: `reactivex.timer(duetime, period)` now correctly resets the initial
   delay on each resubscription (e.g. via `repeat()`). Previously `nonlocal
   duetime` in the subscribe closure mutated the shared outer variable so
   subsequent subscriptions would use the stale absolute time computed by the
   first subscription, causing the timer to fire immediately instead of waiting
   for `duetime`. Fixes #697.
+- Testing: Fixed pyright strict-mode type errors in `tests/test_subject/` (added type
+  annotations to closure containers, callback function parameters, and narrowed `None`
+  checks). Removed `tests/test_subject/` from the pyright exclude list.
 - Testing: Fixed ruff lint issues in `tests/test_scheduler/` (import ordering,
   f-string upgrades, `object` base class removal) and removed it from the
   ruff exclude list. `tests/test_subject/` also removed from the ruff exclude

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,10 +109,8 @@ asyncio_mode = "strict"
 [tool.pyright]
 include = ["reactivex", "tests"]
 exclude = [
-    # Stage 1 complete, Stage 2 partial (test_integration complete)
-    # test_subject and test_scheduler now pass ruff and pyright in standard mode
-    # keeping them excluded until type annotations are added to all callbacks (strict mode)
-    "tests/test_subject",
+    # Stage 1 complete, Stage 2 complete (test_subject done)
+    # test_scheduler still has strict-mode pyright errors
     "tests/test_scheduler",
     "tests/test_observable",
 ]

--- a/tests/test_subject/test_asyncsubject.py
+++ b/tests/test_subject/test_asyncsubject.py
@@ -1,5 +1,6 @@
 import pytest
 
+from reactivex.abc import DisposableBase, SchedulerBase
 from reactivex.internal.exceptions import DisposedException
 from reactivex.subject import AsyncSubject
 from reactivex.testing import ReactiveTest, TestScheduler
@@ -17,17 +18,12 @@ class RxException(Exception):
     pass
 
 
-# Helper function for raising exceptions within lambdas
-def _raise(ex):
-    raise RxException(ex)
-
-
 def test_infinite():
-    subject = [None]
-    subscription = [None]
-    subscription1 = [None]
-    subscription2 = [None]
-    subscription3 = [None]
+    subject: list[AsyncSubject[int] | None] = [None]
+    subscription: list[DisposableBase | None] = [None]
+    subscription1: list[DisposableBase | None] = [None]
+    subscription2: list[DisposableBase | None] = [None]
+    subscription3: list[DisposableBase | None] = [None]
 
     scheduler = TestScheduler()
     xs = scheduler.create_hot_observable(
@@ -48,52 +44,61 @@ def test_infinite():
     results2 = scheduler.create_observer()
     results3 = scheduler.create_observer()
 
-    def action1(scheduler, state=None):
+    def action1(scheduler: SchedulerBase, state: object = None) -> None:
         subject[0] = AsyncSubject()
 
     scheduler.schedule_absolute(100, action1)
 
-    def action2(scheduler, state=None):
+    def action2(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subject[0] is not None
         subscription[0] = xs.subscribe(subject[0])
 
     scheduler.schedule_absolute(200, action2)
 
-    def action3(scheduler, state=None):
+    def action3(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subscription[0] is not None
         subscription[0].dispose()
 
     scheduler.schedule_absolute(1000, action3)
 
-    def action4(scheduler, state=None):
+    def action4(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subject[0] is not None
         subscription1[0] = subject[0].subscribe(results1)
 
     scheduler.schedule_absolute(300, action4)
 
-    def action5(scheduler, state=None):
+    def action5(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subject[0] is not None
         subscription2[0] = subject[0].subscribe(results2)
 
     scheduler.schedule_absolute(400, action5)
 
-    def action6(scheduler, state=None):
+    def action6(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subject[0] is not None
         subscription3[0] = subject[0].subscribe(results3)
 
     scheduler.schedule_absolute(900, action6)
 
-    def action7(scheduler, state=None):
+    def action7(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subscription1[0] is not None
         subscription1[0].dispose()
 
     scheduler.schedule_absolute(600, action7)
 
-    def action8(scheduler, state=None):
+    def action8(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subscription2[0] is not None
         subscription2[0].dispose()
 
     scheduler.schedule_absolute(700, action8)
 
-    def action9(scheduler, state=None):
+    def action9(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subscription1[0] is not None
         subscription1[0].dispose()
 
     scheduler.schedule_absolute(800, action9)
 
-    def action10(scheduler, state=None):
+    def action10(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subscription3[0] is not None
         subscription3[0].dispose()
 
     scheduler.schedule_absolute(950, action10)
@@ -105,11 +110,11 @@ def test_infinite():
 
 
 def test_finite():
-    subject = [None]
-    subscription = [None]
-    subscription1 = [None]
-    subscription2 = [None]
-    subscription3 = [None]
+    subject: list[AsyncSubject[int] | None] = [None]
+    subscription: list[DisposableBase | None] = [None]
+    subscription1: list[DisposableBase | None] = [None]
+    subscription2: list[DisposableBase | None] = [None]
+    subscription3: list[DisposableBase | None] = [None]
 
     scheduler = TestScheduler()
     xs = scheduler.create_hot_observable(
@@ -129,52 +134,61 @@ def test_finite():
     results2 = scheduler.create_observer()
     results3 = scheduler.create_observer()
 
-    def action1(scheduler, state=None):
+    def action1(scheduler: SchedulerBase, state: object = None) -> None:
         subject[0] = AsyncSubject()
 
     scheduler.schedule_absolute(100, action1)
 
-    def action2(scheduler, state=None):
+    def action2(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subject[0] is not None
         subscription[0] = xs.subscribe(subject[0])
 
     scheduler.schedule_absolute(200, action2)
 
-    def action3(scheduler, state=None):
+    def action3(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subscription[0] is not None
         subscription[0].dispose()
 
     scheduler.schedule_absolute(1000, action3)
 
-    def action4(scheduler, state=None):
+    def action4(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subject[0] is not None
         subscription1[0] = subject[0].subscribe(results1)
 
     scheduler.schedule_absolute(300, action4)
 
-    def action5(scheduler, state=None):
+    def action5(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subject[0] is not None
         subscription2[0] = subject[0].subscribe(results2)
 
     scheduler.schedule_absolute(400, action5)
 
-    def action6(scheduler, state=None):
+    def action6(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subject[0] is not None
         subscription3[0] = subject[0].subscribe(results3)
 
     scheduler.schedule_absolute(900, action6)
 
-    def action7(scheduler, state=None):
+    def action7(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subscription1[0] is not None
         subscription1[0].dispose()
 
     scheduler.schedule_absolute(600, action7)
 
-    def action8(scheduler, state=None):
+    def action8(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subscription2[0] is not None
         subscription2[0].dispose()
 
     scheduler.schedule_absolute(700, action8)
 
-    def action9(scheduler, state=None):
+    def action9(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subscription1[0] is not None
         subscription1[0].dispose()
 
     scheduler.schedule_absolute(800, action9)
 
-    def action10(scheduler, state=None):
+    def action10(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subscription3[0] is not None
         subscription3[0].dispose()
 
     scheduler.schedule_absolute(950, action10)
@@ -186,11 +200,11 @@ def test_finite():
 
 
 def test_error():
-    subject = [None]
-    subscription = [None]
-    subscription1 = [None]
-    subscription2 = [None]
-    subscription3 = [None]
+    subject: list[AsyncSubject[int] | None] = [None]
+    subscription: list[DisposableBase | None] = [None]
+    subscription1: list[DisposableBase | None] = [None]
+    subscription2: list[DisposableBase | None] = [None]
+    subscription3: list[DisposableBase | None] = [None]
 
     ex = "ex"
     scheduler = TestScheduler()
@@ -211,52 +225,61 @@ def test_error():
     results2 = scheduler.create_observer()
     results3 = scheduler.create_observer()
 
-    def action(scheduler, state=None):
+    def action(scheduler: SchedulerBase, state: object = None) -> None:
         subject[0] = AsyncSubject()
 
     scheduler.schedule_absolute(100, action)
 
-    def action1(scheduler, state=None):
+    def action1(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subject[0] is not None
         subscription[0] = xs.subscribe(subject[0])
 
     scheduler.schedule_absolute(200, action1)
 
-    def action2(scheduler, state=None):
+    def action2(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subscription[0] is not None
         subscription[0].dispose()
 
     scheduler.schedule_absolute(1000, action2)
 
-    def action3(scheduler, state=None):
+    def action3(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subject[0] is not None
         subscription1[0] = subject[0].subscribe(results1)
 
     scheduler.schedule_absolute(300, action3)
 
-    def action4(scheduler, state=None):
+    def action4(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subject[0] is not None
         subscription2[0] = subject[0].subscribe(results2)
 
     scheduler.schedule_absolute(400, action4)
 
-    def action5(scheduler, state=None):
+    def action5(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subject[0] is not None
         subscription3[0] = subject[0].subscribe(results3)
 
     scheduler.schedule_absolute(900, action5)
 
-    def action6(scheduler, state=None):
+    def action6(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subscription1[0] is not None
         subscription1[0].dispose()
 
     scheduler.schedule_absolute(600, action6)
 
-    def action7(scheduler, state=None):
+    def action7(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subscription2[0] is not None
         subscription2[0].dispose()
 
     scheduler.schedule_absolute(700, action7)
 
-    def action8(scheduler, state=None):
+    def action8(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subscription1[0] is not None
         subscription1[0].dispose()
 
     scheduler.schedule_absolute(800, action8)
 
-    def action9(scheduler, state=None):
+    def action9(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subscription3[0] is not None
         subscription3[0].dispose()
 
     scheduler.schedule_absolute(950, action9)
@@ -268,11 +291,11 @@ def test_error():
 
 
 def test_canceled():
-    subject = [None]
-    subscription = [None]
-    subscription1 = [None]
-    subscription2 = [None]
-    subscription3 = [None]
+    subject: list[AsyncSubject[int] | None] = [None]
+    subscription: list[DisposableBase | None] = [None]
+    subscription1: list[DisposableBase | None] = [None]
+    subscription2: list[DisposableBase | None] = [None]
+    subscription3: list[DisposableBase | None] = [None]
 
     scheduler = TestScheduler()
     xs = scheduler.create_hot_observable(
@@ -283,52 +306,61 @@ def test_canceled():
     results2 = scheduler.create_observer()
     results3 = scheduler.create_observer()
 
-    def action1(scheduler, state=None):
+    def action1(scheduler: SchedulerBase, state: object = None) -> None:
         subject[0] = AsyncSubject()
 
     scheduler.schedule_absolute(100, action1)
 
-    def action2(scheduler, state=None):
+    def action2(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subject[0] is not None
         subscription[0] = xs.subscribe(subject[0])
 
     scheduler.schedule_absolute(200, action2)
 
-    def action3(scheduler, state=None):
+    def action3(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subscription[0] is not None
         subscription[0].dispose()
 
     scheduler.schedule_absolute(1000, action3)
 
-    def action4(scheduler, state=None):
+    def action4(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subject[0] is not None
         subscription1[0] = subject[0].subscribe(results1)
 
     scheduler.schedule_absolute(300, action4)
 
-    def action5(scheduler, state=None):
+    def action5(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subject[0] is not None
         subscription2[0] = subject[0].subscribe(results2)
 
     scheduler.schedule_absolute(400, action5)
 
-    def action6(scheduler, state=None):
+    def action6(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subject[0] is not None
         subscription3[0] = subject[0].subscribe(results3)
 
     scheduler.schedule_absolute(900, action6)
 
-    def action7(scheduler, state=None):
+    def action7(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subscription1[0] is not None
         subscription1[0].dispose()
 
     scheduler.schedule_absolute(600, action7)
 
-    def action8(scheduler, state=None):
+    def action8(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subscription2[0] is not None
         subscription2[0].dispose()
 
     scheduler.schedule_absolute(700, action8)
 
-    def action9(scheduler, state=None):
+    def action9(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subscription1[0] is not None
         subscription1[0].dispose()
 
     scheduler.schedule_absolute(800, action9)
 
-    def action10(scheduler, state=None):
+    def action10(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subscription3[0] is not None
         subscription3[0].dispose()
 
     scheduler.schedule_absolute(950, action10)
@@ -340,101 +372,117 @@ def test_canceled():
 
 
 def test_subject_disposed():
-    subject = [None]
-    subscription1 = [None]
-    subscription2 = [None]
-    subscription3 = [None]
+    subject: list[AsyncSubject[int] | None] = [None]
+    subscription1: list[DisposableBase | None] = [None]
+    subscription2: list[DisposableBase | None] = [None]
+    subscription3: list[DisposableBase | None] = [None]
     scheduler = TestScheduler()
 
     results1 = scheduler.create_observer()
     results2 = scheduler.create_observer()
     results3 = scheduler.create_observer()
 
-    def action1(scheduler, state=None):
+    def action1(scheduler: SchedulerBase, state: object = None) -> None:
         subject[0] = AsyncSubject()
 
     scheduler.schedule_absolute(100, action1)
 
-    def action2(scheduler, state=None):
+    def action2(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subject[0] is not None
         subscription1[0] = subject[0].subscribe(results1)
 
     scheduler.schedule_absolute(200, action2)
 
-    def action3(scheduler, state=None):
+    def action3(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subject[0] is not None
         subscription2[0] = subject[0].subscribe(results2)
 
     scheduler.schedule_absolute(300, action3)
 
-    def action4(scheduler, state=None):
+    def action4(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subject[0] is not None
         subscription3[0] = subject[0].subscribe(results3)
 
     scheduler.schedule_absolute(400, action4)
 
-    def action5(scheduler, state=None):
+    def action5(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subscription1[0] is not None
         subscription1[0].dispose()
 
     scheduler.schedule_absolute(500, action5)
 
-    def action6(scheduler, state=None):
+    def action6(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subject[0] is not None
         subject[0].dispose()
 
     scheduler.schedule_absolute(600, action6)
 
-    def action7(scheduler, state=None):
+    def action7(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subscription2[0] is not None
         subscription2[0].dispose()
 
     scheduler.schedule_absolute(700, action7)
 
-    def action8(scheduler, state=None):
+    def action8(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subscription3[0] is not None
         subscription3[0].dispose()
 
     scheduler.schedule_absolute(800, action8)
 
-    def action9(scheduler, state=None):
+    def action9(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subject[0] is not None
         subject[0].on_next(1)
 
     scheduler.schedule_absolute(150, action9)
 
-    def action10(scheduler, state=None):
+    def action10(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subject[0] is not None
         subject[0].on_next(2)
 
     scheduler.schedule_absolute(250, action10)
 
-    def action11(scheduler, state=None):
+    def action11(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subject[0] is not None
         subject[0].on_next(3)
 
     scheduler.schedule_absolute(350, action11)
 
-    def action12(scheduler, state=None):
+    def action12(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subject[0] is not None
         subject[0].on_next(4)
 
     scheduler.schedule_absolute(450, action12)
 
-    def action13(scheduler, state=None):
+    def action13(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subject[0] is not None
         subject[0].on_next(5)
 
     scheduler.schedule_absolute(550, action13)
 
-    def action14(scheduler, state=None):
+    def action14(scheduler: SchedulerBase, state: object = None) -> None:
         with pytest.raises(DisposedException):
+            assert subject[0] is not None
             subject[0].on_next(6)
 
     scheduler.schedule_absolute(650, action14)
 
-    def action15(scheduler, state=None):
+    def action15(scheduler: SchedulerBase, state: object = None) -> None:
         with pytest.raises(DisposedException):
+            assert subject[0] is not None
             subject[0].on_completed()
 
     scheduler.schedule_absolute(750, action15)
 
-    def action16(scheduler, state=None):
+    def action16(scheduler: SchedulerBase, state: object = None) -> None:
         with pytest.raises(DisposedException):
-            subject[0].on_error("ex")
+            assert subject[0] is not None
+            subject[0].on_error(Exception("ex"))
 
     scheduler.schedule_absolute(850, action16)
 
-    def action17(scheduler, state=None):
+    def action17(scheduler: SchedulerBase, state: object = None) -> None:
         with pytest.raises(DisposedException):
+            assert subject[0] is not None
             subject[0].subscribe(None)
 
     scheduler.schedule_absolute(950, action17)

--- a/tests/test_subject/test_behaviorsubject.py
+++ b/tests/test_subject/test_behaviorsubject.py
@@ -52,6 +52,7 @@ def test_infinite():
     scheduler.schedule_absolute(100, action1)
 
     def action2(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subject[0] is not None
         subscription[0] = xs.subscribe(subject[0])
 
     scheduler.schedule_absolute(200, action2)
@@ -156,6 +157,7 @@ def test_finite():
     scheduler.schedule_absolute(100, action1)
 
     def action2(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subject[0] is not None
         subscription[0] = xs.subscribe(subject[0])
 
     scheduler.schedule_absolute(200, action2)
@@ -262,6 +264,7 @@ def test_error():
     scheduler.schedule_absolute(100, action1)
 
     def action2(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subject[0] is not None
         subscription[0] = xs.subscribe(subject[0])
 
     scheduler.schedule_absolute(200, action2)
@@ -359,6 +362,7 @@ def test_canceled():
     scheduler.schedule_absolute(100, action1)
 
     def action2(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subject[0] is not None
         subscription[0] = xs.subscribe(subject[0])
 
     scheduler.schedule_absolute(200, action2)

--- a/tests/test_subject/test_behaviorsubject.py
+++ b/tests/test_subject/test_behaviorsubject.py
@@ -1,5 +1,6 @@
 import pytest
 
+from reactivex.abc import DisposableBase, SchedulerBase
 from reactivex.internal.exceptions import DisposedException
 from reactivex.subject import BehaviorSubject
 from reactivex.testing import ReactiveTest, TestScheduler
@@ -15,11 +16,6 @@ created = ReactiveTest.created
 
 class RxException(Exception):
     pass
-
-
-# Helper function for raising exceptions within lambdas
-def _raise(ex):
-    raise RxException(ex)
 
 
 def test_infinite():
@@ -40,62 +36,70 @@ def test_infinite():
         on_next(1020, 12),
     )
 
-    subject = [None]
-    subscription = [None]
-    subscription1 = [None]
-    subscription2 = [None]
-    subscription3 = [None]
+    subject: list[BehaviorSubject[int] | None] = [None]
+    subscription: list[DisposableBase | None] = [None]
+    subscription1: list[DisposableBase | None] = [None]
+    subscription2: list[DisposableBase | None] = [None]
+    subscription3: list[DisposableBase | None] = [None]
 
     results1 = scheduler.create_observer()
     results2 = scheduler.create_observer()
     results3 = scheduler.create_observer()
 
-    def action1(scheduler, state=None):
+    def action1(scheduler: SchedulerBase, state: object = None) -> None:
         subject[0] = BehaviorSubject(100)
 
     scheduler.schedule_absolute(100, action1)
 
-    def action2(scheduler, state=None):
+    def action2(scheduler: SchedulerBase, state: object = None) -> None:
         subscription[0] = xs.subscribe(subject[0])
 
     scheduler.schedule_absolute(200, action2)
 
-    def action3(scheduler, state=None):
+    def action3(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subscription[0] is not None
         subscription[0].dispose()
 
     scheduler.schedule_absolute(1000, action3)
 
-    def action4(scheduler, state=None):
+    def action4(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subject[0] is not None
         subscription1[0] = subject[0].subscribe(results1)
 
     scheduler.schedule_absolute(300, action4)
 
-    def action5(scheduler, state=None):
+    def action5(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subject[0] is not None
         subscription2[0] = subject[0].subscribe(results2)
 
     scheduler.schedule_absolute(400, action5)
 
-    def action6(scheduler, state=None):
+    def action6(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subject[0] is not None
         subscription3[0] = subject[0].subscribe(results3)
 
     scheduler.schedule_absolute(900, action6)
 
-    def action7(scheduler, state=None):
+    def action7(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subscription1[0] is not None
         subscription1[0].dispose()
 
     scheduler.schedule_absolute(600, action7)
 
-    def action8(scheduler, state=None):
+    def action8(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subscription2[0] is not None
         subscription2[0].dispose()
 
     scheduler.schedule_absolute(700, action8)
 
-    def action9(scheduler, state=None):
+    def action9(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subscription1[0] is not None
         subscription1[0].dispose()
 
     scheduler.schedule_absolute(800, action9)
 
-    def action10(scheduler, state=None):
+    def action10(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subscription3[0] is not None
         subscription3[0].dispose()
 
     scheduler.schedule_absolute(950, action10)
@@ -136,62 +140,70 @@ def test_finite():
         on_error(660, RxException()),
     )
 
-    subject = [None]
-    subscription = [None]
-    subscription1 = [None]
-    subscription2 = [None]
-    subscription3 = [None]
+    subject: list[BehaviorSubject[int] | None] = [None]
+    subscription: list[DisposableBase | None] = [None]
+    subscription1: list[DisposableBase | None] = [None]
+    subscription2: list[DisposableBase | None] = [None]
+    subscription3: list[DisposableBase | None] = [None]
 
     results1 = scheduler.create_observer()
     results2 = scheduler.create_observer()
     results3 = scheduler.create_observer()
 
-    def action1(scheduler, state=None):
+    def action1(scheduler: SchedulerBase, state: object = None) -> None:
         subject[0] = BehaviorSubject(100)
 
     scheduler.schedule_absolute(100, action1)
 
-    def action2(scheduler, state=None):
+    def action2(scheduler: SchedulerBase, state: object = None) -> None:
         subscription[0] = xs.subscribe(subject[0])
 
     scheduler.schedule_absolute(200, action2)
 
-    def action3(scheduler, state=None):
+    def action3(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subscription[0] is not None
         subscription[0].dispose()
 
     scheduler.schedule_absolute(1000, action3)
 
-    def action4(scheduler, state=None):
+    def action4(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subject[0] is not None
         subscription1[0] = subject[0].subscribe(results1)
 
     scheduler.schedule_absolute(300, action4)
 
-    def action5(scheduler, state=None):
+    def action5(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subject[0] is not None
         subscription2[0] = subject[0].subscribe(results2)
 
     scheduler.schedule_absolute(400, action5)
 
-    def action6(scheduler, state=None):
+    def action6(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subject[0] is not None
         subscription3[0] = subject[0].subscribe(results3)
 
     scheduler.schedule_absolute(900, action6)
 
-    def action7(scheduler, state=None):
+    def action7(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subscription1[0] is not None
         subscription1[0].dispose()
 
     scheduler.schedule_absolute(600, action7)
 
-    def action8(scheduler, state=None):
+    def action8(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subscription2[0] is not None
         subscription2[0].dispose()
 
     scheduler.schedule_absolute(700, action8)
 
-    def action9(scheduler, state=None):
+    def action9(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subscription1[0] is not None
         subscription1[0].dispose()
 
     scheduler.schedule_absolute(800, action9)
 
-    def action10(scheduler, state=None):
+    def action10(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subscription3[0] is not None
         subscription3[0].dispose()
 
     scheduler.schedule_absolute(950, action10)
@@ -234,62 +246,70 @@ def test_error():
         on_error(660, RxException()),
     )
 
-    subject = [None]
-    subscription = [None]
-    subscription1 = [None]
-    subscription2 = [None]
-    subscription3 = [None]
+    subject: list[BehaviorSubject[int] | None] = [None]
+    subscription: list[DisposableBase | None] = [None]
+    subscription1: list[DisposableBase | None] = [None]
+    subscription2: list[DisposableBase | None] = [None]
+    subscription3: list[DisposableBase | None] = [None]
 
     results1 = scheduler.create_observer()
     results2 = scheduler.create_observer()
     results3 = scheduler.create_observer()
 
-    def action1(scheduler, state=None):
+    def action1(scheduler: SchedulerBase, state: object = None) -> None:
         subject[0] = BehaviorSubject(100)
 
     scheduler.schedule_absolute(100, action1)
 
-    def action2(scheduler, state=None):
+    def action2(scheduler: SchedulerBase, state: object = None) -> None:
         subscription[0] = xs.subscribe(subject[0])
 
     scheduler.schedule_absolute(200, action2)
 
-    def action3(scheduler, state=None):
+    def action3(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subscription[0] is not None
         subscription[0].dispose()
 
     scheduler.schedule_absolute(1000, action3)
 
-    def action4(scheduler, state=None):
+    def action4(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subject[0] is not None
         subscription1[0] = subject[0].subscribe(results1)
 
     scheduler.schedule_absolute(300, action4)
 
-    def action5(scheduler, state=None):
+    def action5(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subject[0] is not None
         subscription2[0] = subject[0].subscribe(results2)
 
     scheduler.schedule_absolute(400, action5)
 
-    def action6(scheduler, state=None):
+    def action6(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subject[0] is not None
         subscription3[0] = subject[0].subscribe(results3)
 
     scheduler.schedule_absolute(900, action6)
 
-    def action7(scheduler, state=None):
+    def action7(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subscription1[0] is not None
         subscription1[0].dispose()
 
     scheduler.schedule_absolute(600, action7)
 
-    def action8(scheduler, state=None):
+    def action8(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subscription2[0] is not None
         subscription2[0].dispose()
 
     scheduler.schedule_absolute(700, action8)
 
-    def action9(scheduler, state=None):
+    def action9(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subscription1[0] is not None
         subscription1[0].dispose()
 
     scheduler.schedule_absolute(800, action9)
 
-    def action10(scheduler, state=None):
+    def action10(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subscription3[0] is not None
         subscription3[0].dispose()
 
     scheduler.schedule_absolute(950, action10)
@@ -323,62 +343,70 @@ def test_canceled():
         on_error(660, RxException()),
     )
 
-    subject = [None]
-    subscription = [None]
-    subscription1 = [None]
-    subscription2 = [None]
-    subscription3 = [None]
+    subject: list[BehaviorSubject[int] | None] = [None]
+    subscription: list[DisposableBase | None] = [None]
+    subscription1: list[DisposableBase | None] = [None]
+    subscription2: list[DisposableBase | None] = [None]
+    subscription3: list[DisposableBase | None] = [None]
 
     results1 = scheduler.create_observer()
     results2 = scheduler.create_observer()
     results3 = scheduler.create_observer()
 
-    def action1(scheduler, state=None):
+    def action1(scheduler: SchedulerBase, state: object = None) -> None:
         subject[0] = BehaviorSubject(100)
 
     scheduler.schedule_absolute(100, action1)
 
-    def action2(scheduler, state=None):
+    def action2(scheduler: SchedulerBase, state: object = None) -> None:
         subscription[0] = xs.subscribe(subject[0])
 
     scheduler.schedule_absolute(200, action2)
 
-    def action3(scheduler, state=None):
+    def action3(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subscription[0] is not None
         subscription[0].dispose()
 
     scheduler.schedule_absolute(1000, action3)
 
-    def action4(scheduler, state=None):
+    def action4(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subject[0] is not None
         subscription1[0] = subject[0].subscribe(results1)
 
     scheduler.schedule_absolute(300, action4)
 
-    def action5(scheduler, state=None):
+    def action5(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subject[0] is not None
         subscription2[0] = subject[0].subscribe(results2)
 
     scheduler.schedule_absolute(400, action5)
 
-    def action6(scheduler, state=None):
+    def action6(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subject[0] is not None
         subscription3[0] = subject[0].subscribe(results3)
 
     scheduler.schedule_absolute(900, action6)
 
-    def action7(scheduler, state=None):
+    def action7(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subscription1[0] is not None
         subscription1[0].dispose()
 
     scheduler.schedule_absolute(600, action7)
 
-    def action8(scheduler, state=None):
+    def action8(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subscription2[0] is not None
         subscription2[0].dispose()
 
     scheduler.schedule_absolute(700, action8)
 
-    def action9(scheduler, state=None):
+    def action9(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subscription1[0] is not None
         subscription1[0].dispose()
 
     scheduler.schedule_absolute(800, action9)
 
-    def action10(scheduler, state=None):
+    def action10(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subscription3[0] is not None
         subscription3[0].dispose()
 
     scheduler.schedule_absolute(950, action10)
@@ -395,102 +423,118 @@ def test_canceled():
 def test_subject_disposed():
     scheduler = TestScheduler()
 
-    subject = [None]
+    subject: list[BehaviorSubject[int] | None] = [None]
 
     results1 = scheduler.create_observer()
-    subscription1 = [None]
+    subscription1: list[DisposableBase | None] = [None]
 
     results2 = scheduler.create_observer()
-    subscription2 = [None]
+    subscription2: list[DisposableBase | None] = [None]
 
     results3 = scheduler.create_observer()
-    subscription3 = [None]
+    subscription3: list[DisposableBase | None] = [None]
 
-    def action1(scheduler, state=None):
+    def action1(scheduler: SchedulerBase, state: object = None) -> None:
         subject[0] = BehaviorSubject(0)
 
     scheduler.schedule_absolute(100, action1)
 
-    def action2(scheduler, state=None):
+    def action2(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subject[0] is not None
         subscription1[0] = subject[0].subscribe(results1)
 
     scheduler.schedule_absolute(200, action2)
 
-    def action3(scheduler, state=None):
+    def action3(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subject[0] is not None
         subscription2[0] = subject[0].subscribe(results2)
 
     scheduler.schedule_absolute(300, action3)
 
-    def action4(scheduler, state=None):
+    def action4(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subject[0] is not None
         subscription3[0] = subject[0].subscribe(results3)
 
     scheduler.schedule_absolute(400, action4)
 
-    def action5(scheduler, state=None):
+    def action5(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subscription1[0] is not None
         subscription1[0].dispose()
 
     scheduler.schedule_absolute(500, action5)
 
-    def action6(scheduler, state=None):
+    def action6(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subject[0] is not None
         subject[0].dispose()
 
     scheduler.schedule_absolute(600, action6)
 
-    def action7(scheduler, state=None):
+    def action7(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subscription2[0] is not None
         subscription2[0].dispose()
 
     scheduler.schedule_absolute(700, action7)
 
-    def action8(scheduler, state=None):
+    def action8(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subscription3[0] is not None
         subscription3[0].dispose()
 
     scheduler.schedule_absolute(800, action8)
 
-    def action9(scheduler, state=None):
+    def action9(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subject[0] is not None
         subject[0].on_next(1)
 
     scheduler.schedule_absolute(150, action9)
 
-    def action10(scheduler, state=None):
+    def action10(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subject[0] is not None
         subject[0].on_next(2)
 
     scheduler.schedule_absolute(250, action10)
 
-    def action11(scheduler, state=None):
+    def action11(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subject[0] is not None
         subject[0].on_next(3)
 
     scheduler.schedule_absolute(350, action11)
 
-    def action12(scheduler, state=None):
+    def action12(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subject[0] is not None
         subject[0].on_next(4)
 
     scheduler.schedule_absolute(450, action12)
 
-    def action13(scheduler, state=None):
+    def action13(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subject[0] is not None
         subject[0].on_next(5)
 
     scheduler.schedule_absolute(550, action13)
 
-    def action14(scheduler, state=None):
+    def action14(scheduler: SchedulerBase, state: object = None) -> None:
         with pytest.raises(DisposedException):
+            assert subject[0] is not None
             subject[0].on_next(6)
 
     scheduler.schedule_absolute(650, action14)
 
-    def action15(scheduler, state=None):
+    def action15(scheduler: SchedulerBase, state: object = None) -> None:
         with pytest.raises(DisposedException):
+            assert subject[0] is not None
             subject[0].on_completed()
 
     scheduler.schedule_absolute(750, action15)
 
-    def action16(scheduler, state=None):
+    def action16(scheduler: SchedulerBase, state: object = None) -> None:
         with pytest.raises(DisposedException):
+            assert subject[0] is not None
             subject[0].on_error(RxException())
 
     scheduler.schedule_absolute(850, action16)
 
-    def action17(scheduler, state=None):
+    def action17(scheduler: SchedulerBase, state: object = None) -> None:
         with pytest.raises(DisposedException):
+            assert subject[0] is not None
             subject[0].subscribe(None)
 
     scheduler.schedule_absolute(950, action17)

--- a/tests/test_subject/test_replaysubject.py
+++ b/tests/test_subject/test_replaysubject.py
@@ -54,6 +54,7 @@ def test_infinite():
     scheduler.schedule_absolute(100, action1)
 
     def action2(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subject[0] is not None
         subscription[0] = xs.subscribe(subject[0])
 
     scheduler.schedule_absolute(200, action2)
@@ -162,6 +163,7 @@ def test_infinite2():
     scheduler.schedule_absolute(100, action1)
 
     def action2(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subject[0] is not None
         subscription[0] = xs.subscribe(subject[0])
 
     scheduler.schedule_absolute(200, action2)
@@ -268,6 +270,7 @@ def test_finite():
     scheduler.schedule_absolute(100, action1)
 
     def action3(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subject[0] is not None
         subscription[0] = xs.subscribe(subject[0])
 
     scheduler.schedule_absolute(200, action3)
@@ -375,6 +378,7 @@ def test_error():
     scheduler.schedule_absolute(100, action1)
 
     def action2(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subject[0] is not None
         subscription[0] = xs.subscribe(subject[0])
 
     scheduler.schedule_absolute(200, action2)
@@ -473,6 +477,7 @@ def test_canceled():
     scheduler.schedule_absolute(100, action1)
 
     def action2(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subject[0] is not None
         subscription[0] = xs.subscribe(subject[0])
 
     scheduler.schedule_absolute(200, action2)
@@ -704,6 +709,7 @@ def test_replay_subject_dies_out():
     scheduler.schedule_absolute(100, action1)
 
     def action2(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subject[0] is not None
         xs.subscribe(subject[0])
 
     scheduler.schedule_absolute(200, action2)

--- a/tests/test_subject/test_replaysubject.py
+++ b/tests/test_subject/test_replaysubject.py
@@ -2,6 +2,7 @@ import sys
 
 import pytest
 
+from reactivex.abc import DisposableBase, SchedulerBase
 from reactivex.internal.exceptions import DisposedException
 from reactivex.subject import ReplaySubject
 from reactivex.testing import ReactiveTest, TestScheduler
@@ -17,11 +18,6 @@ created = ReactiveTest.created
 
 class RxException(Exception):
     pass
-
-
-# Helper function for raising exceptions within lambdas
-def _raise(ex):
-    raise RxException(ex)
 
 
 def test_infinite():
@@ -42,62 +38,70 @@ def test_infinite():
         on_next(1020, 12),
     )
 
-    subject = [None]
-    subscription = [None]
-    subscription1 = [None]
-    subscription2 = [None]
-    subscription3 = [None]
+    subject: list[ReplaySubject[int] | None] = [None]
+    subscription: list[DisposableBase | None] = [None]
+    subscription1: list[DisposableBase | None] = [None]
+    subscription2: list[DisposableBase | None] = [None]
+    subscription3: list[DisposableBase | None] = [None]
 
     results1 = scheduler.create_observer()
     results2 = scheduler.create_observer()
     results3 = scheduler.create_observer()
 
-    def action1(scheduler, state=None):
+    def action1(scheduler: SchedulerBase, state: object = None) -> None:
         subject[0] = ReplaySubject(3, 100, scheduler)
 
     scheduler.schedule_absolute(100, action1)
 
-    def action2(scheduler, state=None):
+    def action2(scheduler: SchedulerBase, state: object = None) -> None:
         subscription[0] = xs.subscribe(subject[0])
 
     scheduler.schedule_absolute(200, action2)
 
-    def action3(scheduler, state=None):
+    def action3(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subscription[0] is not None
         subscription[0].dispose()
 
     scheduler.schedule_absolute(1000, action3)
 
-    def action4(scheduler, state=None):
+    def action4(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subject[0] is not None
         subscription1[0] = subject[0].subscribe(results1)
 
     scheduler.schedule_absolute(300, action4)
 
-    def action5(scheduler, state=None):
+    def action5(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subject[0] is not None
         subscription2[0] = subject[0].subscribe(results2)
 
     scheduler.schedule_absolute(400, action5)
 
-    def action6(scheduler, state=None):
+    def action6(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subject[0] is not None
         subscription3[0] = subject[0].subscribe(results3)
 
     scheduler.schedule_absolute(900, action6)
 
-    def action7(scheduler, state=None):
+    def action7(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subscription1[0] is not None
         subscription1[0].dispose()
 
     scheduler.schedule_absolute(600, action7)
 
-    def action8(scheduler, state=None):
+    def action8(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subscription2[0] is not None
         subscription2[0].dispose()
 
     scheduler.schedule_absolute(700, action8)
 
-    def action9(scheduler, state=None):
+    def action9(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subscription1[0] is not None
         subscription1[0].dispose()
 
     scheduler.schedule_absolute(800, action9)
 
-    def action10(scheduler, state=None):
+    def action10(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subscription3[0] is not None
         subscription3[0].dispose()
 
     scheduler.schedule_absolute(950, action10)
@@ -142,62 +146,70 @@ def test_infinite2():
         on_next(1020, 12),
     )
 
-    subject = [None]
-    subscription = [None]
-    subscription1 = [None]
-    subscription2 = [None]
-    subscription3 = [None]
+    subject: list[ReplaySubject[int] | None] = [None]
+    subscription: list[DisposableBase | None] = [None]
+    subscription1: list[DisposableBase | None] = [None]
+    subscription2: list[DisposableBase | None] = [None]
+    subscription3: list[DisposableBase | None] = [None]
 
     results1 = scheduler.create_observer()
     results2 = scheduler.create_observer()
     results3 = scheduler.create_observer()
 
-    def action1(scheduler, state=None):
+    def action1(scheduler: SchedulerBase, state: object = None) -> None:
         subject[0] = ReplaySubject(3, 100, scheduler)
 
     scheduler.schedule_absolute(100, action1)
 
-    def action2(scheduler, state=None):
+    def action2(scheduler: SchedulerBase, state: object = None) -> None:
         subscription[0] = xs.subscribe(subject[0])
 
     scheduler.schedule_absolute(200, action2)
 
-    def action3(scheduler, state=None):
+    def action3(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subscription[0] is not None
         subscription[0].dispose()
 
     scheduler.schedule_absolute(1000, action3)
 
-    def action4(scheduler, state=None):
+    def action4(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subject[0] is not None
         subscription1[0] = subject[0].subscribe(results1)
 
     scheduler.schedule_absolute(300, action4)
 
-    def action5(scheduler, state=None):
+    def action5(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subject[0] is not None
         subscription2[0] = subject[0].subscribe(results2)
 
     scheduler.schedule_absolute(400, action5)
 
-    def action6(scheduler, state=None):
+    def action6(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subject[0] is not None
         subscription3[0] = subject[0].subscribe(results3)
 
     scheduler.schedule_absolute(900, action6)
 
-    def action7(scheduler, state=None):
+    def action7(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subscription1[0] is not None
         subscription1[0].dispose()
 
     scheduler.schedule_absolute(600, action7)
 
-    def action8(scheduler, state=None):
+    def action8(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subscription2[0] is not None
         subscription2[0].dispose()
 
     scheduler.schedule_absolute(700, action8)
 
-    def action9(scheduler, state=None):
+    def action9(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subscription1[0] is not None
         subscription1[0].dispose()
 
     scheduler.schedule_absolute(800, action9)
 
-    def action10(scheduler, state=None):
+    def action10(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subscription3[0] is not None
         subscription3[0].dispose()
 
     scheduler.schedule_absolute(950, action10)
@@ -240,62 +252,70 @@ def test_finite():
         on_error(660, "ex"),
     )
 
-    subject = [None]
-    subscription = [None]
-    subscription1 = [None]
-    subscription2 = [None]
-    subscription3 = [None]
+    subject: list[ReplaySubject[int] | None] = [None]
+    subscription: list[DisposableBase | None] = [None]
+    subscription1: list[DisposableBase | None] = [None]
+    subscription2: list[DisposableBase | None] = [None]
+    subscription3: list[DisposableBase | None] = [None]
 
     results1 = scheduler.create_observer()
     results2 = scheduler.create_observer()
     results3 = scheduler.create_observer()
 
-    def action1(scheduler, state=None):
+    def action1(scheduler: SchedulerBase, state: object = None) -> None:
         subject[0] = ReplaySubject(3, 100, scheduler)
 
     scheduler.schedule_absolute(100, action1)
 
-    def action3(scheduler, state=None):
+    def action3(scheduler: SchedulerBase, state: object = None) -> None:
         subscription[0] = xs.subscribe(subject[0])
 
     scheduler.schedule_absolute(200, action3)
 
-    def action4(scheduler, state=None):
+    def action4(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subscription[0] is not None
         subscription[0].dispose()
 
     scheduler.schedule_absolute(1000, action4)
 
-    def action5(scheduler, state=None):
+    def action5(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subject[0] is not None
         subscription1[0] = subject[0].subscribe(results1)
 
     scheduler.schedule_absolute(300, action5)
 
-    def action6(scheduler, state=None):
+    def action6(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subject[0] is not None
         subscription2[0] = subject[0].subscribe(results2)
 
     scheduler.schedule_absolute(400, action6)
 
-    def action7(scheduler, state=None):
+    def action7(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subject[0] is not None
         subscription3[0] = subject[0].subscribe(results3)
 
     scheduler.schedule_absolute(900, action7)
 
-    def action8(scheduler, state=None):
+    def action8(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subscription1[0] is not None
         subscription1[0].dispose()
 
     scheduler.schedule_absolute(600, action8)
 
-    def action9(scheduler, state=None):
+    def action9(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subscription2[0] is not None
         subscription2[0].dispose()
 
     scheduler.schedule_absolute(700, action9)
 
-    def action10(scheduler, state=None):
+    def action10(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subscription1[0] is not None
         subscription1[0].dispose()
 
     scheduler.schedule_absolute(800, action10)
 
-    def action11(scheduler, state=None):
+    def action11(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subscription3[0] is not None
         subscription3[0].dispose()
 
     scheduler.schedule_absolute(950, action11)
@@ -339,62 +359,70 @@ def test_error():
         on_error(660, RxException("ex")),
     )
 
-    subject = [None]
-    subscription = [None]
-    subscription1 = [None]
-    subscription2 = [None]
-    subscription3 = [None]
+    subject: list[ReplaySubject[int] | None] = [None]
+    subscription: list[DisposableBase | None] = [None]
+    subscription1: list[DisposableBase | None] = [None]
+    subscription2: list[DisposableBase | None] = [None]
+    subscription3: list[DisposableBase | None] = [None]
 
     results1 = scheduler.create_observer()
     results2 = scheduler.create_observer()
     results3 = scheduler.create_observer()
 
-    def action1(scheduler, state=None):
+    def action1(scheduler: SchedulerBase, state: object = None) -> None:
         subject[0] = ReplaySubject(3, 100, scheduler)
 
     scheduler.schedule_absolute(100, action1)
 
-    def action2(scheduler, state=None):
+    def action2(scheduler: SchedulerBase, state: object = None) -> None:
         subscription[0] = xs.subscribe(subject[0])
 
     scheduler.schedule_absolute(200, action2)
 
-    def action3(scheduler, state=None):
+    def action3(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subscription[0] is not None
         subscription[0].dispose()
 
     scheduler.schedule_absolute(1000, action3)
 
-    def action4(scheduler, state=None):
+    def action4(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subject[0] is not None
         subscription1[0] = subject[0].subscribe(results1)
 
     scheduler.schedule_absolute(300, action4)
 
-    def action5(scheduler, state=None):
+    def action5(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subject[0] is not None
         subscription2[0] = subject[0].subscribe(results2)
 
     scheduler.schedule_absolute(400, action5)
 
-    def action6(scheduler, state=None):
+    def action6(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subject[0] is not None
         subscription3[0] = subject[0].subscribe(results3)
 
     scheduler.schedule_absolute(900, action6)
 
-    def action7(scheduler, state=None):
+    def action7(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subscription1[0] is not None
         subscription1[0].dispose()
 
     scheduler.schedule_absolute(600, action7)
 
-    def action8(scheduler, state=None):
+    def action8(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subscription2[0] is not None
         subscription2[0].dispose()
 
     scheduler.schedule_absolute(700, action8)
 
-    def action9(scheduler, state=None):
+    def action9(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subscription1[0] is not None
         subscription1[0].dispose()
 
     scheduler.schedule_absolute(800, action9)
 
-    def action10(scheduler, state=None):
+    def action10(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subscription3[0] is not None
         subscription3[0].dispose()
 
     scheduler.schedule_absolute(950, action10)
@@ -429,62 +457,70 @@ def test_canceled():
         on_error(660, RxException()),
     )
 
-    subject = [None]
-    subscription = [None]
-    subscription1 = [None]
-    subscription2 = [None]
-    subscription3 = [None]
+    subject: list[ReplaySubject[int] | None] = [None]
+    subscription: list[DisposableBase | None] = [None]
+    subscription1: list[DisposableBase | None] = [None]
+    subscription2: list[DisposableBase | None] = [None]
+    subscription3: list[DisposableBase | None] = [None]
 
     results1 = scheduler.create_observer()
     results2 = scheduler.create_observer()
     results3 = scheduler.create_observer()
 
-    def action1(scheduler, state=None):
+    def action1(scheduler: SchedulerBase, state: object = None) -> None:
         subject[0] = ReplaySubject(3, 100, scheduler)
 
     scheduler.schedule_absolute(100, action1)
 
-    def action2(scheduler, state=None):
+    def action2(scheduler: SchedulerBase, state: object = None) -> None:
         subscription[0] = xs.subscribe(subject[0])
 
     scheduler.schedule_absolute(200, action2)
 
-    def action3(scheduler, state=None):
+    def action3(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subscription[0] is not None
         subscription[0].dispose()
 
     scheduler.schedule_absolute(1000, action3)
 
-    def action4(scheduler, state=None):
+    def action4(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subject[0] is not None
         subscription1[0] = subject[0].subscribe(results1)
 
     scheduler.schedule_absolute(300, action4)
 
-    def action5(scheduler, state=None):
+    def action5(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subject[0] is not None
         subscription2[0] = subject[0].subscribe(results2)
 
     scheduler.schedule_absolute(400, action5)
 
-    def action6(scheduler, state=None):
+    def action6(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subject[0] is not None
         subscription3[0] = subject[0].subscribe(results3)
 
     scheduler.schedule_absolute(900, action6)
 
-    def action7(scheduler, state=None):
+    def action7(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subscription1[0] is not None
         subscription1[0].dispose()
 
     scheduler.schedule_absolute(600, action7)
 
-    def action8(scheduler, state=None):
+    def action8(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subscription2[0] is not None
         subscription2[0].dispose()
 
     scheduler.schedule_absolute(700, action8)
 
-    def action9(scheduler, state=None):
+    def action9(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subscription1[0] is not None
         subscription1[0].dispose()
 
     scheduler.schedule_absolute(800, action9)
 
-    def action10(scheduler, state=None):
+    def action10(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subscription3[0] is not None
         subscription3[0].dispose()
 
     scheduler.schedule_absolute(950, action10)
@@ -501,100 +537,116 @@ def test_canceled():
 def test_subject_disposed():
     scheduler = TestScheduler()
 
-    subject = [None]
-    subscription1 = [None]
-    subscription2 = [None]
-    subscription3 = [None]
+    subject: list[ReplaySubject[int] | None] = [None]
+    subscription1: list[DisposableBase | None] = [None]
+    subscription2: list[DisposableBase | None] = [None]
+    subscription3: list[DisposableBase | None] = [None]
 
     results1 = scheduler.create_observer()
     results2 = scheduler.create_observer()
     results3 = scheduler.create_observer()
 
-    def action1(scheduler, state=None):
+    def action1(scheduler: SchedulerBase, state: object = None) -> None:
         subject[0] = ReplaySubject(scheduler=scheduler)
 
     scheduler.schedule_absolute(100, action1)
 
-    def action2(scheduler, state=None):
+    def action2(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subject[0] is not None
         subscription1[0] = subject[0].subscribe(results1)
 
     scheduler.schedule_absolute(200, action2)
 
-    def action3(scheduler, state=None):
+    def action3(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subject[0] is not None
         subscription2[0] = subject[0].subscribe(results2)
 
     scheduler.schedule_absolute(300, action3)
 
-    def action4(scheduler, state=None):
+    def action4(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subject[0] is not None
         subscription3[0] = subject[0].subscribe(results3)
 
     scheduler.schedule_absolute(400, action4)
 
-    def action5(scheduler, state=None):
+    def action5(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subscription1[0] is not None
         subscription1[0].dispose()
 
     scheduler.schedule_absolute(500, action5)
 
-    def action6(scheduler, state=None):
+    def action6(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subject[0] is not None
         subject[0].dispose()
 
     scheduler.schedule_absolute(600, action6)
 
-    def action7(scheduler, state=None):
+    def action7(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subscription2[0] is not None
         subscription2[0].dispose()
 
     scheduler.schedule_absolute(700, action7)
 
-    def action8(scheduler, state=None):
+    def action8(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subscription3[0] is not None
         subscription3[0].dispose()
 
     scheduler.schedule_absolute(800, action8)
 
-    def action9(scheduler, state=None):
+    def action9(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subject[0] is not None
         subject[0].on_next(1)
 
     scheduler.schedule_absolute(150, action9)
 
-    def action10(scheduler, state=None):
+    def action10(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subject[0] is not None
         subject[0].on_next(2)
 
     scheduler.schedule_absolute(250, action10)
 
-    def action11(scheduler, state=None):
+    def action11(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subject[0] is not None
         subject[0].on_next(3)
 
     scheduler.schedule_absolute(350, action11)
 
-    def action12(scheduler, state=None):
+    def action12(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subject[0] is not None
         subject[0].on_next(4)
 
     scheduler.schedule_absolute(450, action12)
 
-    def action13(scheduler, state=None):
+    def action13(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subject[0] is not None
         subject[0].on_next(5)
 
     scheduler.schedule_absolute(550, action13)
 
-    def action14(scheduler, state=None):
+    def action14(scheduler: SchedulerBase, state: object = None) -> None:
         with pytest.raises(DisposedException):
+            assert subject[0] is not None
             subject[0].on_next(6)
 
     scheduler.schedule_absolute(650, action14)
 
-    def action15(scheduler, state=None):
+    def action15(scheduler: SchedulerBase, state: object = None) -> None:
         with pytest.raises(DisposedException):
+            assert subject[0] is not None
             subject[0].on_completed()
 
     scheduler.schedule_absolute(750, action15)
 
-    def action16(scheduler, state=None):
+    def action16(scheduler: SchedulerBase, state: object = None) -> None:
         with pytest.raises(DisposedException):
+            assert subject[0] is not None
             subject[0].on_error(Exception())
 
     scheduler.schedule_absolute(850, action16)
 
-    def action17(scheduler, state=None):
+    def action17(scheduler: SchedulerBase, state: object = None) -> None:
         with pytest.raises(DisposedException):
+            assert subject[0] is not None
             subject[0].subscribe(None)
 
     scheduler.schedule_absolute(950, action17)
@@ -639,39 +691,43 @@ def test_replay_subject_dies_out():
         on_completed(580),
     )
 
-    subject = [None]
+    subject: list[ReplaySubject[int] | None] = [None]
 
     results1 = scheduler.create_observer()
     results2 = scheduler.create_observer()
     results3 = scheduler.create_observer()
     results4 = scheduler.create_observer()
 
-    def action1(scheduler, state=None):
+    def action1(scheduler: SchedulerBase, state: object = None) -> None:
         subject[0] = ReplaySubject(sys.maxsize, 100, scheduler)
 
     scheduler.schedule_absolute(100, action1)
 
-    def action2(scheduler, state=None):
+    def action2(scheduler: SchedulerBase, state: object = None) -> None:
         xs.subscribe(subject[0])
 
     scheduler.schedule_absolute(200, action2)
 
-    def action3(scheduler, state=None):
+    def action3(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subject[0] is not None
         subject[0].subscribe(results1)
 
     scheduler.schedule_absolute(300, action3)
 
-    def action4(scheduler, state=None):
+    def action4(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subject[0] is not None
         subject[0].subscribe(results2)
 
     scheduler.schedule_absolute(400, action4)
 
-    def action5(scheduler, state=None):
+    def action5(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subject[0] is not None
         subject[0].subscribe(results3)
 
     scheduler.schedule_absolute(600, action5)
 
-    def action6(scheduler, state=None):
+    def action6(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subject[0] is not None
         subject[0].subscribe(results4)
 
     scheduler.schedule_absolute(900, action6)

--- a/tests/test_subject/test_subject.py
+++ b/tests/test_subject/test_subject.py
@@ -1,3 +1,4 @@
+from reactivex.abc import DisposableBase, SchedulerBase
 from reactivex.subject import Subject
 from reactivex.testing import ReactiveTest, TestScheduler
 
@@ -14,17 +15,12 @@ class RxException(Exception):
     pass
 
 
-# Helper function for raising exceptions within lambdas
-def _raise(ex):
-    raise RxException(ex)
-
-
 def test_infinite():
-    subscription = [None]
-    subscription1 = [None]
-    subscription2 = [None]
-    subscription3 = [None]
-    s = [None]
+    subscription: list[DisposableBase | None] = [None]
+    subscription1: list[DisposableBase | None] = [None]
+    subscription2: list[DisposableBase | None] = [None]
+    subscription3: list[DisposableBase | None] = [None]
+    s: list[Subject[int] | None] = [None]
     scheduler = TestScheduler()
 
     xs = scheduler.create_hot_observable(
@@ -46,52 +42,61 @@ def test_infinite():
     results2 = scheduler.create_observer()
     results3 = scheduler.create_observer()
 
-    def action1(scheduler, state=None):
+    def action1(scheduler: SchedulerBase, state: object = None) -> None:
         s[0] = Subject()
 
     scheduler.schedule_absolute(100, action1)
 
-    def action2(scheduler, state=None):
+    def action2(scheduler: SchedulerBase, state: object = None) -> None:
+        assert s[0] is not None
         subscription[0] = xs.subscribe(s[0])
 
     scheduler.schedule_absolute(200, action2)
 
-    def action3(scheduler, state=None):
+    def action3(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subscription[0] is not None
         subscription[0].dispose()
 
     scheduler.schedule_absolute(1000, action3)
 
-    def action4(scheduler, state=None):
+    def action4(scheduler: SchedulerBase, state: object = None) -> None:
+        assert s[0] is not None
         subscription1[0] = s[0].subscribe(results1)
 
     scheduler.schedule_absolute(300, action4)
 
-    def action5(scheduler, state=None):
+    def action5(scheduler: SchedulerBase, state: object = None) -> None:
+        assert s[0] is not None
         subscription2[0] = s[0].subscribe(results2)
 
     scheduler.schedule_absolute(400, action5)
 
-    def action6(scheduler, state=None):
+    def action6(scheduler: SchedulerBase, state: object = None) -> None:
+        assert s[0] is not None
         subscription3[0] = s[0].subscribe(results3)
 
     scheduler.schedule_absolute(900, action6)
 
-    def action7(scheduler, state=None):
+    def action7(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subscription1[0] is not None
         subscription1[0].dispose()
 
     scheduler.schedule_absolute(600, action7)
 
-    def action8(scheduler, state=None):
+    def action8(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subscription2[0] is not None
         subscription2[0].dispose()
 
     scheduler.schedule_absolute(700, action8)
 
-    def action9(scheduler, state=None):
+    def action9(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subscription1[0] is not None
         subscription1[0].dispose()
 
     scheduler.schedule_absolute(800, action9)
 
-    def action10(scheduler, state=None):
+    def action10(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subscription3[0] is not None
         subscription3[0].dispose()
 
     scheduler.schedule_absolute(950, action10)
@@ -105,11 +110,11 @@ def test_infinite():
 
 def test_finite():
     scheduler = TestScheduler()
-    subscription = [None]
-    subscription1 = [None]
-    subscription2 = [None]
-    subscription3 = [None]
-    s = [None]
+    subscription: list[DisposableBase | None] = [None]
+    subscription1: list[DisposableBase | None] = [None]
+    subscription2: list[DisposableBase | None] = [None]
+    subscription3: list[DisposableBase | None] = [None]
+    s: list[Subject[int] | None] = [None]
 
     xs = scheduler.create_hot_observable(
         on_next(70, 1),
@@ -129,52 +134,61 @@ def test_finite():
     results2 = scheduler.create_observer()
     results3 = scheduler.create_observer()
 
-    def action1(scheduler, state=None):
+    def action1(scheduler: SchedulerBase, state: object = None) -> None:
         s[0] = Subject()
 
     scheduler.schedule_absolute(100, action1)
 
-    def action2(scheduler, state=None):
+    def action2(scheduler: SchedulerBase, state: object = None) -> None:
+        assert s[0] is not None
         subscription[0] = xs.subscribe(s[0])
 
     scheduler.schedule_absolute(200, action2)
 
-    def action3(scheduler, state=None):
+    def action3(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subscription[0] is not None
         subscription[0].dispose()
 
     scheduler.schedule_absolute(1000, action3)
 
-    def action4(scheduler, state=None):
+    def action4(scheduler: SchedulerBase, state: object = None) -> None:
+        assert s[0] is not None
         subscription1[0] = s[0].subscribe(results1)
 
     scheduler.schedule_absolute(300, action4)
 
-    def action5(scheduler, state=None):
+    def action5(scheduler: SchedulerBase, state: object = None) -> None:
+        assert s[0] is not None
         subscription2[0] = s[0].subscribe(results2)
 
     scheduler.schedule_absolute(400, action5)
 
-    def action6(scheduler, state=None):
+    def action6(scheduler: SchedulerBase, state: object = None) -> None:
+        assert s[0] is not None
         subscription3[0] = s[0].subscribe(results3)
 
     scheduler.schedule_absolute(900, action6)
 
-    def action7(scheduler, state=None):
+    def action7(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subscription1[0] is not None
         subscription1[0].dispose()
 
     scheduler.schedule_absolute(600, action7)
 
-    def action8(scheduler, state=None):
+    def action8(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subscription2[0] is not None
         subscription2[0].dispose()
 
     scheduler.schedule_absolute(700, action8)
 
-    def action9(scheduler, state=None):
+    def action9(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subscription1[0] is not None
         subscription1[0].dispose()
 
     scheduler.schedule_absolute(800, action9)
 
-    def action10(scheduler, state=None):
+    def action10(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subscription3[0] is not None
         subscription3[0].dispose()
 
     scheduler.schedule_absolute(950, action10)
@@ -187,11 +201,11 @@ def test_finite():
 
 
 def test_error():
-    s = [None]
-    subscription = [None]
-    subscription1 = [None]
-    subscription2 = [None]
-    subscription3 = [None]
+    s: list[Subject[int] | None] = [None]
+    subscription: list[DisposableBase | None] = [None]
+    subscription1: list[DisposableBase | None] = [None]
+    subscription2: list[DisposableBase | None] = [None]
+    subscription3: list[DisposableBase | None] = [None]
     ex = "ex"
 
     scheduler = TestScheduler()
@@ -214,52 +228,61 @@ def test_error():
     results2 = scheduler.create_observer()
     results3 = scheduler.create_observer()
 
-    def action(scheduler, state=None):
+    def action(scheduler: SchedulerBase, state: object = None) -> None:
         s[0] = Subject()
 
     scheduler.schedule_absolute(100, action)
 
-    def action1(scheduler, state=None):
+    def action1(scheduler: SchedulerBase, state: object = None) -> None:
+        assert s[0] is not None
         subscription[0] = xs.subscribe(s[0])
 
     scheduler.schedule_absolute(200, action1)
 
-    def action2(scheduler, state=None):
+    def action2(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subscription[0] is not None
         subscription[0].dispose()
 
     scheduler.schedule_absolute(1000, action2)
 
-    def action3(scheduler, state=None):
+    def action3(scheduler: SchedulerBase, state: object = None) -> None:
+        assert s[0] is not None
         subscription1[0] = s[0].subscribe(results1)
 
     scheduler.schedule_absolute(300, action3)
 
-    def action4(scheduler, state=None):
+    def action4(scheduler: SchedulerBase, state: object = None) -> None:
+        assert s[0] is not None
         subscription2[0] = s[0].subscribe(results2)
 
     scheduler.schedule_absolute(400, action4)
 
-    def action5(scheduler, state=None):
+    def action5(scheduler: SchedulerBase, state: object = None) -> None:
+        assert s[0] is not None
         subscription3[0] = s[0].subscribe(results3)
 
     scheduler.schedule_absolute(900, action5)
 
-    def action6(scheduler, state=None):
+    def action6(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subscription1[0] is not None
         subscription1[0].dispose()
 
     scheduler.schedule_absolute(600, action6)
 
-    def action7(scheduler, state=None):
+    def action7(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subscription2[0] is not None
         subscription2[0].dispose()
 
     scheduler.schedule_absolute(700, action7)
 
-    def action8(scheduler, state=None):
+    def action8(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subscription1[0] is not None
         subscription1[0].dispose()
 
     scheduler.schedule_absolute(800, action8)
 
-    def action9(scheduler, state=None):
+    def action9(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subscription3[0] is not None
         subscription3[0].dispose()
 
     scheduler.schedule_absolute(950, action9)
@@ -272,11 +295,11 @@ def test_error():
 
 
 def test_canceled():
-    s = [None]
-    subscription = [None]
-    subscription1 = [None]
-    subscription2 = [None]
-    subscription3 = [None]
+    s: list[Subject[int] | None] = [None]
+    subscription: list[DisposableBase | None] = [None]
+    subscription1: list[DisposableBase | None] = [None]
+    subscription2: list[DisposableBase | None] = [None]
+    subscription3: list[DisposableBase | None] = [None]
 
     scheduler = TestScheduler()
     xs = scheduler.create_hot_observable(
@@ -287,52 +310,61 @@ def test_canceled():
     results2 = scheduler.create_observer()
     results3 = scheduler.create_observer()
 
-    def action1(scheduler, state=None):
+    def action1(scheduler: SchedulerBase, state: object = None) -> None:
         s[0] = Subject()
 
     scheduler.schedule_absolute(100, action1)
 
-    def action2(scheduler, state=None):
+    def action2(scheduler: SchedulerBase, state: object = None) -> None:
+        assert s[0] is not None
         subscription[0] = xs.subscribe(s[0])
 
     scheduler.schedule_absolute(200, action2)
 
-    def action3(scheduler, state=None):
+    def action3(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subscription[0] is not None
         subscription[0].dispose()
 
     scheduler.schedule_absolute(1000, action3)
 
-    def action4(scheduler, state=None):
+    def action4(scheduler: SchedulerBase, state: object = None) -> None:
+        assert s[0] is not None
         subscription1[0] = s[0].subscribe(results1)
 
     scheduler.schedule_absolute(300, action4)
 
-    def action5(scheduler, state=None):
+    def action5(scheduler: SchedulerBase, state: object = None) -> None:
+        assert s[0] is not None
         subscription2[0] = s[0].subscribe(results2)
 
     scheduler.schedule_absolute(400, action5)
 
-    def action6(scheduler, state=None):
+    def action6(scheduler: SchedulerBase, state: object = None) -> None:
+        assert s[0] is not None
         subscription3[0] = s[0].subscribe(results3)
 
     scheduler.schedule_absolute(900, action6)
 
-    def action7(scheduler, state=None):
+    def action7(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subscription1[0] is not None
         subscription1[0].dispose()
 
     scheduler.schedule_absolute(600, action7)
 
-    def action8(scheduler, state=None):
+    def action8(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subscription2[0] is not None
         subscription2[0].dispose()
 
     scheduler.schedule_absolute(700, action8)
 
-    def action9(scheduler, state=None):
+    def action9(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subscription1[0] is not None
         subscription1[0].dispose()
 
     scheduler.schedule_absolute(800, action9)
 
-    def action10(scheduler, state=None):
+    def action10(scheduler: SchedulerBase, state: object = None) -> None:
+        assert subscription3[0] is not None
         subscription3[0].dispose()
 
     scheduler.schedule_absolute(950, action10)


### PR DESCRIPTION
- Add type annotations to closure container lists (list[T | None])
- Add type annotations to scheduler callback parameters
- Add assert narrowing before attribute access on nullable list items
- Fix on_error("ex") -> on_error(Exception("ex")) (real type bug)
- Remove unused _raise helper functions
- Remove SchedulerBase import where not needed
- Remove tests/test_subject/ from pyright exclude list in pyproject.toml

All 21 tests pass. Full pyright: 0 errors. Ruff: 0 errors.