### PR TITLE
feat(operators): add tap as an alias for do_action

### DIFF
--- a/reactivex/operators/__init__.py
+++ b/reactivex/operators/__init__.py
@@ -3665,6 +3665,47 @@ def take_with_time(
     return take_with_time_(duration, scheduler=scheduler)
 
 
+def tap(
+    on_next: typing.OnNext[_T] | None = None,
+    on_error: typing.OnError | None = None,
+    on_completed: typing.OnCompleted | None = None,
+) -> Callable[[Observable[_T]], Observable[_T]]:
+    """Alias for :func:`do_action`.
+
+    Invokes an action for each element in the observable sequence and
+    invokes an action on graceful or exceptional termination of the
+    observable sequence. This method can be used for debugging,
+    logging, etc. of query behavior by intercepting the message stream
+    to run arbitrary actions for messages on the pipeline.
+
+    .. marble::
+        :alt: tap
+
+        ----1---2---3---4---|
+        [   tap(i: foo())   ]
+        ----1---2---3---4---|
+
+    Examples:
+        >>> tap(send)
+        >>> tap(on_next, on_error)
+        >>> tap(on_next, on_error, on_completed)
+
+    Args:
+        on_next: [Optional] Action to invoke for each element in the
+            observable sequence.
+        on_error: [Optional] Action to invoke on exceptional
+            termination of the observable sequence.
+        on_completed: [Optional] Action to invoke on graceful
+            termination of the observable sequence.
+
+    Returns:
+        An operator function that takes the source observable an
+        returns the source sequence with the side-effecting behavior
+        applied.
+    """
+    return do_action(on_next, on_error, on_completed)
+
+
 def throttle_first(
     window_duration: typing.RelativeTime, scheduler: abc.SchedulerBase | None = None
 ) -> Callable[[Observable[_T]], Observable[_T]]:
@@ -4322,6 +4363,7 @@ __all__ = [
     "take_while",
     "take_while_indexed",
     "take_with_time",
+    "tap",
     "throttle_first",
     "throttle_with_mapper",
     "timestamp",

--- a/tests/test_observable/test_doaction.py
+++ b/tests/test_observable/test_doaction.py
@@ -1,6 +1,7 @@
 import unittest
 
 import reactivex
+from reactivex import Observable
 from reactivex import operators as _
 from reactivex.testing import ReactiveTest, TestScheduler
 
@@ -132,6 +133,83 @@ class TestDo(unittest.TestCase):
         scheduler.start(create)
 
         assert completed[0]
+
+
+class TestTap(unittest.TestCase):
+    """``tap`` is an alias for ``do_action``."""
+
+    def test_tap_is_do_action(self) -> None:
+        assert _.tap is not _.do_action
+        assert _.tap.__doc__ is not None
+        assert "do_action" in _.tap.__doc__
+
+    def test_tap_should_see_all_values(self) -> None:
+        scheduler = TestScheduler()
+        xs: Observable[int] = scheduler.create_hot_observable(
+            on_next(150, 1),
+            on_next(210, 2),
+            on_next(220, 3),
+            on_next(230, 4),
+            on_next(240, 5),
+            on_completed(250),
+        )
+        count = 0
+        total = 2 + 3 + 4 + 5
+
+        def create() -> Observable[int]:
+            def action(x: int) -> None:
+                nonlocal count, total
+                count += 1
+                total -= x
+
+            return xs.pipe(_.tap(action))
+
+        scheduler.start(create)
+
+        self.assertEqual(4, count)
+        self.assertEqual(0, total)
+
+    def test_tap_next_completed(self) -> None:
+        scheduler = TestScheduler()
+        xs: Observable[int] = scheduler.create_hot_observable(
+            on_next(150, 1), on_next(210, 2), on_completed(250)
+        )
+        seen: list[int] = []
+        completed = False
+
+        def create() -> Observable[int]:
+            def _on_next(x: int) -> None:
+                seen.append(x)
+
+            def _on_completed() -> None:
+                nonlocal completed
+                completed = True
+
+            return xs.pipe(_.tap(on_next=_on_next, on_completed=_on_completed))
+
+        scheduler.start(create)
+
+        self.assertEqual([2], seen)
+        assert completed
+
+    def test_tap_error(self) -> None:
+        ex = Exception("ex")
+        scheduler = TestScheduler()
+        xs: Observable[int] = scheduler.create_hot_observable(
+            on_next(150, 1), on_next(210, 2), on_error(250, ex)
+        )
+        errors: list[Exception] = []
+
+        def create() -> Observable[int]:
+            def _on_error(e: Exception) -> None:
+                errors.append(e)
+
+            return xs.pipe(_.tap(on_error=_on_error))
+
+        results = scheduler.start(create)
+
+        self.assertEqual([ex], errors)
+        assert results.messages == [on_next(210, 2), on_error(250, ex)]
 
 
 # def test_do_next_error(self):


### PR DESCRIPTION
Closes #750.

## Background

`tap` was never a standalone operator in RxPY — it was an **alias for `do_action`**, and it disappeared as collateral damage of the RxPY 3.0 rewrite:

| When | Commit | What |
|---|---|---|
| 2014-09-13 | `a5ba6d59` | `tap = do_action  # Alias` first appears |
| 2014-12-21 | `c82b2d22` | Becomes `@extensionmethod(Observable, alias="tap")` on `do_action` |
| **2017-12-16** | **`5be144c1`** | **Removed** |

The old API bolted operators onto `Observable` via `rx/internal/extensionmethod.py`, whose decorator took an `alias=` argument that simply did an extra `setattr(base, func_name, func)`. So `obs.tap(...)` and `obs.do_action(...)` were literally the same function under two attribute names.

Commit `5be144c1` was part of the first iteration of RxPY 3.0, which deleted the extension-method machinery entirely and converted operators to standalone pipeable functions. The alias mechanism went away with it and nothing carried `tap` forward into `rx.operators.__init__`. It was not a deliberate removal decision — hence no changelog entry and no issue discussion, which is exactly why the reporter could not find one.

## Change

Reintroduces `tap` in `reactivex/operators/__init__.py`, alphabetically between `take_with_time` and `throttle_first`, plus a `"tap"` entry in `__all__`:

```python
def tap(
    on_next: typing.OnNext[_T] | None = None,
    on_error: typing.OnError | None = None,
    on_completed: typing.OnCompleted | None = None,
) -> Callable[[Observable[_T]], Observable[_T]]:
    """Alias for :func:`do_action`.
    ...
    """
    return do_action(on_next, on_error, on_completed)
```

It is a delegating function rather than a bare `tap = do_action` assignment because `docs/reference_operators.rst` uses `automodule:: reactivex.operators :members:` — a plain assignment would render as a duplicate of `do_action` under the wrong name. The wrapper carries its own marble diagram and a `:func:` cross-reference back to `do_action`, so the docs state the relationship explicitly.

This also aligns the name with RxJS, which renamed `do` to `tap` in v5.5.

## Tests

New `TestTap` class in `tests/test_observable/test_doaction.py` — alias identity/docstring, sees all values, next + completed, and error propagation. Fully type-annotated, even though `tests/test_observable` is still in the pyright exclude list.

## Verification

- `uv run pytest` — 1508 passed, 15 skipped
- `uv run ruff check` / `ruff format --check` — clean
- `uv run pyright reactivex/operators/__init__.py` — 0 errors
- `uv run mypy reactivex` — 2 errors in that file both before and after this change (verified by stashing); they are the pre-existing `Never` and implicit-`Optional` issues at lines 940 and 2735, unrelated to `tap`

Pure addition, so semver-minor — no exported symbol is renamed, removed, or changed. `CHANGELOG.md` is untouched per `AGENTS.md`; the entry will be generated from the conventional commit at release time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)