### PR TITLE
ci: make CHANGELOG.md ready for ShipIt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -170,7 +170,7 @@ this file; the release script normalizes between them.
 - Refactored operators to use C# like extensionmethods using function decorators
 - More PEP8 alignment
 
-## 0.15
+## 0.15.0
 
 - Python slicing and indexing of observables. Thus you can write xs[1:-1:2]
 - Aligned backpressure with RxJS
@@ -178,7 +178,7 @@ this file; the release script normalizes between them.
 - `from_` is now an alias for `from_iterable`. Removed `from_array`
 - Fixes for `flat_map`/`flat_map`. Selector may return iterable
 
-## 0.14
+## 0.14.0
 
 - Made `ScheduledObserver` thread safe
 - Thread safe handling for `take_while` and `group_join`
@@ -186,7 +186,7 @@ this file; the release script normalizes between them.
 - Added support for IronPython (by removing six)
 - Aggregate is now an alias for reduce
 
-## 0.13
+## 0.13.0
 
 - Aligning throttle type operator naming with RxJS and RxJava
 - Added `throttle_last()` as alias for `sample()`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,58 @@ this file; the release script normalizes between them.
   `Scheduler` base class.
 - CI: Standardised `actions/setup-python` to `@v5` across all workflow jobs.
 
+## 5.0.0a2
+
+- Documentation header formatting fixes.
+
+## 5.0.0a1
+
+- **Fluent method chaining** — operators are now available as methods on
+  `Observable` in addition to the existing `pipe()` style. Both work
+  interchangeably and can be mixed freely. Implemented via eleven category
+  mixins (transformation, filtering, combination, error handling,
+  windowing/buffering, multicasting, etc.). Zero breaking changes from 4.x —
+  all existing `pipe()`-based code continues to work. (#743)
+- Migrated project tooling from Poetry to `uv`.
+- Replaced Black + isort with Ruff for formatting and linting.
+- Dropped Python 3.8; added support for Python 3.11, 3.12, 3.13.
+- Added `scheduler` parameter to `run()` for consistent scheduling control.
+- Fixed `subscribe_on` not forwarding scheduler to the source. Thanks to
+  @MainRo
+- Minor internal: renamed `ReplaySubject.window` to `ReplaySubject._window`
+  to free the `window` name for the new method.
+
+## 4.0.0
+
+- Renamed the distribution from `rx` to `reactivex` (`pip install reactivex`).
+- Flattened the package: `Observable` and operators now live at the top level
+  (`rx.core` gone).
+- Raised minimum Python to 3.7.
+- Full pyright-strict type coverage; `disallow_untyped_defs` enforced.
+- Migrated from `setup.py` to Poetry.
+- Improved scheduler type annotations and asyncio thread-safety.
+- Internal operators renamed with a leading underscore (`_map`, `_filter`,
+  etc.).
+- Marble-diagram documentation added for every operator.
+- Test scheduler and marble-testing improvements. Thanks to @MainRo
+
+## 3.0.0
+
+- Replaced method chaining with a pipe-based functional API as the
+  recommended style.
+- Dropped Python 2 support; Python 3.6+ only.
+- Renamed the `concurrency` package to `scheduler`; split mainloop and
+  eventloop schedulers into their own modules.
+- Simplified variadic operator signatures (`amb`, `combine_latest`, `concat`,
+  `merge`, `on_error_resume_next`, `catch`, `zip`) — the leading `Iterable`
+  argument is gone.
+- Removed `result_mapper` from `join`, `group_join`, `zip`, `generate`.
+- Added comprehensive type hints and a `py.typed` marker (PEP 561).
+- Collapsed `AnonymousObservable` into `Observable`.
+- Renamed `catch_exception` to `catch`.
+- Added `TrampolineScheduler` and priority-queue scheduler improvements.
+- Replaced the blocking observable with a single `run()` function.
+
 ## 2.0.0-alpha
 
 - Extension methods and extension class methods have been removed. This

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,11 +54,11 @@ this file; the release script normalizes between them.
   `Scheduler` base class.
 - CI: Standardised `actions/setup-python` to `@v5` across all workflow jobs.
 
-## 5.0.0a2
+## 5.0.0-alpha.2
 
 - Documentation header formatting fixes.
 
-## 5.0.0a1
+## 5.0.0-alpha.1
 
 - **Fluent method chaining** — operators are now available as methods on
   `Observable` in addition to the existing `pipe()` style. Both work


### PR DESCRIPTION
## Summary

Two related fixes so ShipIt can scan our CHANGELOG.md cleanly and so the file actually reflects the project's history.

**1. Pad two-part historical versions to strict SemVer.** ShipIt parses every `## X.Y[.Z]...` heading with `SemVersionStyles.Strict`, which requires `MAJOR.MINOR.PATCH`. The first post-merge run failed at `Generate/Changelog.fs:42` with `System.Exception: Invalid version` on `## 0.15` / `## 0.14` / `## 0.13`. Rewritten to `0.15.0` / `0.14.0` / `0.13.0`. `## 2.0.0-alpha` is valid strict SemVer (bare pre-release identifiers are allowed).

**2. Reconstruct missing history for 3.0.0, 4.0.0, 5.0.0a1, 5.0.0a2.** The CHANGELOG previously jumped from `## 2.0.0-alpha` straight back to `## 1.5.0`, skipping the entire 3.x and 4.x lines and the two 5.0.0 alphas. Curated bullets from git log between tag pairs plus PR #743 for the 5.0.0a1 headline (fluent method chaining). Not exhaustive — just the majors (API rewrites, `rx` → `reactivex` package rename, Python-version floors, tooling moves).

## Test plan

- [ ] After merge, the `shipit-pr` job progresses past `findVersions` without the "Invalid version" exception.
- [ ] Bot opens the `chore: release 5.0.0-rc.1` PR.
- [ ] Historical 3.0.0/4.0.0 claims look accurate to you — especially that the `rx` → `reactivex` rename landed at 4.0.0 (agent-derived, not forensically verified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)