### PR TITLE
docs: fix occured typo in run.py docstrings

### DIFF
--- a/reactivex/run.py
+++ b/reactivex/run.py
@@ -17,7 +17,7 @@ def run(source: Observable[_T], scheduler: abc.SchedulerBase | None = None) -> _
 
     Subscribes to the observable source. Then blocks and waits for the
     observable source to either complete or error. Returns the
-    last value emitted, or throws exception if any error occured.
+    last value emitted, or throws exception if any error occurred.
 
     Examples:
         >>> result = run(source)
@@ -30,7 +30,7 @@ def run(source: Observable[_T], scheduler: abc.SchedulerBase | None = None) -> _
     Raises:
         SequenceContainsNoElementsError: if observable completes
             (on_completed) without any values being emitted.
-        Exception: raises exception if any error (on_error) occured.
+        Exception: raises exception if any error (on_error) occurred.
 
     Returns:
         The last element emitted from the observable.


### PR DESCRIPTION
Fix "occured" -> "occurred" in two docstrings in reactivex/run.py.