### PR TITLE
docs: fix version showing as 0.0.0 on Read the Docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -16,7 +16,6 @@ import sys
 
 import guzzle_sphinx_theme
 import tomli
-from dunamai import Version
 
 root = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 sys.path.insert(0, root)
@@ -39,11 +38,12 @@ description = project_meta["description"]
 url = project_meta["urls"]["Homepage"]
 title = project + " Documentation"
 
-_version = Version.from_git()
-# The full version, including alpha/beta/rc tags
-release = _version.serialize(metadata=False)
+# The version is declared statically in pyproject.toml. Don't derive it from git
+# tags: Read the Docs clones without tags, so the lookup would fall back to
+# "0.0.0" on the published docs.
+release = project_meta["version"]
 # The short X.Y.Z version
-version = _version.base
+version = release
 
 
 # -- General configuration ---------------------------------------------------

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,4 +3,3 @@ sphinx-autodoc-typehints>=1.10.3
 guzzle_sphinx_theme>=0.7.11
 sphinxcontrib_dooble>=1.0
 tomli>=2.0
-dunamai>=1.9.0


### PR DESCRIPTION
## Problem

https://rxpy.readthedocs.io/en/latest/ displays the version as `0.0.0`.

`docs/conf.py` derived the version from git tags via dunamai:

```python
_version = Version.from_git()
```

Read the Docs clones without tags, so the lookup finds no tag and falls back to `0.0.0`. Locally it resolves fine (`git describe` → `v5.0.0-...`), which is why this only shows up on the published site.

## Fix

The project has since migrated to a static PEP 621 version (`pyproject.toml` → `version = "5.0.0"`), and `conf.py` already parses `pyproject.toml` for the other project metadata. So the version can just come from there, and the `dunamai` docs dependency is dropped.

Trade-off: the docs version now tracks `pyproject.toml` rather than the last git tag, so it is bumped at release time along with the package version — which keeps it in sync with what is published on PyPI.

## Verification

Full `sphinx-build` run locally: build succeeds, and the rendered `index.html` shows `reactivex 5.0.0` with no remaining `0.0.0`. The 67 build warnings are pre-existing docstring/reference warnings, unaffected by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)