### PR TITLE
ci: skip invalid commits in ShipIt

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -31,7 +31,7 @@ jobs:
         run: dotnet tool restore
 
       - name: Run ShipIt
-        run: dotnet shipit --pre-release rc --allow-branch master
+        run: dotnet shipit --pre-release rc --allow-branch master --skip-invalid-commit
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Summary
- Adds `--skip-invalid-commit` to `dotnet shipit` in the publish workflow so non-conventional commit messages are warned about and skipped instead of aborting the release.
- Unblocks ShipIt after Dependabot PR #772 landed with an un-prefixed commit title (`Bump the python-dependencies group with 8 updates`). See failing run: https://github.com/ReactiveX/RxPY/actions/runs/24692644854/job/72217999652

## Test plan
- [ ] After merge, confirm the `Publish Package` workflow's `ShipIt - Pull Request` job succeeds on master.
- [ ] Verify ShipIt opens/updates the `chore: release …` PR and that the skipped commit is absent from the generated changelog entry (expected; can be added manually if desired).

🤖 Generated with [Claude Code](https://claude.com/claude-code)