### PR TITLE
fix(operators): synchronize window_with_time_or_count

### DIFF
--- a/reactivex/operators/_windowwithtimeorcount.py
+++ b/reactivex/operators/_windowwithtimeorcount.py
@@ -7,7 +7,7 @@ from reactivex.disposable import (
     SerialDisposable,
     SingleAssignmentDisposable,
 )
-from reactivex.internal import add_ref, curry_flip
+from reactivex.internal import add_ref, curry_flip, synchronized
 from reactivex.scheduler import TimeoutScheduler
 from reactivex.subject import Subject
 
@@ -56,6 +56,7 @@ def window_with_time_or_count_(
             m = SingleAssignmentDisposable()
             timer_d.disposable = m
 
+            @synchronized(source.lock)
             def action(scheduler: abc.SchedulerBase, state: Any = None):
                 nonlocal n, s, window_id
                 if _id != window_id:
@@ -74,6 +75,7 @@ def window_with_time_or_count_(
         observer.on_next(add_ref(s, ref_count_disposable))
         create_timer(0)
 
+        @synchronized(source.lock)
         def on_next(x: _T) -> None:
             nonlocal n, s, window_id
             new_window = False
@@ -93,10 +95,12 @@ def window_with_time_or_count_(
             if new_window:
                 create_timer(new_id)
 
+        @synchronized(source.lock)
         def on_error(e: Exception) -> None:
             s.on_error(e)
             observer.on_error(e)
 
+        @synchronized(source.lock)
         def on_completed() -> None:
             s.on_completed()
             observer.on_completed()

--- a/tests/test_observable/test_windowwithtimeorcount.py
+++ b/tests/test_observable/test_windowwithtimeorcount.py
@@ -1,6 +1,9 @@
+import time
 import unittest
+from datetime import timedelta
 
 from reactivex import operators as ops
+from reactivex.subject import Subject
 from reactivex.testing import ReactiveTest, TestScheduler
 
 on_next = ReactiveTest.on_next
@@ -140,3 +143,37 @@ class TestWindowWithTime(unittest.TestCase):
             on_next(370, "2 7"),
         ]
         assert xs.subscriptions == [subscribe(200, 370)]
+
+    def test_window_with_time_or_count_no_loss_on_slow_consumer(self) -> None:
+        """A window closed by the timer must not drop concurrent emissions.
+
+        The timer fires on another thread, so without synchronization the
+        source thread keeps pushing into the subject that the timer has
+        already completed, and those items are silently lost. See #694.
+        """
+        source: Subject[int] = Subject()
+        total = 0
+
+        def record(value: int) -> None:
+            nonlocal total
+            total = value
+
+        def slow(_: int) -> None:
+            time.sleep(0.01)
+
+        subscription = source.pipe(
+            ops.window_with_time_or_count(timedelta(milliseconds=50), 1_000),
+            ops.flat_map(lambda window: window.pipe(ops.count())),
+            ops.do_action(slow),
+            ops.scan(lambda acc, x: acc + x, 0),
+        ).subscribe(record)
+
+        count = 300
+        for i in range(count):
+            time.sleep(0.001)
+            source.on_next(i)
+        source.on_completed()
+        time.sleep(0.1)
+        subscription.dispose()
+
+        assert total == count


### PR DESCRIPTION
Fixes #694.

## Problem

`window_with_time_or_count` mutates its window state (`n`, `s`, `window_id`) from two threads with no synchronization:

- `on_next` runs on the source's thread
- the timer's `action` runs on the scheduler thread

When the timer closes a window it calls `s.on_completed()` *before* reassigning `s = Subject()`. `on_completed()` synchronously runs the entire downstream chain, so for as long as any user work takes, the source thread keeps calling `s.on_next(x)` on a subject that has **already completed** — and `Subject` silently discards those items.

That is why the reporter in #694 saw window counts summing to 1999 instead of 2000, and why the repro in the issue thread loses roughly one item per millisecond of downstream work, per window boundary.

`buffer_with_time_or_count` is implemented on top of this operator, so it had the same defect.

## Fix

Guard `action`, `on_next`, `on_error` and `on_completed` with `synchronized(source.lock)`.

This is exactly what the sibling operator `window_with_time` already does — it was simply never applied here. Rx.NET's `WindowTimeCount` serializes on a gate for the same reason. The source thread now blocks at a window boundary until the timer has completed the old subject *and* installed the new one, so nothing can land in a closed window.

## Trade-off

Serializing means a slow consumer now applies backpressure to the producer at window boundaries instead of dropping data. That is the correct trade-off — silent data loss is worse — but it does mean the timer thread holds the lock while running downstream user code, so a downstream that blocks indefinitely will stall the producer rather than quietly discarding its items.

## Verification

Repro (300 items at 1 ms, 50 ms windows, 10 ms of downstream work) deterministically lost 40-50 items before; exact on every run after.

- New regression test `test_window_with_time_or_count_no_loss_on_slow_consumer` fails on the unpatched operator (`assert 250 == 300`) and passes with the fix.
- Full suite: 1529 passed, 15 skipped.
- pyright clean on both changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)