### PR TITLE
ci: tell ShipIt that master is an allowed release branch

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -31,7 +31,7 @@ jobs:
         run: dotnet tool restore
 
       - name: Run ShipIt
-        run: dotnet shipit --pre-release rc
+        run: dotnet shipit --pre-release rc --allow-branch master
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Summary

ShipIt's default `--allow-branch` is `main`, but RxPY ships from `master`. The first post-merge run failed with:

> Branch 'master' is not allowed to generate the changelog.
> Allowed branches are:
> - main
> You can use the --allow-branch option to allow other branches.

Pass `--allow-branch master` explicitly so ShipIt proceeds.

## Test plan

- [ ] After merge, the `shipit-pr` job succeeds past the branch-allowlist check.
- [ ] A `chore: release 5.0.0-rc.1` PR is opened by the bot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)