### PR TITLE
fix(scripts): keep uv.lock in sync and scope the version sed to [project]

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -27,6 +27,11 @@ jobs:
         with:
           dotnet-version: '9.x'
 
+      # ShipIt's command updater (scripts/shipit_bump_version.sh) runs `uv lock`
+      # to keep uv.lock's recorded project version in step with pyproject.toml.
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+
       - name: Restore .NET tools
         run: dotnet tool restore
 

--- a/scripts/shipit_bump_version.sh
+++ b/scripts/shipit_bump_version.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 # Invoked by EasyBuild.ShipIt as a command-type updater (see CHANGELOG.md frontmatter).
 # Receives a SemVer version (e.g. 5.0.0-rc.1), translates it to PEP 440
-# (e.g. 5.0.0rc1), and writes it into pyproject.toml and reactivex/_version.py.
+# (e.g. 5.0.0rc1), and writes it into pyproject.toml, reactivex/_version.py
+# and uv.lock.
 set -euo pipefail
 
 if [ $# -ne 1 ]; then
@@ -19,7 +20,14 @@ PEP440=$(echo "$SEMVER" | sed -E '
   s/-rc\.([0-9]+)$/rc\1/
 ')
 
-sed -i "s/^version = \".*\"/version = \"$PEP440\"/" pyproject.toml
+# Restrict the substitution to the [project] table. An unanchored '^version = '
+# would also rewrite a top-level version key in any later [tool.*] section.
+sed -i "/^\[project\]/,/^\[/ s/^version = \".*\"/version = \"$PEP440\"/" pyproject.toml
 printf '__version__ = "%s"\n' "$PEP440" > reactivex/_version.py
+
+# uv.lock records the project's own version, so it goes stale on every release
+# unless it is refreshed here. This only re-resolves the local package; the
+# pinned dependency versions are left alone (that is what --upgrade would do).
+uv lock --quiet
 
 echo "Bumped version to $PEP440 (from SemVer $SEMVER)"


### PR DESCRIPTION
Two defects in `scripts/shipit_bump_version.sh`, the command updater ShipIt invokes to write the release version. Both surfaced while working on #798/#800.

## 1. `uv.lock` was never updated

`uv.lock` records the project's own version, but the updater only wrote `pyproject.toml` and `reactivex/_version.py`. The lock has been drifting for two releases:

```
uv.lock:        version = "5.0.0rc1"   ← stale
pyproject.toml: version = "5.0.0rc2"
```

Any later `uv` command silently corrects it, so the drift shows up as an unrelated `uv.lock` diff in an otherwise clean working tree — which is exactly how I ran into it.

Fixed by running `uv lock` after the bump. Only the local package is re-resolved; pinned dependency versions are left alone (that would be `--upgrade`).

## 2. The version sed was not scoped to a table

```bash
sed -i "s/^version = \".*\"/version = \"$PEP440\"/" pyproject.toml
```

This rewrites **every** column-0 `version` key in the file. Only `[project]` has one today, so nothing was silently corrupted — but a top-level `version` in any future `[tool.*]` section would have been clobbered. Now restricted to the `[project]` table.

## 3. `setup-uv` added to the `shipit-pr` job

The updater runs inside `shipit-pr`, which sets up **.NET only** — no Python, no uv. Without this step `uv lock` would fail under `set -euo pipefail` and break release-PR generation. This is a required part of change 1, not an unrelated addition.

## Verification

Ran the script for real (`5.0.0-rc.9`):

| File | Before | After |
|---|---|---|
| `pyproject.toml` | 5.0.0rc2 | 5.0.0rc9 |
| `reactivex/_version.py` | 5.0.0rc2 | 5.0.0rc9 |
| `uv.lock` | **5.0.0rc1** | 5.0.0rc9 |

Diffing every `version =` line in the lock before/after shows the project's own version as the sole change — no dependency drift.

For the sed, I appended a `[tool.faketool]` section with `version = "9.9.9"` and ran both variants:

- old, unanchored → `9.9.9` overwritten with `5.0.0` (the bug)
- new, anchored → `9.9.9` preserved, `[project]` still correctly bumped

Also: `bash -n` clean, workflow YAML parses, `pre-commit run --all-files` passes (ruff check, ruff format, pyright, mypy).

## Note

This adds a new failure mode: if `uv lock` fails, the updater now fails and takes the ShipIt run with it. That is intentional — a half-updated version set is worse than a failed release PR — but it does mean release-PR generation now depends on uv being installable and the lock being resolvable.

Independent of #800; either can merge first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)