### PR TITLE
fix(scheduler): use wall clock time for now() in event loop schedulers

### DIFF
--- a/reactivex/abc/scheduler.py
+++ b/reactivex/abc/scheduler.py
@@ -28,6 +28,11 @@ class SchedulerBase(ABC):
         scheduled on a scheduler will adhere to the time denoted by this
         property.
 
+        Except for virtual-time schedulers, this is the current wall clock
+        time in UTC. Absolute duetimes passed to :meth:`schedule_absolute`
+        (and to time-based operators) are thus ordinary
+        ``datetime.now(timezone.utc)`` values.
+
         Returns:
              The scheduler's current time, as a datetime instance.
         """

--- a/reactivex/scheduler/eventloop/asyncioscheduler.py
+++ b/reactivex/scheduler/eventloop/asyncioscheduler.py
@@ -1,6 +1,5 @@
 import asyncio
 import logging
-from datetime import datetime
 from typing import TypeVar
 
 from reactivex import abc, typing
@@ -9,7 +8,6 @@ from reactivex.disposable import (
     Disposable,
     SingleAssignmentDisposable,
 )
-from reactivex.internal.basic import default_now
 
 from ..periodicscheduler import PeriodicScheduler
 
@@ -110,15 +108,3 @@ class AsyncIOScheduler(PeriodicScheduler):
 
         duetime = self.to_datetime(duetime)
         return self.schedule_relative(duetime - self.now, action, state=state)
-
-    @property
-    def now(self) -> datetime:
-        """Represents a notion of time for this scheduler. Tasks being
-        scheduled on a scheduler will adhere to the time denoted by this
-        property.
-
-        Returns:
-             The scheduler's current time, as a datetime instance.
-        """
-
-        return default_now()

--- a/reactivex/scheduler/eventloop/eventletscheduler.py
+++ b/reactivex/scheduler/eventloop/eventletscheduler.py
@@ -1,5 +1,4 @@
 import logging
-from datetime import datetime
 from typing import Any, TypeVar
 
 from reactivex import abc, typing
@@ -112,15 +111,3 @@ class EventletScheduler(PeriodicScheduler):
 
         duetime = self.to_datetime(duetime)
         return self.schedule_relative(duetime - self.now, action, state=state)
-
-    @property
-    def now(self) -> datetime:
-        """Represents a notion of time for this scheduler. Tasks being
-        scheduled on a scheduler will adhere to the time denoted by this
-        property.
-
-        Returns:
-             The scheduler's current time, as a datetime instance.
-        """
-
-        return self.to_datetime(self._eventlet.hubs.get_hub().clock())

--- a/reactivex/scheduler/eventloop/geventscheduler.py
+++ b/reactivex/scheduler/eventloop/geventscheduler.py
@@ -1,5 +1,4 @@
 import logging
-from datetime import datetime
 from typing import Any, TypeVar
 
 from reactivex import abc, typing
@@ -113,15 +112,3 @@ class GEventScheduler(PeriodicScheduler):
 
         duetime = self.to_datetime(duetime)
         return self.schedule_relative(duetime - self.now, action, state=state)
-
-    @property
-    def now(self) -> datetime:
-        """Represents a notion of time for this scheduler. Tasks being
-        scheduled on a scheduler will adhere to the time denoted by this
-        property.
-
-        Returns:
-             The scheduler's current time, as a datetime instance.
-        """
-
-        return self.to_datetime(self._gevent.get_hub().loop.now())

--- a/reactivex/scheduler/eventloop/ioloopscheduler.py
+++ b/reactivex/scheduler/eventloop/ioloopscheduler.py
@@ -1,5 +1,4 @@
 import logging
-from datetime import datetime
 from typing import Any, TypeVar
 
 from reactivex import abc, typing
@@ -118,15 +117,3 @@ class IOLoopScheduler(PeriodicScheduler):
 
         duetime = self.to_datetime(duetime)
         return self.schedule_relative(duetime - self.now, action, state=state)
-
-    @property
-    def now(self) -> datetime:
-        """Represents a notion of time for this scheduler. Tasks being
-        scheduled on a scheduler will adhere to the time denoted by this
-        property.
-
-        Returns:
-             The scheduler's current time, as a datetime instance.
-        """
-
-        return self.to_datetime(self._loop.time())

--- a/reactivex/scheduler/eventloop/twistedscheduler.py
+++ b/reactivex/scheduler/eventloop/twistedscheduler.py
@@ -1,5 +1,4 @@
 import logging
-from datetime import datetime
 from typing import Any, TypeVar
 
 from reactivex import abc, typing
@@ -99,15 +98,3 @@ class TwistedScheduler(PeriodicScheduler):
 
         duetime = self.to_datetime(duetime)
         return self.schedule_relative(duetime - self.now, action, state=state)
-
-    @property
-    def now(self) -> datetime:
-        """Represents a notion of time for this scheduler. Tasks being
-        scheduled on a scheduler will adhere to the time denoted by this
-        property.
-
-        Returns:
-             The scheduler's current time, as a datetime instance.
-        """
-
-        return self.to_datetime(float(self._reactor.seconds()))

--- a/reactivex/scheduler/scheduler.py
+++ b/reactivex/scheduler/scheduler.py
@@ -22,6 +22,12 @@ class Scheduler(abc.SchedulerBase):
         scheduled on a scheduler will adhere to the time denoted by this
         property.
 
+        This is the current wall clock time in UTC, so absolute duetimes
+        are ordinary ``datetime.now(timezone.utc)`` values. Schedulers
+        driven by an event loop with its own (typically monotonic) clock
+        still report wall clock time here, so that scheduling relative to
+        it stays compatible across schedulers.
+
         Returns:
              The scheduler's current time, as a datetime instance.
         """

--- a/tests/test_scheduler/test_eventloop/test_asyncioscheduler.py
+++ b/tests/test_scheduler/test_eventloop/test_asyncioscheduler.py
@@ -87,6 +87,28 @@ class TestAsyncIOScheduler(unittest.TestCase):
         finally:
             loop.close()
 
+    def test_asyncio_schedule_action_absolute(self) -> None:
+        loop = asyncio.new_event_loop()
+        try:
+
+            async def go() -> None:
+                scheduler = AsyncIOScheduler(loop)
+                ran = False
+
+                def action(scheduler: abc.SchedulerBase, state: Any) -> None:
+                    nonlocal ran
+                    ran = True
+
+                duetime = datetime.now(timezone.utc) + timedelta(milliseconds=100)
+                scheduler.schedule_absolute(duetime, action)
+
+                await asyncio.sleep(0.3)
+                assert ran is True
+
+            loop.run_until_complete(go())
+        finally:
+            loop.close()
+
     def test_asyncio_schedule_action_cancel(self):
         loop = asyncio.new_event_loop()
         try:

--- a/tests/test_scheduler/test_eventloop/test_eventletscheduler.py
+++ b/tests/test_scheduler/test_eventloop/test_eventletscheduler.py
@@ -15,9 +15,8 @@ class TestEventletScheduler(unittest.TestCase):
     @pytest.mark.skipif(CI, reason="Flaky test in GitHub Actions")
     def test_eventlet_schedule_now(self):
         scheduler = EventletScheduler(eventlet)
-        hub = eventlet.hubs.get_hub()
-        diff = scheduler.now - datetime.fromtimestamp(hub.clock(), tz=timezone.utc)
-        assert abs(diff) < timedelta(milliseconds=1)
+        diff = scheduler.now - datetime.now(timezone.utc)
+        assert abs(diff) < timedelta(milliseconds=100)
 
     @pytest.mark.skipif(CI, reason="Flaky test in GitHub Actions")
     def test_eventlet_schedule_now_units(self):
@@ -55,6 +54,20 @@ class TestEventletScheduler(unittest.TestCase):
         assert endtime is not None
         diff = endtime - starttime
         assert diff > timedelta(seconds=0.18)
+
+    def test_eventlet_schedule_action_absolute(self):
+        scheduler = EventletScheduler(eventlet)
+        ran = False
+
+        def action(scheduler, state):
+            nonlocal ran
+            ran = True
+
+        duetime = datetime.now(timezone.utc) + timedelta(milliseconds=100)
+        scheduler.schedule_absolute(duetime, action)
+
+        eventlet.sleep(0.3)
+        assert ran is True
 
     def test_eventlet_schedule_action_cancel(self):
         scheduler = EventletScheduler(eventlet)

--- a/tests/test_scheduler/test_eventloop/test_geventscheduler.py
+++ b/tests/test_scheduler/test_eventloop/test_geventscheduler.py
@@ -11,9 +11,8 @@ gevent = pytest.importorskip("gevent")
 class TestGEventScheduler(unittest.TestCase):
     def test_gevent_schedule_now(self):
         scheduler = GEventScheduler(gevent)
-        hub = gevent.get_hub()
-        diff = scheduler.now - datetime.fromtimestamp(hub.loop.now(), tz=timezone.utc)
-        assert abs(diff) < timedelta(milliseconds=1)
+        diff = scheduler.now - datetime.now(timezone.utc)
+        assert abs(diff) < timedelta(milliseconds=100)
 
     def test_gevent_schedule_now_units(self):
         scheduler = GEventScheduler(gevent)
@@ -50,6 +49,20 @@ class TestGEventScheduler(unittest.TestCase):
         assert endtime is not None
         diff = endtime - starttime
         assert diff > timedelta(seconds=0.18)
+
+    def test_gevent_schedule_action_absolute(self):
+        scheduler = GEventScheduler(gevent)
+        ran = False
+
+        def action(scheduler, state):
+            nonlocal ran
+            ran = True
+
+        duetime = datetime.now(timezone.utc) + timedelta(milliseconds=100)
+        scheduler.schedule_absolute(duetime, action)
+
+        gevent.sleep(0.3)
+        assert ran is True
 
     def test_gevent_schedule_action_cancel(self):
         scheduler = GEventScheduler(gevent)

--- a/tests/test_scheduler/test_eventloop/test_ioloopscheduler.py
+++ b/tests/test_scheduler/test_eventloop/test_ioloopscheduler.py
@@ -14,8 +14,8 @@ class TestIOLoopScheduler(unittest.TestCase):
     def test_ioloop_schedule_now(self):
         loop = ioloop.IOLoop.instance()
         scheduler = IOLoopScheduler(loop)
-        diff = scheduler.now - datetime.fromtimestamp(loop.time(), tz=timezone.utc)
-        assert abs(diff) < timedelta(milliseconds=1)
+        diff = scheduler.now - datetime.now(timezone.utc)
+        assert abs(diff) < timedelta(milliseconds=100)
 
     def test_ioloop_schedule_now_units(self):
         loop = ioloop.IOLoop.instance()
@@ -61,6 +61,26 @@ class TestIOLoopScheduler(unittest.TestCase):
             assert endtime is not None
             diff = endtime - starttime
             assert diff > 0.18
+            loop.stop()
+
+        loop.call_later(0.3, done)
+        loop.start()
+
+    def test_ioloop_schedule_action_absolute(self):
+        loop = ioloop.IOLoop.instance()
+
+        scheduler = IOLoopScheduler(loop)
+        ran = False
+
+        def action(scheduler, state):
+            nonlocal ran
+            ran = True
+
+        duetime = datetime.now(timezone.utc) + timedelta(milliseconds=100)
+        scheduler.schedule_absolute(duetime, action)
+
+        def done():
+            assert ran is True
             loop.stop()
 
         loop.call_later(0.3, done)

--- a/tests/test_scheduler/test_eventloop/test_twistedscheduler.py
+++ b/tests/test_scheduler/test_eventloop/test_twistedscheduler.py
@@ -16,10 +16,8 @@ from twisted.trial import unittest  # noqa: E402  # type: ignore[import-untyped]
 class TestTwistedScheduler(unittest.TestCase):
     def test_twisted_schedule_now(self):
         scheduler = TwistedScheduler(reactor)
-        diff = scheduler.now - datetime.fromtimestamp(
-            float(reactor.seconds()), tz=timezone.utc
-        )
-        assert abs(diff) < timedelta(milliseconds=1)
+        diff = scheduler.now - datetime.now(timezone.utc)
+        assert abs(diff) < timedelta(milliseconds=100)
 
     def test_twisted_schedule_now_units(self):
         scheduler = TwistedScheduler(reactor)
@@ -67,6 +65,26 @@ class TestTwistedScheduler(unittest.TestCase):
         yield promise
         diff = endtime - starttime
         assert diff > 0.18
+
+    @defer.inlineCallbacks
+    def test_twisted_schedule_action_absolute(self):
+        scheduler = TwistedScheduler(reactor)
+        promise = defer.Deferred()
+        ran = False
+
+        def action(scheduler, state):
+            nonlocal ran
+            ran = True
+
+        def done():
+            promise.callback("Done")
+
+        duetime = datetime.now(timezone.utc) + timedelta(milliseconds=100)
+        scheduler.schedule_absolute(duetime, action)
+        reactor.callLater(0.3, done)
+
+        yield promise
+        assert ran is True
 
     @defer.inlineCallbacks
     def test_twisted_schedule_action_cancel(self):


### PR DESCRIPTION
Fixes #724.

## Problem

`schedule_absolute()` is implemented everywhere as `schedule_relative(duetime - self.now, ...)`. Four event loop schedulers overrode `now` with their loop's **internal monotonic clock** instead of wall clock, so an ordinary `datetime` — the kind users pass to `take_until_with_time()`, `skip_until_with_time()`, etc. — resolved to a duetime decades in the future and the action never fired.

| Scheduler | old `now` | broken? |
|---|---|---|
| `EventletScheduler` | `hub.clock()` (monotonic) | **yes** |
| `AsyncIOScheduler` | `loop.time()` (monotonic) | fixed earlier in v5 |
| `GEventScheduler` | `hub.loop.now()` | no (libev reports real time) |
| `IOLoopScheduler` | `loop.time()` | no (tornado defaults to `time.time()`) |
| `TwistedScheduler` | `reactor.seconds()` | no (defaults to `time.time()`) |

Verified against the unpatched library, the new eventlet test fails with a ~56 year offset:

```
abs(timedelta(days=-20615, ...)) < timedelta(milliseconds=100)  # FAILED
```

## Changes

- Drop the `now` overrides from `asyncioscheduler.py`, `eventletscheduler.py`, `geventscheduler.py`, `ioloopscheduler.py` and `twistedscheduler.py`, so they inherit `Scheduler.now` (wall clock UTC) like every other scheduler in the library. `schedule_relative()` is unaffected — it passes seconds to the loop's own `call_later()` and never consults `now`.
- Document the contract on `abc.SchedulerBase.now` and `Scheduler.now`, which makes the existing `take_until_with_time` / `skip_until_with_time` docstrings (already phrased in terms of `datetime.now(timezone.utc)`) accurate.
- Update the four `test_*_schedule_now` tests to assert against wall clock, and add a `test_*_schedule_action_absolute` regression test to all five event loop scheduler test files.

## Testing

Full suite passes — 1553 passed, 11 skipped — including the normally-skipped gevent/eventlet/tornado/twisted suites, run via `uv run --with gevent --with eventlet --with tornado --with twisted pytest`. `ruff check` and `ruff format --check` are clean, and `mypy` reports no errors under `scheduler/eventloop`.

## Note

`PeriodicScheduler.schedule_periodic` uses `now` for drift correction, so on these four schedulers that correction now rides on wall clock and can be perturbed by NTP steps. That is already the case for `ThreadPoolScheduler`, `TimeoutScheduler` and `EventLoopScheduler`, so this makes the behaviour consistent rather than introducing a new exposure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)