### PR TITLE
docs: fix broken Sphinx build and refresh docs for 5.0

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -28,7 +28,7 @@ ReactiveX for Python v5
 For v3.X please go to the `v3 branch
 <https://github.com/ReactiveX/RxPY/tree/release/v3.2.x>`_.
 
-ReactiveX for Python v4.x runs on `Python <http://www.python.org/>`_ 3.9 or above. To
+ReactiveX for Python v5.x runs on `Python <http://www.python.org/>`_ 3.10 or above. To
 install:
 
 .. code:: console
@@ -104,7 +104,7 @@ Read the `documentation
 the principles of ReactiveX and get the complete reference of the available
 operators.
 
-If you need to migrate code from RxPY v1.x or v3.x, read the `migration
+If you need to migrate code from RxPY v1.x, v3.x, or v4.x, read the `migration
 <https://rxpy.readthedocs.io/en/latest/migration.html>`_ section.
 
 There is also a list of third party documentation available `here
@@ -123,7 +123,7 @@ Differences from .NET and RxJS
 
 ReactiveX for Python is a fairly complete implementation of
 `Rx <http://reactivex.io/>`_ with more than
-`120 operators <https://rxpy.readthedocs.io/en/latest/operators.html>`_, and
+`150 operators <https://rxpy.readthedocs.io/en/latest/operators.html>`_, and
 over `1300 passing unit-tests <https://coveralls.io/github/ReactiveX/RxPY>`_. RxPY
 is mostly a direct port of RxJS, but also borrows a bit from Rx.NET and RxJava in
 terms of threading and blocking operators.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -13,7 +13,6 @@
 
 import os
 import sys
-from distutils.command.config import config
 
 import guzzle_sphinx_theme
 import tomli
@@ -29,13 +28,15 @@ sys.path.insert(0, root)
 with open(os.path.join(root, "pyproject.toml"), "rb") as f:
     config = tomli.load(f)
 
-project_meta = config["tool"]["poetry"]
+# Metadata lives in the PEP 621 [project] table (the project migrated off
+# Poetry). authors is a list of {name, email} tables and the homepage moved
+# under [project.urls].
+project_meta = config["project"]
 
-print(project_meta)
 project = project_meta["name"]
-author = project_meta["authors"][0]
+author = project_meta["authors"][0]["name"]
 description = project_meta["description"]
-url = project_meta["homepage"]
+url = project_meta["urls"]["Homepage"]
 title = project + " Documentation"
 
 _version = Version.from_git()

--- a/docs/get_started.rst
+++ b/docs/get_started.rst
@@ -108,7 +108,7 @@ Output:
 Operators and Chaining
 --------------------------
 
-You can also derive new Observables using over 130 operators available in RxPY.
+You can also derive new Observables using over 150 operators available in RxPY.
 Each operator will yield a new :class:`Observable <reactivex.Observable>` that
 transforms emissions from the source in some way. For example, we can
 :func:`map() <reactivex.operators.map>` each `String` to its length, then

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -3,8 +3,8 @@
 Installation
 ============
 
-ReactiveX for Python (RxPY) v4.x runs on `Python
-<http://www.python.org/>`__ 3. To install:
+ReactiveX for Python (RxPY) v5.x runs on `Python
+<http://www.python.org/>`__ 3.10 through 3.14. To install:
 
 .. code:: console
 

--- a/docs/migration.rst
+++ b/docs/migration.rst
@@ -20,7 +20,7 @@ Fluent Style (Method Chaining)
 -------------------------------
 
 RxPY v5 brings back the intuitive method chaining syntax that many developers
-prefer. All ~160 operators are now available as methods on the Observable class:
+prefer. All 150+ operators are now available as methods on the Observable class:
 
 .. code:: python
 
@@ -130,7 +130,7 @@ IDE Support
 -----------
 
 The fluent style provides excellent IDE autocomplete support. When you type
-``source.`` your IDE will show all ~160 available operators with their
+``source.`` your IDE will show all 150+ available operators with their
 documentation and type signatures.
 
 No Breaking Changes
@@ -138,6 +138,22 @@ No Breaking Changes
 
 **All existing RxPY v4 code continues to work without modification.** The addition
 of method chaining is purely additive - no APIs were removed or changed.
+
+Tooling and Python Support
+--------------------------
+
+Beyond the new fluent API, v5 modernizes the project itself. None of these
+affect application code:
+
+- **Python support**: Python 3.8 and 3.9 were dropped; v5 supports Python 3.10
+  through 3.14.
+- **Project tooling**: the build backend moved from Poetry to `uv
+  <https://docs.astral.sh/uv/>`_, and Black plus isort were replaced by `Ruff
+  <https://docs.astral.sh/ruff/>`_ for formatting and linting.
+- **Operator fixes**: several operators had scheduler-forwarding and
+  resubscription bugs corrected (for example ``timer`` resetting its delay on
+  each resubscription, and ``pairwise`` / ``to_marbles`` / ``delay_with_mapper``
+  forwarding the ``scheduler`` argument). These are bug fixes, not API changes.
 
 Migration v4
 ============
@@ -155,7 +171,8 @@ current Python standards:
   new function ``pipe`` that works similar to the ``pipe`` method.
 - RxPY is now a modern Python project using ``pyproject.toml`` instead
   of ``setup.py``, and using modern tools such as Poetry, Black
-  formatter and isort.
+  formatter and isort. (As of v5 these have been replaced by uv and Ruff;
+  see `Tooling and Python Support`_ above.)
 
 .. code:: python
 

--- a/docs/style_guide.rst
+++ b/docs/style_guide.rst
@@ -10,7 +10,7 @@ you understand the differences and choose the right style for your project.
 Both Styles Are First-Class Citizens
 -------------------------------------
 
-Starting with RxPY v4.x, both fluent and functional styles are fully supported,
+Starting with RxPY v5.x, both fluent and functional styles are fully supported,
 type-safe, and equally performant. There is **no performance difference** between
 the two styles - fluent methods internally delegate to the pipe operators.
 
@@ -212,7 +212,7 @@ Both styles are fully type-safe with ``pyright`` strict mode:
     source: Observable[int] = rx.of(1, 2, 3)
     result: Observable[str] = source.pipe(ops.map(lambda x: str(x)))
 
-All 149 operators have complete type annotations in both styles.
+All 150+ operators have complete type annotations in both styles.
 
 Migration from RxPY v4.x
 -------------------------
@@ -312,14 +312,14 @@ there is no additional overhead. The choice is purely stylistic.
 Conclusion
 ----------
 
-RxPY v4.x gives you the freedom to choose the syntax that works best for your
+RxPY v5.x gives you the freedom to choose the syntax that works best for your
 project. Both fluent and functional styles are:
 
 * ✅ Fully supported and maintained
 * ✅ Type-safe with complete annotations
 * ✅ Equally performant (zero overhead)
 * ✅ Well-documented with examples
-* ✅ Compatible with all 149+ operators
+* ✅ Compatible with all 150+ operators
 
 Choose the style that makes your code most readable and maintainable for your
 team. When in doubt, start with the fluent style - it's more Pythonic and easier
@@ -329,5 +329,5 @@ For more information, see:
 
 * :doc:`get_started` - Introduction to RxPY
 * :doc:`operators` - Complete operator reference
-* :doc:`migration` - Migrating from RxPY v3.x or RxJS
+* :doc:`migration` - Migrating from RxPY v3.x or v4.x
 * :doc:`reference_operators` - API reference with both styles


### PR DESCRIPTION
Follow-up to the 5.0.0 release. While reviewing the docs I found the **Sphinx build has been broken** since the Poetry→uv migration — this fixes that plus a set of stale 5.0 content.

## 🔴 The docs build is currently broken

`docs/conf.py` reads project metadata from `[tool.poetry]`, which no longer exists in `pyproject.toml`:

```python
project_meta = config["tool"]["poetry"]   # KeyError: 'poetry'
```

I confirmed this raises `KeyError` against the current `pyproject.toml`, so the build dies before rendering anything — ReadTheDocs included. Fixed by reading the PEP 621 `[project]` table, accounting for two shape changes:
- `authors` is now a list of `{name, email}` tables → `["authors"][0]["name"]`
- the homepage moved to `[project.urls].Homepage`

Also removed `from distutils.command.config import config` — it's dead code (immediately overwritten by the `tomli` load) **and** `distutils` was removed from the stdlib in Python 3.12, which is exactly what `.readthedocs.yaml` builds on.

## 📝 Content refresh for 5.0

| File | Was | Now |
|---|---|---|
| `README.rst` | "v4.x runs on Python 3.9 or above" | v5.x, Python 3.10+ |
| `installation.rst` | "v4.x runs on Python 3" | v5.x, Python 3.10–3.14 |
| `style_guide.rst` ×2 | fluent chaining "Starting with RxPY v4.x" | v5.x (it's the headline v5 feature; the file already said so at line 220) |
| 4 files | operator count as 120 / 130 / 149 / ~160 | unified to "150+" |
| `migration.rst` | v5 section covered only the fluent API | added a **Tooling and Python Support** subsection (uv, Ruff, Python support, operator fixes) |
| cross-refs | "Migrating from v3.x or RxJS" / "v1.x or v3.x" | include v4.x → v5.x |

The operator count was standardized on "over 150" (source has 159 public factory functions; 130 in `__all__`) — a rounded figure that stays honest as operators are added.

## ✅ Verification

Built the docs with `sphinx-build`:
- **Before this PR:** dies immediately at `conf.py` (KeyError).
- **After:** build completes, all new content renders (confirmed the strings in the built HTML), and the added cross-references resolve with no new warnings.

The ~116 remaining warnings are pre-existing autodoc `duplicate object description` noise, unrelated to these changes, and do **not** fail the build — `.readthedocs.yaml` sets no `fail_on_warning`. Left out of scope.

`rstcheck` (not a CI gate; manual-only config) reports only its usual false positives for Sphinx's `:ref:`/`:func:`/`:doc:` roles on pre-existing lines — none introduced here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)