### PR TITLE
fix(operators): accept concurrent.futures.Future wherever futures are accepted

### DIFF
--- a/examples/parallel/timer.py
+++ b/examples/parallel/timer.py
@@ -12,14 +12,17 @@ def sleep(tm: float) -> float:
     return tm
 
 
-def output(result: str) -> None:
+def output(result: float) -> None:
     print("%d seconds" % result)
 
 
-with concurrent.futures.ProcessPoolExecutor(5) as executor:
-    reactivex.from_(seconds).pipe(
-        ops.flat_map(lambda s: executor.submit(sleep, s))
-    ).subscribe(output)
+# The __main__ guard is required by ProcessPoolExecutor for any start method
+# that does not fork, e.g. "spawn" (Windows, macOS) and "forkserver".
+if __name__ == "__main__":
+    with concurrent.futures.ProcessPoolExecutor(5) as executor:
+        reactivex.from_(seconds).pipe(
+            ops.flat_map(lambda s: executor.submit(sleep, s))
+        ).subscribe(output)
 
 # 1 seconds
 # 2 seconds

--- a/reactivex/__init__.py
+++ b/reactivex/__init__.py
@@ -1,6 +1,5 @@
 # pylint: disable=too-many-lines,redefined-outer-name,redefined-builtin
 
-from asyncio import Future
 from collections.abc import Callable, Iterable, Mapping
 from typing import (
     Any,
@@ -64,7 +63,7 @@ def amb(*sources: Observable[_T]) -> Observable[_T]:
 def case(
     mapper: Callable[[], _TKey],
     sources: Mapping[_TKey, Observable[_T]],
-    default_source: Observable[_T] | Future[_T] | None = None,
+    default_source: Observable[_T] | typing.AnyFuture[_T] | None = None,
 ) -> Observable[_T]:
     """Uses mapper to determine which source in sources to use.
 
@@ -282,7 +281,9 @@ def concat_with_iterable(sources: Iterable[Observable[_T]]) -> Observable[_T]:
 
 
 def defer(
-    factory: Callable[[abc.SchedulerBase], Union[Observable[_T], "Future[_T]"]],
+    factory: Callable[
+        [abc.SchedulerBase], Union[Observable[_T], "typing.AnyFuture[_T]"]
+    ],
 ) -> Observable[_T]:
     """Returns an observable sequence that invokes the specified
     factory function whenever a new observer subscribes.
@@ -489,7 +490,7 @@ def from_callback(
     return from_callback_(func, mapper)
 
 
-def from_future(future: "Future[_T]") -> Observable[_T]:
+def from_future(future: "typing.AnyFuture[_T]") -> Observable[_T]:
     """Converts a Future to an Observable sequence
 
     .. marble::
@@ -771,8 +772,8 @@ def hot(
 
 def if_then(
     condition: Callable[[], bool],
-    then_source: Union[Observable[_T], "Future[_T]"],
-    else_source: Union[None, Observable[_T], "Future[_T]"] = None,
+    then_source: Union[Observable[_T], "typing.AnyFuture[_T]"],
+    else_source: Union[None, Observable[_T], "typing.AnyFuture[_T]"] = None,
 ) -> Observable[_T]:
     """Determines whether an observable collection contains values.
 
@@ -910,7 +911,9 @@ def of(*args: _T) -> Observable[_T]:
 
 def on_error_resume_next(
     *sources: Union[
-        Observable[_T], "Future[_T]", Callable[[Exception | None], Observable[_T]]
+        Observable[_T],
+        "typing.AnyFuture[_T]",
+        Callable[[Exception | None], Observable[_T]],
     ],
 ) -> Observable[_T]:
     """Continues an observable sequence that is terminated normally or
@@ -1077,7 +1080,7 @@ def start(
     return start_(func, scheduler)
 
 
-def start_async(function_async: Callable[[], "Future[_T]"]) -> Observable[_T]:
+def start_async(function_async: Callable[[], "typing.AnyFuture[_T]"]) -> Observable[_T]:
     """Invokes the asynchronous function, surfacing the result through
     an observable sequence.
 

--- a/reactivex/internal/__init__.py
+++ b/reactivex/internal/__init__.py
@@ -8,7 +8,7 @@ from .exceptions import (
     SequenceContainsNoElementsError,
 )
 from .priorityqueue import PriorityQueue
-from .utils import NotSet, add_ref, alias, infinite
+from .utils import NotSet, add_ref, alias, infinite, is_future
 
 __all__ = [
     "add_ref",
@@ -19,6 +19,7 @@ __all__ = [
     "default_comparer",
     "default_error",
     "infinite",
+    "is_future",
     "noop",
     "NotSet",
     "SequenceContainsNoElementsError",

--- a/reactivex/internal/utils.py
+++ b/reactivex/internal/utils.py
@@ -1,13 +1,16 @@
+import asyncio
+import concurrent.futures
 from collections.abc import Callable, Iterable
 from functools import update_wrapper
 from types import FunctionType
 from typing import TYPE_CHECKING, Any, TypeVar, cast
 
-from typing_extensions import ParamSpec
+from typing_extensions import ParamSpec, TypeIs
 
 from reactivex import abc
 from reactivex.disposable import CompositeDisposable
 from reactivex.disposable.refcountdisposable import RefCountDisposable
+from reactivex.typing import AnyFuture
 
 if TYPE_CHECKING:
     from reactivex import Observable
@@ -25,6 +28,22 @@ def add_ref(xs: "Observable[_T]", r: RefCountDisposable) -> "Observable[_T]":
         return CompositeDisposable(r.disposable, xs.subscribe(observer))
 
     return Observable(subscribe)
+
+
+def is_future(value: Any) -> TypeIs[AnyFuture[Any]]:
+    """Tests if the given value is a future.
+
+    Both :class:`asyncio.Future` and :class:`concurrent.futures.Future`
+    are considered futures, as are objects that follow the asyncio future
+    protocol, e.g. :class:`asyncio.Task`.
+
+    Args:
+        value: The value to test.
+
+    Returns:
+        True if the value is a future, False otherwise.
+    """
+    return asyncio.isfuture(value) or isinstance(value, concurrent.futures.Future)
 
 
 def infinite() -> Iterable[int]:
@@ -59,4 +78,4 @@ class NotSet:
         return "NotSet"
 
 
-__all__ = ["add_ref", "infinite", "alias", "NotSet"]
+__all__ = ["add_ref", "infinite", "alias", "is_future", "NotSet"]

--- a/reactivex/observable/case.py
+++ b/reactivex/observable/case.py
@@ -1,8 +1,9 @@
-from asyncio import Future
 from collections.abc import Callable, Mapping
 from typing import TypeVar, Union
 
 from reactivex import Observable, abc, defer, empty, from_future
+from reactivex.internal import is_future
+from reactivex.typing import AnyFuture
 
 _Key = TypeVar("_Key")
 _T = TypeVar("_T")
@@ -11,17 +12,17 @@ _T = TypeVar("_T")
 def case_(
     mapper: Callable[[], _Key],
     sources: Mapping[_Key, Observable[_T]],
-    default_source: Union[Observable[_T], "Future[_T]"] | None = None,
+    default_source: Union[Observable[_T], "AnyFuture[_T]"] | None = None,
 ) -> Observable[_T]:
-    default_source_: Observable[_T] | Future[_T] = default_source or empty()
+    default_source_: Observable[_T] | AnyFuture[_T] = default_source or empty()
 
     def factory(_: abc.SchedulerBase) -> Observable[_T]:
         try:
-            result: Observable[_T] | Future[_T] = sources[mapper()]
+            result: Observable[_T] | AnyFuture[_T] = sources[mapper()]
         except KeyError:
             result = default_source_
 
-        if isinstance(result, Future):
+        if is_future(result):
             result_: Observable[_T] = from_future(result)
         else:
             result_ = result

--- a/reactivex/observable/defer.py
+++ b/reactivex/observable/defer.py
@@ -1,15 +1,16 @@
-from asyncio import Future
 from collections.abc import Callable
 from typing import TypeVar, Union
 
 from reactivex import Observable, abc, from_future, throw
+from reactivex.internal import is_future
 from reactivex.scheduler import ImmediateScheduler
+from reactivex.typing import AnyFuture
 
 _T = TypeVar("_T")
 
 
 def defer_(
-    factory: Callable[[abc.SchedulerBase], Union[Observable[_T], "Future[_T]"]],
+    factory: Callable[[abc.SchedulerBase], Union[Observable[_T], "AnyFuture[_T]"]],
 ) -> Observable[_T]:
     """Returns an observable sequence that invokes the specified factory
     function whenever a new observer subscribes.
@@ -35,7 +36,7 @@ def defer_(
         except Exception as ex:  # By design. pylint: disable=W0703
             return throw(ex).subscribe(observer)
 
-        result = from_future(result) if isinstance(result, Future) else result
+        result = from_future(result) if is_future(result) else result
         return result.subscribe(observer, scheduler=scheduler)
 
     return Observable(subscribe)

--- a/reactivex/observable/fromfuture.py
+++ b/reactivex/observable/fromfuture.py
@@ -1,18 +1,19 @@
 import asyncio
-from asyncio import Future
 from typing import Any, TypeVar, cast
 
 from reactivex import Observable, abc
 from reactivex.disposable import Disposable
+from reactivex.typing import AnyFuture
 
 _T = TypeVar("_T")
 
 
-def from_future_(future: "Future[_T]") -> Observable[_T]:
+def from_future_(future: "AnyFuture[_T]") -> Observable[_T]:
     """Converts a Future to an Observable sequence
 
     Args:
-        future -- A Python 3 compatible future.
+        future -- A future, either an :class:`asyncio.Future` or a
+            :class:`concurrent.futures.Future`.
             https://docs.python.org/3/library/asyncio-task.html#future
 
     Returns:
@@ -23,7 +24,7 @@ def from_future_(future: "Future[_T]") -> Observable[_T]:
     def subscribe(
         observer: abc.ObserverBase[Any], scheduler: abc.SchedulerBase | None = None
     ) -> abc.DisposableBase:
-        def done(future: "Future[_T]") -> None:
+        def done(future: "AnyFuture[_T]") -> None:
             try:
                 value: Any = future.result()
             except Exception as ex:

--- a/reactivex/observable/ifthen.py
+++ b/reactivex/observable/ifthen.py
@@ -1,17 +1,18 @@
-from asyncio import Future
 from collections.abc import Callable
 from typing import TypeVar, Union
 
 import reactivex
 from reactivex import Observable, abc
+from reactivex.internal import is_future
+from reactivex.typing import AnyFuture
 
 _T = TypeVar("_T")
 
 
 def if_then_(
     condition: Callable[[], bool],
-    then_source: Union[Observable[_T], "Future[_T]"],
-    else_source: Union[None, Observable[_T], "Future[_T]"] = None,
+    then_source: Union[Observable[_T], "AnyFuture[_T]"],
+    else_source: Union[None, Observable[_T], "AnyFuture[_T]"] = None,
 ) -> Observable[_T]:
     """Determines whether an observable collection contains values.
 
@@ -34,20 +35,16 @@ def if_then_(
         else_source.
     """
 
-    else_source_: Observable[_T] | Future[_T] = else_source or reactivex.empty()
+    else_source_: Observable[_T] | AnyFuture[_T] = else_source or reactivex.empty()
 
     then_source = (
-        reactivex.from_future(then_source)
-        if isinstance(then_source, Future)
-        else then_source
+        reactivex.from_future(then_source) if is_future(then_source) else then_source
     )
     else_source_ = (
-        reactivex.from_future(else_source_)
-        if isinstance(else_source_, Future)
-        else else_source_
+        reactivex.from_future(else_source_) if is_future(else_source_) else else_source_
     )
 
-    def factory(_: abc.SchedulerBase) -> Union[Observable[_T], "Future[_T]"]:
+    def factory(_: abc.SchedulerBase) -> Union[Observable[_T], "AnyFuture[_T]"]:
         return then_source if condition() else else_source_
 
     return reactivex.defer(factory)

--- a/reactivex/observable/onerrorresumenext.py
+++ b/reactivex/observable/onerrorresumenext.py
@@ -1,4 +1,3 @@
-from asyncio import Future
 from collections.abc import Callable
 from typing import TypeVar, Union
 
@@ -9,14 +8,16 @@ from reactivex.disposable import (
     SerialDisposable,
     SingleAssignmentDisposable,
 )
+from reactivex.internal import is_future
 from reactivex.scheduler import CurrentThreadScheduler
+from reactivex.typing import AnyFuture
 
 _T = TypeVar("_T")
 
 
 def on_error_resume_next_(
     *sources: Union[
-        Observable[_T], "Future[_T]", Callable[[Exception | None], Observable[_T]]
+        Observable[_T], "AnyFuture[_T]", Callable[[Exception | None], Observable[_T]]
     ],
 ) -> Observable[_T]:
     """Continues an observable sequence that is terminated normally or
@@ -51,9 +52,7 @@ def on_error_resume_next_(
 
             # Allow source to be a factory method taking an error
             source = source(state) if callable(source) else source
-            current = (
-                reactivex.from_future(source) if isinstance(source, Future) else source
-            )
+            current = reactivex.from_future(source) if is_future(source) else source
 
             d = SingleAssignmentDisposable()
             subscription.disposable = d

--- a/reactivex/observable/startasync.py
+++ b/reactivex/observable/startasync.py
@@ -1,13 +1,13 @@
-from asyncio import Future
 from collections.abc import Callable
 from typing import TypeVar
 
 from reactivex import Observable, from_future, throw
+from reactivex.typing import AnyFuture
 
 _T = TypeVar("_T")
 
 
-def start_async_(function_async: Callable[[], "Future[_T]"]) -> Observable[_T]:
+def start_async_(function_async: Callable[[], "AnyFuture[_T]"]) -> Observable[_T]:
     try:
         future = function_async()
     except Exception as ex:  # pylint: disable=broad-except

--- a/reactivex/observable/zip.py
+++ b/reactivex/observable/zip.py
@@ -1,10 +1,9 @@
-from asyncio import Future
 from threading import RLock
-from typing import Any, cast
+from typing import Any
 
 from reactivex import Observable, abc, from_future
 from reactivex.disposable import CompositeDisposable, SingleAssignmentDisposable
-from reactivex.internal import synchronized
+from reactivex.internal import is_future, synchronized
 
 
 def zip_(*args: Observable[Any]) -> Observable[tuple[Any, ...]]:
@@ -66,9 +65,8 @@ def zip_(*args: Observable[Any]) -> Observable[tuple[Any, ...]]:
 
         def func(i: int) -> None:
             source: Observable[Any] = sources[i]
-            if isinstance(source, Future):
-                source_ = cast(Future[Any], source)
-                source = from_future(source_)
+            if is_future(source):
+                source = from_future(source)
 
             sad = SingleAssignmentDisposable()
 

--- a/reactivex/operators/__init__.py
+++ b/reactivex/operators/__init__.py
@@ -1,7 +1,7 @@
 # pylint: disable=too-many-lines,redefined-builtin,import-outside-toplevel
 
 
-from asyncio import Future
+import asyncio
 from collections.abc import Callable, Iterable
 from typing import (
     TYPE_CHECKING,
@@ -74,7 +74,9 @@ def all(predicate: Predicate[_T]) -> Callable[[Observable[_T]], Observable[bool]
     return all_(predicate)
 
 
-def amb(right_source: Observable[_T]) -> Callable[[Observable[_T]], Observable[_T]]:
+def amb(
+    right_source: Union[Observable[_T], "typing.AnyFuture[_T]"],
+) -> Callable[[Observable[_T]], Observable[_T]]:
     """Propagates the observable sequence that reacts first.
 
     .. marble::
@@ -1265,6 +1267,18 @@ def flat_map(
 ) -> Callable[[Observable[_T1]], Observable[_T2]]: ...
 
 
+@overload
+def flat_map(
+    mapper: "typing.AnyFuture[_T2] | None" = None,
+) -> Callable[[Observable[Any]], Observable[_T2]]: ...
+
+
+@overload
+def flat_map(
+    mapper: Mapper[_T1, "typing.AnyFuture[_T2]"] | None = None,
+) -> Callable[[Observable[_T1]], Observable[_T2]]: ...
+
+
 def flat_map(
     mapper: Any | None = None,
 ) -> Callable[[Observable[Any]], Observable[Any]]:
@@ -1379,7 +1393,7 @@ def flat_map_indexed(
 
 
 def flat_map_latest(
-    mapper: Mapper[_T1, Union[Observable[_T2], "Future[_T2]"]],
+    mapper: Mapper[_T1, Union[Observable[_T2], "typing.AnyFuture[_T2]"]],
 ) -> Callable[[Observable[_T1]], Observable[_T2]]:
     """Projects each element of an observable sequence into a new
     sequence of observable sequences by incorporating the element's
@@ -1914,7 +1928,9 @@ def merge(
     return merge_(*sources, max_concurrent=max_concurrent)
 
 
-def merge_all() -> Callable[[Observable[Observable[_T]]], Observable[_T]]:
+def merge_all() -> Callable[
+    [Observable[Union[Observable[_T], "typing.AnyFuture[_T]"]]], Observable[_T]
+]:
     """The merge_all operator.
 
     Merges an observable sequence of observable sequences into an
@@ -2830,7 +2846,7 @@ def skip_last_with_time(
 
 
 def skip_until(
-    other: Union[Observable[Any], "Future[Any]"],
+    other: Union[Observable[Any], "typing.AnyFuture[Any]"],
 ) -> Callable[[Observable[_T]], Observable[_T]]:
     """Returns the values from the source observable sequence only
     after the other observable sequence produces a value.
@@ -3259,7 +3275,7 @@ def sum(
 
 
 def switch_latest() -> Callable[
-    [Observable[Union[Observable[_T], "Future[_T]"]]], Observable[_T]
+    [Observable[Union[Observable[_T], "typing.AnyFuture[_T]"]]], Observable[_T]
 ]:
     """The switch_latest operator.
 
@@ -3499,7 +3515,9 @@ def take_last_with_time(
     return take_last_with_time_(duration, scheduler=scheduler)
 
 
-def take_until(other: Observable[Any]) -> Callable[[Observable[_T]], Observable[_T]]:
+def take_until(
+    other: Union[Observable[Any], "typing.AnyFuture[Any]"],
+) -> Callable[[Observable[_T]], Observable[_T]]:
     """Returns the values from the source observable sequence until the
     other observable sequence produces a value.
 
@@ -3780,7 +3798,7 @@ def timestamp(
 
 def timeout(
     duetime: typing.AbsoluteOrRelativeTime,
-    other: Observable[_T] | None = None,
+    other: Union[Observable[_T], "typing.AnyFuture[_T]"] | None = None,
     scheduler: abc.SchedulerBase | None = None,
 ) -> Callable[[Observable[_T]], Observable[_T]]:
     """Returns the source observable sequence or the other observable
@@ -3909,8 +3927,8 @@ def to_dict(
 
 
 def to_future(
-    future_ctor: Callable[[], "Future[_T]"] | None = None,
-) -> Callable[[Observable[_T]], "Future[_T]"]:
+    future_ctor: Callable[[], "asyncio.Future[_T]"] | None = None,
+) -> Callable[[Observable[_T]], "asyncio.Future[_T]"]:
     """Converts an existing observable sequence to a Future.
 
     Example:

--- a/reactivex/operators/_amb.py
+++ b/reactivex/operators/_amb.py
@@ -1,9 +1,9 @@
-from asyncio import Future
 from typing import TypeVar, Union
 
 from reactivex import Observable, abc, from_future
 from reactivex.disposable import CompositeDisposable, SingleAssignmentDisposable
-from reactivex.internal import curry_flip
+from reactivex.internal import curry_flip, is_future
+from reactivex.typing import AnyFuture
 
 _T = TypeVar("_T")
 
@@ -11,7 +11,7 @@ _T = TypeVar("_T")
 @curry_flip
 def amb_(
     left_source: Observable[_T],
-    right_source: Union[Observable[_T], "Future[_T]"],
+    right_source: Union[Observable[_T], "AnyFuture[_T]"],
 ) -> Observable[_T]:
     """Propagates the observable sequence that reacts first.
 
@@ -27,7 +27,7 @@ def amb_(
         An observable sequence that surfaces either of the given sequences,
         whichever reacted first.
     """
-    if isinstance(right_source, Future):
+    if is_future(right_source):
         obs: Observable[_T] = from_future(right_source)
     else:
         obs = right_source

--- a/reactivex/operators/_catch.py
+++ b/reactivex/operators/_catch.py
@@ -1,18 +1,20 @@
-from asyncio import Future
 from collections.abc import Callable
 from typing import TypeVar, Union
 
 import reactivex
 from reactivex import Observable, abc
 from reactivex.disposable import SerialDisposable, SingleAssignmentDisposable
-from reactivex.internal import curry_flip
+from reactivex.internal import curry_flip, is_future
+from reactivex.typing import AnyFuture
 
 _T = TypeVar("_T")
 
 
 def catch_handler(
     source: Observable[_T],
-    handler: Callable[[Exception, Observable[_T]], Union[Observable[_T], "Future[_T]"]],
+    handler: Callable[
+        [Exception, Observable[_T]], Union[Observable[_T], "AnyFuture[_T]"]
+    ],
 ) -> Observable[_T]:
     def subscribe(
         observer: abc.ObserverBase[_T], scheduler: abc.SchedulerBase | None = None
@@ -29,9 +31,7 @@ def catch_handler(
                 observer.on_error(ex)
                 return
 
-            result = (
-                reactivex.from_future(result) if isinstance(result, Future) else result
-            )
+            result = reactivex.from_future(result) if is_future(result) else result
             d = SingleAssignmentDisposable()
             subscription.disposable = d
             d.disposable = result.subscribe(observer, scheduler=scheduler)

--- a/reactivex/operators/_exclusive.py
+++ b/reactivex/operators/_exclusive.py
@@ -1,10 +1,10 @@
-from asyncio import Future
 from typing import TypeVar, Union
 
 import reactivex
 from reactivex import Observable, abc
 from reactivex.disposable import CompositeDisposable, SingleAssignmentDisposable
-from reactivex.internal import curry_flip
+from reactivex.internal import curry_flip, is_future
+from reactivex.typing import AnyFuture
 
 _T = TypeVar("_T")
 
@@ -38,13 +38,13 @@ def exclusive_(source: Observable[Observable[_T]]) -> Observable[_T]:
 
         g.add(m)
 
-        def on_next(inner_source: Union[Observable[_T], "Future[_T]"]) -> None:
+        def on_next(inner_source: Union[Observable[_T], "AnyFuture[_T]"]) -> None:
             if not has_current[0]:
                 has_current[0] = True
 
                 inner_source = (
                     reactivex.from_future(inner_source)
-                    if isinstance(inner_source, Future)
+                    if is_future(inner_source)
                     else inner_source
                 )
 

--- a/reactivex/operators/_flatmap.py
+++ b/reactivex/operators/_flatmap.py
@@ -1,11 +1,10 @@
-from asyncio import Future
 from typing import Any, TypeVar, Union, cast
 
 from reactivex import Observable, from_, from_future
 from reactivex import operators as ops
-from reactivex.internal import curry_flip
+from reactivex.internal import curry_flip, is_future
 from reactivex.internal.basic import identity
-from reactivex.typing import Mapper, MapperIndexed
+from reactivex.typing import AnyFuture, Mapper, MapperIndexed
 
 _T1 = TypeVar("_T1")
 _T2 = TypeVar("_T2")
@@ -24,8 +23,8 @@ def _flat_map_internal(
             if mapper_indexed
             else identity
         )
-        if isinstance(mapper_result, Future):
-            result: Observable[Any] = from_future(cast("Future[Any]", mapper_result))
+        if is_future(mapper_result):
+            result: Observable[Any] = from_future(mapper_result)
         elif isinstance(mapper_result, Observable):
             result = cast(Observable[Any], mapper_result)
         else:
@@ -41,7 +40,7 @@ def _flat_map_internal(
 @curry_flip
 def flat_map_(
     source: Observable[_T1],
-    mapper: Mapper[_T1, Observable[_T2]] | None = None,
+    mapper: Mapper[_T1, Union[Observable[_T2], "AnyFuture[_T2]"]] | None = None,
 ) -> Observable[_T2]:
     """Projects each element of an observable sequence to an observable
     sequence and merges the resulting observable sequences into one
@@ -102,7 +101,7 @@ def flat_map_indexed_(
 @curry_flip
 def flat_map_latest_(
     source: Observable[_T1],
-    mapper: Mapper[_T1, Union[Observable[_T2], "Future[_T2]"]],
+    mapper: Mapper[_T1, Union[Observable[_T2], "AnyFuture[_T2]"]],
 ) -> Observable[_T2]:
     """Projects each element of an observable sequence into a new
     sequence of observable sequences by incorporating the element's

--- a/reactivex/operators/_merge.py
+++ b/reactivex/operators/_merge.py
@@ -1,10 +1,9 @@
-from asyncio import Future
 from typing import TypeVar, Union
 
 import reactivex
 from reactivex import Observable, abc, from_future, typing
 from reactivex.disposable import CompositeDisposable, SingleAssignmentDisposable
-from reactivex.internal import curry_flip, synchronized
+from reactivex.internal import curry_flip, is_future, synchronized
 
 _T = TypeVar("_T")
 
@@ -92,7 +91,9 @@ def merge_(
 
 
 @curry_flip
-def merge_all_(source: Observable[Observable[_T]]) -> Observable[_T]:
+def merge_all_(
+    source: Observable[Union[Observable[_T], "typing.AnyFuture[_T]"]],
+) -> Observable[_T]:
     """Merges an observable sequence of observable sequences into an
     observable sequence.
 
@@ -117,14 +118,12 @@ def merge_all_(source: Observable[Observable[_T]]) -> Observable[_T]:
         m = SingleAssignmentDisposable()
         group.add(m)
 
-        def on_next(inner_source: Union[Observable[_T], "Future[_T]"]):
+        def on_next(inner_source: Union[Observable[_T], "typing.AnyFuture[_T]"]):
             inner_subscription = SingleAssignmentDisposable()
             group.add(inner_subscription)
 
             inner_source = (
-                from_future(inner_source)
-                if isinstance(inner_source, Future)
-                else inner_source
+                from_future(inner_source) if is_future(inner_source) else inner_source
             )
 
             @synchronized(source.lock)

--- a/reactivex/operators/_skipuntil.py
+++ b/reactivex/operators/_skipuntil.py
@@ -1,9 +1,9 @@
-from asyncio import Future
 from typing import Any, TypeVar, Union
 
 from reactivex import Observable, abc, from_future
 from reactivex.disposable import CompositeDisposable, SingleAssignmentDisposable
-from reactivex.internal import curry_flip
+from reactivex.internal import curry_flip, is_future
+from reactivex.typing import AnyFuture
 
 _T = TypeVar("_T")
 
@@ -11,7 +11,7 @@ _T = TypeVar("_T")
 @curry_flip
 def skip_until_(
     source: Observable[_T],
-    other: Union[Observable[Any], "Future[Any]"],
+    other: Union[Observable[Any], "AnyFuture[Any]"],
 ) -> Observable[_T]:
     """Returns the values from the source observable sequence only after
     the other observable sequence produces a value.
@@ -31,7 +31,7 @@ def skip_until_(
         propagation.
     """
 
-    if isinstance(other, Future):
+    if is_future(other):
         obs: Observable[Any] = from_future(other)
     else:
         obs = other

--- a/reactivex/operators/_switchlatest.py
+++ b/reactivex/operators/_switchlatest.py
@@ -1,4 +1,3 @@
-from asyncio import Future
 from typing import Any, TypeVar, Union
 
 from reactivex import Observable, abc, from_future
@@ -7,14 +6,15 @@ from reactivex.disposable import (
     SerialDisposable,
     SingleAssignmentDisposable,
 )
-from reactivex.internal import curry_flip
+from reactivex.internal import curry_flip, is_future
+from reactivex.typing import AnyFuture
 
 _T = TypeVar("_T")
 
 
 @curry_flip
 def switch_latest_(
-    source: Observable[Union[Observable[_T], "Future[_T]"]],
+    source: Observable[Union[Observable[_T], "AnyFuture[_T]"]],
 ) -> Observable[_T]:
     """Transforms an observable sequence of observable sequences into
     an observable sequence producing values only from the most
@@ -42,7 +42,7 @@ def switch_latest_(
         is_stopped = [False]
         latest = [0]
 
-        def on_next(inner_source: Union[Observable[_T], "Future[_T]"]) -> None:
+        def on_next(inner_source: Union[Observable[_T], "AnyFuture[_T]"]) -> None:
             nonlocal source
 
             d = SingleAssignmentDisposable()
@@ -53,7 +53,7 @@ def switch_latest_(
             inner_subscription.disposable = d
 
             # Check if Future or Observable
-            if isinstance(inner_source, Future):
+            if is_future(inner_source):
                 obs = from_future(inner_source)
             else:
                 obs = inner_source

--- a/reactivex/operators/_takeuntil.py
+++ b/reactivex/operators/_takeuntil.py
@@ -1,9 +1,9 @@
-from asyncio import Future
 from typing import TypeVar
 
 from reactivex import Observable, abc, from_future
 from reactivex.disposable import CompositeDisposable
-from reactivex.internal import curry_flip, noop
+from reactivex.internal import curry_flip, is_future, noop
+from reactivex.typing import AnyFuture
 
 _T = TypeVar("_T")
 
@@ -11,7 +11,7 @@ _T = TypeVar("_T")
 @curry_flip
 def take_until_(
     source: Observable[_T],
-    other: Observable[_T] | Future[_T],
+    other: Observable[_T] | "AnyFuture[_T]",
 ) -> Observable[_T]:
     """Returns the values from the source observable sequence until
     the other observable sequence produces a value.
@@ -29,7 +29,7 @@ def take_until_(
         sequence up to the point the other sequence interrupted
         further propagation.
     """
-    if isinstance(other, Future):
+    if is_future(other):
         obs: Observable[_T] = from_future(other)
     else:
         obs = other

--- a/reactivex/operators/_timeout.py
+++ b/reactivex/operators/_timeout.py
@@ -1,4 +1,3 @@
-from asyncio import Future
 from datetime import datetime
 from typing import Any, TypeVar, Union
 
@@ -8,7 +7,7 @@ from reactivex.disposable import (
     SerialDisposable,
     SingleAssignmentDisposable,
 )
-from reactivex.internal import curry_flip
+from reactivex.internal import curry_flip, is_future
 from reactivex.scheduler import TimeoutScheduler
 
 _T = TypeVar("_T")
@@ -18,7 +17,7 @@ _T = TypeVar("_T")
 def timeout_(
     source: Observable[_T],
     duetime: typing.AbsoluteOrRelativeTime,
-    other: Union[Observable[_T], "Future[_T]"] | None = None,
+    other: Union[Observable[_T], "typing.AnyFuture[_T]"] | None = None,
     scheduler: abc.SchedulerBase | None = None,
 ) -> Observable[_T]:
     """Returns the source observable sequence or the other observable
@@ -39,7 +38,7 @@ def timeout_(
         case of a timeout.
     """
     other = other or throw(Exception("Timeout"))
-    if isinstance(other, Future):
+    if is_future(other):
         obs = from_future(other)
     else:
         obs = other

--- a/reactivex/operators/_whiledo.py
+++ b/reactivex/operators/_whiledo.py
@@ -1,12 +1,11 @@
 import itertools
-from asyncio import Future
 from collections.abc import Callable
 from typing import TypeVar, Union
 
 import reactivex
 from reactivex import Observable
-from reactivex.internal.utils import infinite
-from reactivex.typing import Predicate
+from reactivex.internal.utils import infinite, is_future
+from reactivex.typing import AnyFuture, Predicate
 
 _T = TypeVar("_T")
 
@@ -14,7 +13,7 @@ _T = TypeVar("_T")
 def while_do_(
     condition: Predicate[Observable[_T]],
 ) -> Callable[[Observable[_T]], Observable[_T]]:
-    def while_do(source: Union[Observable[_T], "Future[_T]"]) -> Observable[_T]:
+    def while_do(source: Union[Observable[_T], "AnyFuture[_T]"]) -> Observable[_T]:
         """Repeats source as long as condition holds emulating a while
         loop.
 
@@ -26,7 +25,7 @@ def while_do_(
             An observable sequence which is repeated as long as the
             condition holds.
         """
-        if isinstance(source, Future):
+        if is_future(source):
             obs = reactivex.from_future(source)
         else:
             obs = source

--- a/reactivex/typing.py
+++ b/reactivex/typing.py
@@ -1,3 +1,5 @@
+import asyncio
+import concurrent.futures
 from collections.abc import Callable
 from threading import Thread
 from typing import TypeAlias, TypeVar
@@ -44,12 +46,22 @@ SubComparer = TypeAliasType(
 Accumulator = TypeAliasType(
     "Accumulator", Callable[[_TState, _T1], _TState], type_params=(_TState, _T1)
 )
+AnyFuture = TypeAliasType(
+    "AnyFuture",
+    asyncio.Future[_T1] | concurrent.futures.Future[_T1],
+    type_params=(_T1,),
+)
+"""Any future-like object, i.e. either an :class:`asyncio.Future` or a
+:class:`concurrent.futures.Future`. Both provide the ``add_done_callback``,
+``result`` and ``cancel`` methods that RxPY needs in order to lift a future
+into an :class:`Observable`."""
 
 __all__ = [
     "Accumulator",
     "AbsoluteTime",
     "AbsoluteOrRelativeTime",
     "Action",
+    "AnyFuture",
     "Comparer",
     "Mapper",
     "MapperIndexed",

--- a/tests/test_observable/test_concurrentfuture.py
+++ b/tests/test_observable/test_concurrentfuture.py
@@ -1,0 +1,192 @@
+import asyncio
+import unittest
+from concurrent.futures import Future, ThreadPoolExecutor
+
+import reactivex
+from reactivex import operators as ops
+from reactivex.internal import is_future
+
+
+class TestIsFuture(unittest.TestCase):
+    def test_is_future_concurrent(self) -> None:
+        future: Future[int] = Future()
+        assert is_future(future)
+
+    def test_is_future_asyncio(self) -> None:
+        loop = asyncio.new_event_loop()
+        try:
+            assert is_future(loop.create_future())
+        finally:
+            loop.close()
+
+    def test_is_future_observable(self) -> None:
+        assert not is_future(reactivex.of(1, 2, 3))
+
+    def test_is_future_iterable(self) -> None:
+        assert not is_future([1, 2, 3])
+
+
+class TestFromConcurrentFuture(unittest.TestCase):
+    def test_future_success(self) -> None:
+        values: list[int] = []
+        errors: list[Exception] = []
+        completed: list[bool] = []
+
+        future: Future[int] = Future()
+        future.set_result(42)
+
+        reactivex.from_future(future).subscribe(
+            values.append, errors.append, lambda: completed.append(True)
+        )
+
+        assert values == [42]
+        assert errors == []
+        assert completed == [True]
+
+    def test_future_failure(self) -> None:
+        error = Exception("woops")
+        values: list[int] = []
+        errors: list[Exception] = []
+        completed: list[bool] = []
+
+        future: Future[int] = Future()
+        future.set_exception(error)
+
+        reactivex.from_future(future).subscribe(
+            values.append, errors.append, lambda: completed.append(True)
+        )
+
+        assert values == []
+        assert errors == [error]
+        assert completed == []
+
+
+class TestConcurrentFutureOperators(unittest.TestCase):
+    """Concurrent futures should be lifted just like asyncio futures.
+
+    See https://github.com/ReactiveX/RxPY/issues/709
+    """
+
+    def test_flat_map_concurrent_future(self) -> None:
+        futures: dict[int, Future[int]] = {x: Future() for x in (1, 2, 3)}
+        values: list[int] = []
+        completed: list[bool] = []
+
+        reactivex.from_(list(futures)).pipe(
+            ops.flat_map(lambda x: futures[x])
+        ).subscribe(values.append, on_completed=lambda: completed.append(True))
+
+        assert values == []
+
+        for x, future in futures.items():
+            future.set_result(x * 10)
+
+        assert values == [10, 20, 30]
+        assert completed == [True]
+
+    def test_flat_map_executor(self) -> None:
+        values: list[int] = []
+
+        # Leaving the context manager shuts the executor down, which waits
+        # for all the submitted futures to complete.
+        with ThreadPoolExecutor(3) as executor:
+            reactivex.from_([1, 2, 3]).pipe(
+                ops.flat_map(lambda x: executor.submit(lambda: x * 10))
+            ).subscribe(values.append)
+
+        assert sorted(values) == [10, 20, 30]
+
+    def test_merge_all_concurrent_future(self) -> None:
+        future: Future[int] = Future()
+        values: list[int] = []
+
+        reactivex.of(future).pipe(ops.merge_all()).subscribe(values.append)
+        future.set_result(42)
+
+        assert values == [42]
+
+    def test_switch_latest_concurrent_future(self) -> None:
+        future: Future[int] = Future()
+        values: list[int] = []
+
+        reactivex.of(future).pipe(ops.switch_latest()).subscribe(values.append)
+        future.set_result(42)
+
+        assert values == [42]
+
+    def test_take_until_concurrent_future(self) -> None:
+        future: Future[int] = Future()
+        subject: reactivex.Subject[int] = reactivex.Subject()
+        values: list[int] = []
+        completed: list[bool] = []
+
+        subject.pipe(ops.take_until(future)).subscribe(
+            values.append, on_completed=lambda: completed.append(True)
+        )
+
+        subject.on_next(1)
+        future.set_result(0)
+        subject.on_next(2)
+
+        assert values == [1]
+        assert completed == [True]
+
+    def test_amb_concurrent_future(self) -> None:
+        future: Future[int] = Future()
+        subject: reactivex.Subject[int] = reactivex.Subject()
+        values: list[int] = []
+
+        subject.pipe(ops.amb(future)).subscribe(values.append)
+
+        future.set_result(42)
+        subject.on_next(1)
+
+        assert values == [42]
+
+    def test_defer_concurrent_future(self) -> None:
+        future: Future[int] = Future()
+        future.set_result(42)
+        values: list[int] = []
+
+        reactivex.defer(lambda _: future).subscribe(values.append)
+
+        assert values == [42]
+
+    def test_if_then_concurrent_future(self) -> None:
+        future: Future[int] = Future()
+        future.set_result(42)
+        values: list[int] = []
+
+        reactivex.if_then(lambda: True, future).subscribe(values.append)
+
+        assert values == [42]
+
+    def test_case_concurrent_future(self) -> None:
+        future: Future[int] = Future()
+        future.set_result(42)
+        values: list[int] = []
+
+        sources: dict[str, reactivex.Observable[int]] = {}
+        reactivex.case(lambda: "missing", sources, future).subscribe(values.append)
+
+        assert values == [42]
+
+    def test_start_async_concurrent_future(self) -> None:
+        future: Future[int] = Future()
+        future.set_result(42)
+        values: list[int] = []
+
+        reactivex.start_async(lambda: future).subscribe(values.append)
+
+        assert values == [42]
+
+    def test_on_error_resume_next_concurrent_future(self) -> None:
+        future: Future[int] = Future()
+        future.set_result(42)
+        values: list[int] = []
+
+        reactivex.on_error_resume_next(
+            reactivex.throw(Exception("x")), future
+        ).subscribe(values.append)
+
+        assert values == [42]


### PR DESCRIPTION
Fixes #709

## The bug

`examples/parallel/timer.py` prints nothing. With an `on_error` handler hooked up it reports `TypeError: 'Future' object is not iterable`.

Every operator that lifts a future tested for one with `isinstance(x, asyncio.Future)`. `ProcessPoolExecutor.submit()` returns a `concurrent.futures.Future`, which is *not* an `asyncio.Future`, so `flat_map` fell through to `from_(...)` and tried to iterate it.

This is not new in 4.0.4 — RxPY 2 duck-typed futures (`rx/internal/utils.py::is_future` was just `callable(getattr(fut, "add_done_callback", None))`), and the 3.0 rewrite replaced every such check with an `isinstance` against `asyncio.Future`. The example has been broken since then, and the same limitation applied to **16 call sites across 15 files**.

## The fix

- New public alias `reactivex.typing.AnyFuture[T]` = `asyncio.Future[T] | concurrent.futures.Future[T]`.
- New internal `reactivex.internal.is_future()`, a `TypeIs` guard: `asyncio.isfuture(v) or isinstance(v, concurrent.futures.Future)`. Using `asyncio.isfuture` rather than `isinstance` also covers `Task` and other asyncio-protocol objects.
- All 16 sites now use it, with annotations widened to `AnyFuture`: `flat_map`, `merge`, `amb`, `catch`, `exclusive`, `skip_until`, `switch_latest`, `take_until`, `timeout`, `while_do`, plus `case`, `defer`, `if_then`, `zip`, `on_error_resume_next`, `from_future` and `start_async`.

`from_future()` is purely structural (`add_done_callback` / `result()` / `cancel()`), so it already worked with both kinds at runtime — only its annotation said otherwise. `to_future()` deliberately keeps returning an `asyncio.Future`, since it constructs one.

Two changes beyond the mechanical swap, because without them the issue's snippet still fails *type*-checking even though it runs:

- `flat_map` gains two future-returning overloads, and `flat_map_`'s mapper is widened.
- `merge_all` / `merge_all_` accept `Observable[Observable[T] | AnyFuture[T]]` — its `on_next` already lifted futures at runtime.

The `amb` / `take_until` / `timeout` facades were declaring `Observable`-only while their impls did the future check; they now match.

## Example

`examples/parallel/timer.py` runs again exactly as originally written — no `from_future` wrapper needed. Also added the `if __name__ == "__main__":` guard that `ProcessPoolExecutor` requires on non-fork start methods (Python 3.14 defaults to forkserver on Linux), and fixed `output`'s `result: str` annotation, which was formatted with `%d`.

```console
$ python examples/parallel/timer.py
1 seconds
2 seconds
3 seconds
4 seconds
5 seconds
```

## Verification

- New `tests/test_observable/test_concurrentfuture.py` — 17 fully-annotated tests: `is_future` unit cases, `from_future` success/failure with a concurrent future, and concurrent futures through `flat_map` (manual resolution plus a real `ThreadPoolExecutor`), `merge_all`, `switch_latest`, `take_until`, `amb`, `defer`, `if_then`, `case`, `start_async`, `on_error_resume_next`.
- `pytest -n auto`: 1525 passed, 15 skipped.
- `pyright` (strict): 0 errors.
- `mypy reactivex`: identical to master's baseline after normalizing line numbers — no new errors.
- `ruff check` / `ruff format`: clean.
- The new test file and the example live under paths pyright excludes, so both were additionally checked with the exclude temporarily relaxed — 0 errors each.

## Compatibility

Purely additive: every signature change is a widening, so existing call sites keep type-checking. No exported symbol was renamed or removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)