### PR TITLE
ci: release 5.0.0 as stable instead of a release candidate

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -31,7 +31,7 @@ jobs:
         run: dotnet tool restore
 
       - name: Run ShipIt
-        run: dotnet shipit --pre-release rc --allow-branch master --skip-invalid-commit
+        run: dotnet shipit --allow-branch master --skip-invalid-commit
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ---
+force_version: 5.0.0
 last_commit_released: 915311e3e002b933f2eb4d59c9eac1cab327ff78
-pre_release: rc
 name: reactivex
 updaters:
   - command: ./scripts/shipit_bump_version.sh {version}


### PR DESCRIPTION
Promotes `5.0.0-rc.2` to the stable **5.0.0** release. No functional changes — this is a two-line configuration change.

## What changed

```diff
  ---
+ force_version: 5.0.0
  last_commit_released: 915311e3...
- pre_release: rc
```
```diff
- dotnet shipit --pre-release rc --allow-branch master --skip-invalid-commit
+ dotnet shipit --allow-branch master --skip-invalid-commit
```

## Why all three parts are needed

**Dropping `pre_release: rc` and the CLI flag** stops ShipIt generating release candidates. Both are required — the frontmatter key alone forces an rc even with the flag gone, and ShipIt rewrites the key on every release, so it has to be removed explicitly rather than assumed absent.

**That alone produces nothing.** ShipIt derives the next version from commits after `last_commit_released`, and the only commit since rc.2 is its own `chore: release` commit, which is not a version-bumping type. With just the two removals, the run reports:

> `No changelog would be bumped, nothing to ship.`

I confirmed this isn't about commit type — a `ci:` commit doesn't bump it either.

**`force_version: 5.0.0`** is ShipIt's documented override for exactly this case. It promotes the release candidate without inventing a functional commit purely to trigger a bump.

## Verification

`shipit --dry-run` with these changes:

```
┌───────────┬────────┬─────────────┐
│ Project   │ Status │ New Version │
├───────────┼────────┼─────────────┤
│ reactivex │   🚀   │    5.0.0    │
└───────────┴────────┴─────────────┘
│ Title  │ chore: release reactivex@5.0.0 │
```

`pre-commit run --all-files` passes (ruff check, ruff format, pyright, mypy).

## What happens on merge

1. `shipit-pr` opens a **`chore: release reactivex@5.0.0`** PR, with ShipIt writing the CHANGELOG entry and bumping `pyproject.toml` / `reactivex/_version.py`.
2. Merging *that* PR publishes 5.0.0 to PyPI and creates the `v5.0.0` tag and GitHub release — marked as a full release, not a pre-release, since the version carries no `rc` suffix.

## ⚠️ Follow-up required

`force_version` is a **one-shot override for this release**. It must be removed once 5.0.0 ships, or every subsequent release will be pinned to 5.0.0. I could not confirm whether ShipIt strips it automatically, so please check the frontmatter after the release lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)