### PR TITLE
ci: enable uv cache in all CI jobs to speed up dependency installation

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -15,6 +15,8 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
 
       - name: Install dependencies
         run: |
@@ -40,6 +42,8 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
 
       - name: Install dependencies
         run: |
@@ -61,6 +65,8 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
Add `enable-cache: true` to each `astral-sh/setup-uv` step in the
Python package workflow (code-quality, build matrix, coverage).

With caching enabled, uv stores downloaded packages in a persistent
cache directory. Repeated runs (e.g. the 18-job matrix across
3 platforms × 6 Python versions) skip downloading packages already
in cache, reducing install time significantly.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

Closes: #781 
