### PR TITLE
ci: make Dependabot use conventional commit PR titles

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,10 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
+    commit-message:
+      prefix: "chore"
+      prefix-development: "chore"
+      include: "scope"
     groups:
       python-dependencies:
         patterns:
@@ -15,6 +19,9 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
+    commit-message:
+      prefix: "ci"
+      include: "scope"
     groups:
       github-actions:
         patterns:


### PR DESCRIPTION
## Summary
- Dependabot's default PR titles (e.g. `Bump the github-actions group with 6 updates`) fail the `conventional-pr-title` check — see #771.
- Adds `commit-message.prefix` + `include: scope` to each ecosystem in `.github/dependabot.yml` so titles are emitted as:
  - `chore(deps): ...` for Python dependency PRs
  - `ci(deps): ...` for GitHub Actions PRs
- Both prefixes are in the allowed types list in `conventional-pr-title.yml`.

## Test plan
- [ ] Merge and wait for Dependabot to re-open / re-title its PRs
- [ ] Confirm the `conventional-pr-title` check passes on the next Dependabot PR
- [ ] #771 may need to be closed and re-opened (or rebased) to pick up the new title format

🤖 Generated with [Claude Code](https://claude.com/claude-code)