### PR TITLE
docs: correct and expand the GIL free-threading note

### DIFF
--- a/docs/get_started.rst
+++ b/docs/get_started.rst
@@ -267,14 +267,23 @@ choice to create a pool of reusable worker threads.
 
 .. attention::
 
-    The `GIL <https://wiki.python.org/moin/GlobalInterpreterLock>`_ has the potential to 
-    undermine your concurrency  performance in Python versions prior to 3.13, as it prevents 
-    multiple threads from accessing the same line of code simultaneously. Starting with Python 3.13, 
-    the GIL can be disabled via the free-threading mode (enabled with the `--disable-gil` build option),
-    allowing for true multi-threading parallelism. Libraries like `NumPy <http://www.numpy.org/>`_ 
-    can mitigate GIL limitations for parallel intensive computations as they release the GIL during 
-    operations. RxPy may also minimize thread overlap to some degree. Just be sure to test your application
-    with concurrency and ensure there is a performance gain, especially when using free-threading builds.
+    The `GIL <https://wiki.python.org/moin/GlobalInterpreterLock>`_ has the
+    potential to undermine your concurrency performance, as it prevents
+    multiple threads from executing Python bytecode simultaneously. Libraries
+    like `NumPy <http://www.numpy.org/>`_ can mitigate this for parallel
+    intensive computations, as they release the GIL while they work. RxPY may
+    also minimize thread overlap to some degree.
+
+    Since Python 3.13 there is also a `free-threaded build
+    <https://docs.python.org/3/howto/free-threading-python.html>`_ that runs
+    without the GIL entirely, built with ``--disable-gil`` and offered as an
+    option in the official macOS and Windows installers. It was experimental
+    in 3.13 and became officially supported in 3.14 (:pep:`779`). Note that
+    this is a separate interpreter build, not a runtime switch on a normal
+    installation.
+
+    Either way, be sure to test your application with concurrency and confirm
+    there is an actual performance gain.
 
 The :func:`subscribe_on() <reactivex.operators.subscribe_on>` instructs the source
 :class:`Observable <reactivex.Observable>` at the start of the chain which scheduler to
@@ -433,9 +442,10 @@ Both versions complete in about two seconds rather than six.
     parallelism. To bound how many run at once, use :func:`merge()
     <reactivex.operators.merge>` with a ``max_concurrent`` argument.
 
-Remember that the GIL caveat above applies here too: this pattern pays off for
-IO-bound work, or for calls into libraries that release the GIL, more than it
-does for pure-Python computation.
+Remember that the GIL caveat above applies here too: on a regular build this
+pattern pays off for IO-bound work, or for calls into libraries that release
+the GIL, more than it does for pure-Python computation. On a free-threaded
+build, pure-Python work can scale across threads as well.
 
 
 IO Concurrency


### PR DESCRIPTION
Follow-up to #742, which correctly identified that the GIL section was stale but stopped one version short and introduced some formatting noise. Merged first to get the contributor's improvement in; corrections here.

## Content

- **Free threading is a 3.14 story, not a 3.13 one.** `--disable-gil` landed in 3.13, but the build was *experimental* there; [PEP 779](https://peps.python.org/pep-0779/) (Final, Python-Version 3.14, resolved 16-Jun-2025) is what moved it to officially supported. The previous text presented 3.13 as the milestone, which simultaneously overstates 3.13 and omits 3.14 — the version we already test against in CI.
- **It's a separate build, not a runtime switch.** "enabled with the `--disable-gil` build option" reads like a flag you flip on an existing install. Spelled out that it's a distinct interpreter, offered as an option in the official macOS and Windows installers, so a reader on a stock `python3.13` doesn't follow the note and get nothing.
- **Dropped "allowing for true multi-threading parallelism."** In RxPY's own docs this implicitly promises RxPY works under free threading. Nothing backs that — the CI matrix in `.github/workflows/python-package.yml` has no `3.13t`/`3.14t` entry and there's no free-threading handling in the tree. Reworded to describe CPython's capability rather than implying RxPY exploits it.
- **Fixed an inherited inaccuracy:** the GIL prevents concurrent *bytecode execution*, not "accessing the same line of code simultaneously."
- Linked the official [free-threading howto](https://docs.python.org/3/howto/free-threading-python.html).
- Extended the cross-reference added in #810 so the parallelism section notes that pure-Python work *can* scale on a free-threaded build.

## Formatting

- Removed five lines of trailing whitespace and a double space (`concurrency  performance`).
- Re-wrapped to the file's convention: the block had seven lines at 89–107 characters, against three lines over 88 in the entire rest of the file.
- `RxPy` → `RxPY`.

## Verification

`sphinx-build -W --keep-going` gives **67 warnings on this branch and 67 on `master`** — no new ones, and none originating from `get_started.rst`. Confirmed in the built HTML that `:pep:`779`` resolves to peps.python.org and the free-threading howto link renders. Trailing-whitespace count and >88-character line count are both back to the master baseline (1 and 3, each pre-existing elsewhere in the file).

Docs-only; no library changes.

## Note on the changelog

#742 squash-landed as `Revise GIL section for Python 3.13 updates (#742)` without a conventional-commit prefix (the repo's `COMMIT_OR_PR_TITLE` setting preferred the single commit's title over the corrected PR title), so ShipIt won't categorize it. This PR's `docs:` subject covers the GIL section in the changelog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
