### PR TITLE
ci: enable Dependabot for uv and GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,21 @@
+version: 2
+updates:
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    groups:
+      python-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary
- Adds `.github/dependabot.yml` configuring weekly update checks for:
  - **Python dependencies** via the `uv` ecosystem (tracks `pyproject.toml` / `uv.lock`)
  - **GitHub Actions** pins across workflow files
- Updates are grouped per ecosystem to keep PR noise low (one batched PR per week per ecosystem).

## Test plan
- [ ] Merge and confirm Dependabot's initial run appears in the repo's Dependabot tab
- [ ] Verify Dependabot opens grouped PRs (not one PR per dep) on the next scheduled run

🤖 Generated with [Claude Code](https://claude.com/claude-code)